### PR TITLE
Fix Next.js viewport metadata warning

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -15,12 +15,13 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Fintech Intelligence",
   description: "Strategic insights into fintech hiring patterns",
-  viewport: {
-    width: "device-width",
-    initialScale: 1,
-    maximumScale: 5,
-    viewportFit: "cover",
-  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
+  viewportFit: "cover",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
- Move viewport configuration from metadata export to separate viewport export
- Follows Next.js 14+ best practices
- Fixes warning: 'Unsupported metadata viewport is configured in metadata export'

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts Next.js layout metadata to use the dedicated `viewport` export and remove viewport from `metadata` to comply with Next 14+.
> 
> - Moves viewport settings to `export const viewport` in `web/app/layout.tsx` and removes them from `metadata`
> - Adds `Viewport` type import; no UI or runtime behavior changes beyond metadata handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5787c27ba116eea9b2f491e5df07772df5dfb313. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->