### PR TITLE
Migrate all cron jobs to unified job_runs tracking system

### DIFF
--- a/.github/ISSUES/questrade-duplicate-insights.md
+++ b/.github/ISSUES/questrade-duplicate-insights.md
@@ -1,0 +1,57 @@
+# Questrade Showing Twice on Weekly Insights Page
+
+## TL;DR
+Weekly insights page displays duplicate insights for the same company (Questrade shown twice). The page fetches all insights from last 7 days without deduplicating to show only the most recent insight per company.
+
+## Type
+**Bug** - UI/Data Display
+
+## Priority
+**Medium** - Affects user experience but doesn't break functionality
+
+## Effort
+**Low** - Simple deduplication logic needed
+
+## Current State
+- Weekly insights page (`/insights`) shows all insights from last 7 days
+- Multiple insights for the same company are displayed (e.g., Questrade appears twice with timestamps 8:17 AM and 8:14 AM)
+- Header shows "{insights.length} companies analyzed" but actually counts total insights, not unique companies
+- No deduplication logic to show only the most recent insight per company
+
+## Expected Outcome
+- Each company should appear only once in the "Latest Strategic Insights" section
+- Show only the most recent insight per company (by `generated_at`)
+- Header count should reflect unique companies, not total insights
+- If multiple insights exist for same company, show the latest one
+
+## Root Cause
+The query in `web/app/(dashboard)/insights/page.tsx` (lines 27-41) fetches all insights from last 7 days without filtering to the most recent per company:
+
+```typescript
+const { data: latestInsightsRaw } = await supabase
+  .from("company_insights")
+  .select(...)
+  .gte("generated_at", sevenDaysAgo)
+  .order("generated_at", { ascending: false });
+```
+
+The `LatestDigestInsights` component displays all insights passed to it without deduplication.
+
+## Solution
+Add deduplication logic to show only the most recent insight per company:
+
+1. **Option A (Recommended):** Deduplicate in the page component after fetching:
+   - Group insights by `company_id`
+   - Keep only the most recent insight per company (already sorted by `generated_at` desc)
+   - Update count to show unique companies
+
+2. **Option B:** Use SQL DISTINCT ON or window function to fetch only latest per company
+
+## Files to Modify
+- `web/app/(dashboard)/insights/page.tsx` - Add deduplication logic after fetching insights
+- `web/components/insights/LatestDigestInsights.tsx` - Update count display to show unique companies
+
+## Notes
+- Dashboard page (`web/app/(dashboard)/page.tsx`) already has similar deduplication logic (lines 90-108) - can reference that pattern
+- Multiple insights per company can exist if analysis runs multiple times in the same day
+- Archive section should continue showing all historical insights (no deduplication needed there)

--- a/.github/ISSUES/remove-welcome-message.md
+++ b/.github/ISSUES/remove-welcome-message.md
@@ -1,0 +1,33 @@
+# Remove Personalized Welcome Message
+
+## TL;DR
+Remove the personalized welcome banner ("Good morning, [Name]!") from the dashboard as it's an unnecessary distraction.
+
+## Type
+**Improvement** - UI Cleanup
+
+## Priority
+**Normal**
+
+## Effort
+**Small** (remove component and usage)
+
+## Current State
+- Dashboard shows a personalized welcome message banner at the top
+- Displays greeting based on time of day ("Good morning/afternoon/evening, [Name]!")
+- Includes dismiss button and welcome text
+- Takes up space at the top of the dashboard
+
+## Expected Outcome
+- Remove the welcome message banner entirely
+- Dashboard starts directly with stats cards and content
+- Cleaner, more focused dashboard experience
+
+## Files to Modify
+- `web/app/(dashboard)/page.tsx` - Remove WelcomeMessage import and usage
+- `web/components/dashboard/WelcomeMessage.tsx` - Can be deleted (or kept for potential future use)
+
+## Notes
+- Low risk change - purely UI removal
+- No data dependencies to clean up
+- Component can be kept in codebase if there's potential future use, just remove the import/usage

--- a/.github/PLANS/fix-report-jobs-status-tracking.md
+++ b/.github/PLANS/fix-report-jobs-status-tracking.md
@@ -1,0 +1,161 @@
+# Unified Job Tracking: Migrate All Cron Jobs to job_runs
+
+**Overall Progress:** `100%`
+
+## TLDR
+Fully migrate all scheduled jobs from `cron_logs` to `job_runs` table for unified tracking. This includes report jobs, company insights, and manual insight generation. Then remove `cron_logs` table and clean up all references in the codebase.
+
+## Critical Decisions
+- **Decision 1:** Migrate ALL cron jobs to `job_runs` table
+  - Rationale: Unified tracking, consistent status handling, eliminates table mismatch bug
+- **Decision 2:** Add new job types to `job_runs.job_type` CHECK constraint
+  - New types: 'report', 'company-insights', 'insight-generation'
+  - Current types: 'collect', 'analyze'
+- **Decision 3:** Drop `cron_logs` table after migration
+  - Rationale: No need for two logging tables, simplifies architecture
+- **Decision 4:** Clean up all `cron_logs` references in codebase
+  - Rationale: Remove dead code, update documentation
+
+## Affected Files
+
+### Cron Jobs (writes to cron_logs → migrate to job_runs)
+- `web/app/api/cron/report/route.ts` - Weekly report generation
+- `web/app/api/cron/company-insights/route.ts` - Company insights cron
+- `web/app/api/companies/[id]/insights/route.ts` - Manual insight generation
+
+### Admin Routes (reads from cron_logs → update to job_runs)
+- `web/app/api/admin/stats/route.ts` - Dashboard stats (lines 49-50)
+- `web/app/api/admin/cron-logs/route.ts` - Job execution history
+
+### Documentation (references cron_logs → update)
+- `CLAUDE.md` - Agent guidance file (add job_runs as standard for job tracking)
+- `docs/VERCEL_CRON_TROUBLESHOOTING.md`
+- `docs/CRON_VERIFICATION_STEPS.md`
+- `docs/CRON_FIX_SUMMARY.md`
+- `docs/CRON_FINAL_CHECKLIST.md`
+
+## Tasks:
+
+- [x] ✅ **Step 1: Database Schema Update**
+  - [x] ✅ Create migration to expand `job_runs.job_type` CHECK constraint to include: 'collect', 'analyze', 'report', 'company-insights', 'insight-generation'
+  - [x] ✅ Add `details` JSONB column to `job_runs` (if not exists) for storing job-specific metadata
+  - [ ] 🟨 Run migration and verify all new job types can be inserted (manual step)
+
+- [x] ✅ **Step 2: Migrate Report Cron Job**
+  - [x] ✅ Replace `cron_logs` insert with `job_runs` insert
+  - [x] ✅ Map fields: status 'running'→'running', 'success'→'completed', 'error'→'failed'
+  - [x] ✅ Store digest stats in `job_runs` fields (total_insights, details JSONB)
+  - [x] ✅ Update success/error status updates to use `job_runs`
+  - [x] ✅ Remove all `cron_logs` references from report route
+
+- [x] ✅ **Step 3: Migrate Company Insights Cron Job**
+  - [x] ✅ Replace `cron_logs` inserts with `job_runs` inserts in company-insights route
+  - [x] ✅ Map job_type "company-insights" to job_runs
+  - [x] ✅ Store insight metadata in details JSONB
+  - [x] ✅ Remove all `cron_logs` references from company-insights route
+
+- [x] ✅ **Step 4: Migrate Manual Insight Generation**
+  - [x] ✅ Replace `cron_logs` inserts with `job_runs` inserts in insights route
+  - [x] ✅ Map job_type "company-insight-generation" to "insight-generation" in job_runs
+  - [x] ✅ Store generation metadata in details JSONB
+  - [x] ✅ Remove all `cron_logs` references from insights route
+
+- [x] ✅ **Step 5: Update Admin Stats Route**
+  - [x] ✅ Update lastCollectResult query to use `job_runs` with job_type='collect', status='completed'
+  - [x] ✅ Update lastReportResult query to use `job_runs` with job_type='report', status='completed'
+  - [ ] 🟨 Test admin dashboard shows correct "Last Job Collection" and "Last Weekly Report" (manual step)
+
+- [x] ✅ **Step 6: Update Admin Cron Logs Route**
+  - [x] ✅ Update job_type transformation to handle all new types: 'report', 'company-insights', 'insight-generation'
+  - [x] ✅ Remove assumption that non-collect = report
+  - [ ] 🟨 Test admin page displays all job types correctly with proper status badges (manual step)
+
+- [ ] 🟨 **Step 7: Testing & Verification** (manual steps)
+  - [ ] 🟨 Test report cron job: creates entry with 'running', updates to 'completed'/'failed'
+  - [ ] 🟨 Test company insights cron: creates entry with correct type and status
+  - [ ] 🟨 Test manual insight generation: creates entry with correct type and status
+  - [ ] 🟨 Test admin stats route returns correct data
+  - [ ] 🟨 Test admin cron logs displays all job types correctly
+  - [ ] 🟨 Verify no errors in Vercel logs
+
+- [x] ✅ **Step 8: Drop cron_logs Table** (included in Step 1 migration)
+  - [x] ✅ Create migration to drop `cron_logs` table
+  - [x] ✅ Drop associated indexes: idx_cron_logs_job_type, idx_cron_logs_started_at, idx_cron_logs_status
+  - [x] ✅ Drop RLS policies on cron_logs
+  - [ ] 🟨 Run migration and verify table is removed (manual step)
+
+- [x] ✅ **Step 9: Codebase Cleanup**
+  - [x] ✅ Search for any remaining `cron_logs` references in code
+  - [x] ✅ Remove/update any imports or type definitions (none found)
+  - [x] ✅ Update TypeScript types if any reference cron_logs (none found)
+  - [ ] 🟨 Verify build passes with no cron_logs references (manual step)
+
+- [x] ✅ **Step 10: Update CLAUDE.md (Agent Guidance)**
+  - [x] ✅ Add "Job Tracking" section to CLAUDE.md under Architecture
+  - [x] ✅ Document that `job_runs` is the ONLY table for tracking all job/cron execution
+  - [x] ✅ List valid job_types: 'collect', 'analyze', 'report', 'company-insights', 'insight-generation'
+  - [x] ✅ Document status values: 'pending', 'running', 'completed', 'failed'
+  - [x] ✅ Add rule: "Never use cron_logs table (deprecated and removed)"
+  - [x] ✅ Include example of how to log a job run
+
+- [x] ✅ **Step 11: Documentation Cleanup**
+  - [x] ✅ Update `docs/VERCEL_CRON_TROUBLESHOOTING.md` - change cron_logs to job_runs
+  - [x] ✅ Update `docs/CRON_VERIFICATION_STEPS.md` - change cron_logs to job_runs
+  - [x] ✅ Update `docs/CRON_FIX_SUMMARY.md` - change cron_logs to job_runs
+  - [x] ✅ Update `docs/CRON_FINAL_CHECKLIST.md` - change cron_logs to job_runs
+  - [x] ✅ Delete `.github/ISSUES/report-jobs-status-impact-analysis.md` (superseded)
+  - [x] ✅ Delete `.github/ISSUES/report-jobs-stuck-running.md` (completed)
+
+## Field Mapping Reference
+
+### cron_logs → job_runs
+| cron_logs field | job_runs field | Notes |
+|-----------------|----------------|-------|
+| job_type | job_type | Add new types to CHECK |
+| status 'running' | status 'running' | Same |
+| status 'success' | status 'completed' | Different value |
+| status 'error' | status 'failed' | Different value |
+| started_at | started_at | Same |
+| completed_at | completed_at | Same |
+| new_jobs_count | total_new_jobs | Same meaning |
+| closed_jobs_count | total_closed_jobs | Same meaning |
+| insights_generated | total_insights | Same meaning |
+| companies_processed | total_companies | Same meaning |
+| error_message | error_message | Same |
+| details (JSONB) | details (JSONB) | Need to add column if missing |
+
+### Required job_runs fields for new job types
+```sql
+-- For 'report' jobs
+job_type: 'report'
+trigger_type: 'cron'
+scope: 'all'
+status: 'pending' | 'running' | 'completed' | 'failed'
+total_insights: number (companies in digest)
+details: { digestId, totalJobs, emailSent, recipients, ... }
+
+-- For 'company-insights' jobs
+job_type: 'company-insights'
+trigger_type: 'cron'
+scope: 'single'
+company_id: uuid
+status: 'pending' | 'running' | 'completed' | 'failed'
+total_insights: 1
+details: { insightId, duration, estimatedCost, ... }
+
+-- For 'insight-generation' jobs (manual)
+job_type: 'insight-generation'
+trigger_type: 'manual'
+triggered_by: user_id
+scope: 'single'
+company_id: uuid
+status: 'pending' | 'running' | 'completed' | 'failed'
+total_insights: 1
+details: { insightId, estimatedCost, ... }
+```
+
+## Rollback Plan
+If issues occur:
+1. Keep cron_logs table migration as separate final step
+2. Can revert to dual-write (both tables) if needed
+3. Admin routes can fallback to cron_logs if job_runs query fails

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,55 @@ Vercel runs strict TypeScript checking during builds. Common issues:
 - `strategic_insights` - AI-generated analysis
 - `posting_events` - Timeline tracking
 - `job_templates` - Categorized templates
+- `job_runs` - Unified job tracking for all scheduled/manual jobs
+
+### Job Tracking (IMPORTANT)
+
+**All scheduled jobs and manual operations MUST use the `job_runs` table for tracking.**
+
+The `cron_logs` table has been deprecated and removed. Never reference or use `cron_logs`.
+
+#### Valid job_types
+- `collect` - Job scraping/collection
+- `analyze` - AI analysis of job postings
+- `report` - Weekly digest generation
+- `company-insights` - Scheduled company insight generation
+- `insight-generation` - Manual company insight generation
+
+#### Status values
+- `pending` - Job queued but not started
+- `running` - Job currently executing
+- `completed` - Job finished successfully
+- `failed` - Job finished with error
+- `cancelled` - Job was cancelled
+
+#### Example: Logging a job run
+```typescript
+// Create job run entry at start
+const { data: jobRun } = await supabase
+  .from("job_runs")
+  .insert({
+    job_type: "report",           // One of the valid types above
+    trigger_type: "cron",         // 'cron' | 'manual' | 'admin'
+    scope: "all",                 // 'all' | 'single'
+    status: "running",
+    started_at: new Date().toISOString(),
+  })
+  .select("id")
+  .single();
+
+// Update on completion
+await supabase
+  .from("job_runs")
+  .update({
+    status: "completed",          // or "failed"
+    completed_at: new Date().toISOString(),
+    total_companies: 5,
+    total_insights: 5,
+    details: { /* job-specific metadata */ },
+  })
+  .eq("id", jobRun.id);
+```
 
 ### Cron Jobs (Vercel)
 - Daily 6 AM: `/api/cron/collect` - Collect jobs and analyze

--- a/docs/CRON_FINAL_CHECKLIST.md
+++ b/docs/CRON_FINAL_CHECKLIST.md
@@ -39,7 +39,7 @@
 
 **To verify they're running:**
 1. Check Vercel function logs around scheduled times
-2. Check database `cron_logs` table for new entries:
+2. Check database `job_runs` table for new entries (unified job tracking):
 
 ```sql
 SELECT 
@@ -48,10 +48,11 @@ SELECT
   status,
   started_at,
   completed_at,
-  new_jobs_count,
-  closed_jobs_count,
+  total_new_jobs,
+  total_closed_jobs,
+  total_insights,
   error_message
-FROM cron_logs
+FROM job_runs
 ORDER BY started_at DESC
 LIMIT 10;
 ```
@@ -100,7 +101,7 @@ After changing, commit and push to trigger a new deployment.
 ✅ Cron jobs appear in Vercel dashboard
 ✅ Manual trigger via dashboard works
 ✅ Function logs show successful execution
-✅ Database `cron_logs` table has entries
+✅ Database `job_runs` table has entries
 ✅ Jobs run automatically at scheduled times
 
 ## All Set!

--- a/docs/CRON_FIX_SUMMARY.md
+++ b/docs/CRON_FIX_SUMMARY.md
@@ -95,8 +95,8 @@ git push origin main
 
 4. **Check Database**:
    ```sql
-   -- Run in Supabase SQL Editor
-   SELECT * FROM cron_logs 
+   -- Run in Supabase SQL Editor (uses unified job_runs table)
+   SELECT * FROM job_runs 
    ORDER BY started_at DESC 
    LIMIT 10;
    ```

--- a/docs/CRON_VERIFICATION_STEPS.md
+++ b/docs/CRON_VERIFICATION_STEPS.md
@@ -71,10 +71,11 @@ Your manual curl test succeeded! This confirms:
 
 ## Step 5: Monitor Execution
 
-### Check Database for Cron Logs
+### Check Database for Job Runs
 
 ```sql
 -- Run in Supabase SQL Editor
+-- Uses unified job_runs table for all job tracking
 SELECT 
   id,
   job_type,
@@ -82,9 +83,10 @@ SELECT
   started_at,
   completed_at,
   error_message,
-  new_jobs_count,
-  closed_jobs_count
-FROM cron_logs
+  total_new_jobs,
+  total_closed_jobs,
+  total_insights
+FROM job_runs
 ORDER BY started_at DESC
 LIMIT 10;
 ```
@@ -102,7 +104,7 @@ Once everything is configured correctly:
 1. **Vercel automatically triggers** cron jobs at scheduled times
 2. **Vercel adds** `Authorization: Bearer <CRON_SECRET>` header automatically
 3. **Your endpoint validates** the authentication
-4. **Job executes** and creates entries in `cron_logs` table
+4. **Job executes** and creates entries in `job_runs` table
 5. **Logs appear** in Vercel function logs
 
 ## Troubleshooting
@@ -141,6 +143,6 @@ After verifying CRON_SECRET is set in Vercel:
 1. Go to **Cron Jobs** tab
 2. Click **Run Now** on `/api/cron/collect`
 3. Check function logs for successful execution
-4. Check database `cron_logs` table for new entry
+4. Check database `job_runs` table for new entry
 
 If this works, your cron jobs are fully configured! 🎉

--- a/docs/VERCEL_CRON_TROUBLESHOOTING.md
+++ b/docs/VERCEL_CRON_TROUBLESHOOTING.md
@@ -134,16 +134,17 @@ Check your application's logging system (e.g., Supabase logs, external logging s
 
 ### Check Database
 
-Cron jobs create entries in the `cron_logs` table:
+Cron jobs create entries in the `job_runs` table (unified job tracking):
 ```sql
-SELECT * FROM cron_logs 
+SELECT * FROM job_runs 
 ORDER BY started_at DESC 
 LIMIT 10;
 ```
 
 This shows:
 - When jobs ran
-- Success/failure status
+- Job type (collect, report, company-insights, etc.)
+- Success/failure status (completed, failed, running)
 - Error messages
 - Execution statistics
 

--- a/web/app/api/admin/cron-logs/route.ts
+++ b/web/app/api/admin/cron-logs/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 
-// GET /api/admin/cron-logs - Fetch recent cron execution logs
+// GET /api/admin/cron-logs - Fetch recent job execution logs
+// Uses unified job_runs table for all job tracking
 export async function GET(req: NextRequest) {
   const supabase = await createClient();
   
@@ -25,6 +26,7 @@ export async function GET(req: NextRequest) {
   const jobType = searchParams.get("job_type");
   const limit = parseInt(searchParams.get("limit") ?? "20", 10);
 
+  // Query job_runs table (unified job tracking system)
   let query = supabase
     .from("job_runs")
     .select("*")
@@ -42,17 +44,25 @@ export async function GET(req: NextRequest) {
   }
 
   // Transform job_runs to match CronLog interface for backward compatibility
+  // Handles all job types: collect, analyze, report, company-insights, insight-generation
   const logs = (jobRuns || []).map((jr) => ({
     id: jr.id,
-    job_type: jr.job_type === "collect" ? "collect" : "report",
+    // Preserve actual job_type for all types (don't assume non-collect = report)
+    job_type: jr.job_type,
     started_at: jr.started_at,
     completed_at: jr.completed_at,
+    // Map job_runs status to legacy CronLog status format
     status: jr.status === "completed" ? "success" : jr.status === "failed" ? "error" : "running",
     new_jobs_count: jr.total_new_jobs,
     closed_jobs_count: jr.total_closed_jobs,
     insights_generated: jr.total_insights,
     companies_processed: jr.total_companies,
     error_message: jr.error_message,
+    // Include additional fields for enhanced visibility
+    trigger_type: jr.trigger_type,
+    scope: jr.scope,
+    company_id: jr.company_id,
+    details: jr.details,
   }));
 
   return NextResponse.json({ logs });

--- a/web/app/api/admin/stats/route.ts
+++ b/web/app/api/admin/stats/route.ts
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { subDays } from "date-fns";
 
 // GET /api/admin/stats - Fetch admin dashboard statistics
+// Uses unified job_runs table for all job tracking
 export async function GET() {
   const supabase = await createClient();
   
@@ -23,9 +24,9 @@ export async function GET() {
   }
 
   const weekAgo = subDays(new Date(), 7).toISOString();
-  const dayAgo = subDays(new Date(), 1).toISOString();
 
   // Fetch all stats in parallel
+  // Note: Uses job_runs table for all job tracking (unified system)
   const [
     companiesResult,
     activeCompaniesResult,
@@ -46,9 +47,29 @@ export async function GET() {
     supabase.from("strategic_insights").select("*", { count: "exact", head: true }),
     supabase.from("strategic_insights").select("*", { count: "exact", head: true }).gte("run_date", weekAgo),
     supabase.from("profiles").select("*", { count: "exact", head: true }),
-    supabase.from("cron_logs").select("*").eq("job_type", "collect").eq("status", "success").order("completed_at", { ascending: false }).limit(1),
-    supabase.from("cron_logs").select("*").eq("job_type", "report").eq("status", "success").order("completed_at", { ascending: false }).limit(1),
+    // Query job_runs for collect jobs (unified job tracking)
+    supabase.from("job_runs").select("*").eq("job_type", "collect").eq("status", "completed").order("completed_at", { ascending: false }).limit(1),
+    // Query job_runs for report jobs (unified job tracking)
+    supabase.from("job_runs").select("*").eq("job_type", "report").eq("status", "completed").order("completed_at", { ascending: false }).limit(1),
   ]);
+
+  // Transform job_runs data to match expected lastRuns format
+  const transformJobRun = (jobRun: Record<string, unknown> | null) => {
+    if (!jobRun) return null;
+    return {
+      id: jobRun.id,
+      job_type: jobRun.job_type,
+      started_at: jobRun.started_at,
+      completed_at: jobRun.completed_at,
+      status: jobRun.status === "completed" ? "success" : jobRun.status === "failed" ? "error" : "running",
+      new_jobs_count: jobRun.total_new_jobs,
+      closed_jobs_count: jobRun.total_closed_jobs,
+      insights_generated: jobRun.total_insights,
+      companies_processed: jobRun.total_companies,
+      error_message: jobRun.error_message,
+      details: jobRun.details,
+    };
+  };
 
   return NextResponse.json({
     stats: {
@@ -69,8 +90,8 @@ export async function GET() {
         total: usersResult.count ?? 0,
       },
       lastRuns: {
-        collect: lastCollectResult.data?.[0] ?? null,
-        report: lastReportResult.data?.[0] ?? null,
+        collect: transformJobRun(lastCollectResult.data?.[0] ?? null),
+        report: transformJobRun(lastReportResult.data?.[0] ?? null),
       },
     },
   });

--- a/web/app/api/companies/[id]/insights/route.ts
+++ b/web/app/api/companies/[id]/insights/route.ts
@@ -165,6 +165,23 @@ export async function POST(
     }
   }
 
+  // Create job_runs entry for tracking (unified job tracking system)
+  const adminSupabase = createAdminClient();
+  const { data: jobRun } = await adminSupabase
+    .from("job_runs")
+    .insert({
+      job_type: "insight-generation",
+      trigger_type: "manual",
+      triggered_by: user.id,
+      scope: "single",
+      company_id: company.id,
+      status: "running",
+      started_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  const jobRunId = jobRun?.id;
+
   try {
     const insight = await generateCompanyInsight(company.id, company.name, {
       periodDays: periodDays ?? 90,
@@ -172,39 +189,49 @@ export async function POST(
       forceRegenerate: canForce,
     });
 
-    // Log the generation to cron_logs for cost tracking
-    const adminSupabase = createAdminClient();
-    await adminSupabase.from("cron_logs").insert({
-      job_type: "company-insight-generation",
-      status: "success",
-      details: {
-        companyId: company.id,
-        companyName: company.name,
-        insightId: insight.id,
-        triggeredBy: user.id,
-        triggerType: "on-demand",
-        estimatedCost: insight.generationCostEstimate,
-        researchQualityScore: insight.researchQualityScore,
-      },
-    });
+    // Update job_runs with success (unified job tracking)
+    if (jobRunId) {
+      await adminSupabase
+        .from("job_runs")
+        .update({
+          status: "completed",
+          completed_at: new Date().toISOString(),
+          total_companies: 1,
+          total_insights: 1,
+          details: {
+            companyId: company.id,
+            companyName: company.name,
+            insightId: insight.id,
+            triggeredBy: user.id,
+            triggerType: "on-demand",
+            estimatedCost: insight.generationCostEstimate,
+            researchQualityScore: insight.researchQualityScore,
+          },
+        })
+        .eq("id", jobRunId);
+    }
 
     return NextResponse.json({ insight }, { status: 201 });
   } catch (error) {
     console.error("Error generating company insight:", error);
 
-    // Log the failure
-    const adminSupabase = createAdminClient();
-    await adminSupabase.from("cron_logs").insert({
-      job_type: "company-insight-generation",
-      status: "error",
-      error_message: error instanceof Error ? error.message : "Unknown error",
-      details: {
-        companyId: company.id,
-        companyName: company.name,
-        triggeredBy: user.id,
-        triggerType: "on-demand",
-      },
-    });
+    // Update job_runs with failure (unified job tracking)
+    if (jobRunId) {
+      await adminSupabase
+        .from("job_runs")
+        .update({
+          status: "failed",
+          completed_at: new Date().toISOString(),
+          error_message: error instanceof Error ? error.message : "Unknown error",
+          details: {
+            companyId: company.id,
+            companyName: company.name,
+            triggeredBy: user.id,
+            triggerType: "on-demand",
+          },
+        })
+        .eq("id", jobRunId);
+    }
 
     return NextResponse.json(
       { error: error instanceof Error ? error.message : "Failed to generate insight" },

--- a/web/app/api/cron/company-insights/route.ts
+++ b/web/app/api/cron/company-insights/route.ts
@@ -13,6 +13,8 @@ export const maxDuration = 300; // 5 minutes max
  * 
  * Processes one company at a time to avoid timeouts.
  * Should be called multiple times if there are many companies.
+ * 
+ * Uses job_runs table for unified job tracking (not cron_logs).
  */
 export async function GET(req: NextRequest) {
   // Verify cron secret
@@ -26,6 +28,21 @@ export async function GET(req: NextRequest) {
 
   // Check if a specific company was requested
   const companyId = req.nextUrl.searchParams.get("companyId");
+
+  // Create job_runs entry for tracking (unified job tracking system)
+  const { data: jobRun } = await supabase
+    .from("job_runs")
+    .insert({
+      job_type: "company-insights",
+      trigger_type: "cron",
+      scope: companyId ? "single" : "all",
+      company_id: companyId || null,
+      status: "running",
+      started_at: new Date().toISOString(),
+    })
+    .select("id")
+    .single();
+  const jobRunId = jobRun?.id;
 
   try {
     let company: { id: string; name: string } | null = null;
@@ -45,15 +62,22 @@ export async function GET(req: NextRequest) {
     }
 
     if (!company) {
-      // Log completion
-      await supabase.from("cron_logs").insert({
-        job_type: "company-insights",
-        status: "success",
-        details: {
-          message: "All companies have recent insights",
-          triggerType: "cron",
-        },
-      });
+      // Update job_runs with completion (no companies needed processing)
+      if (jobRunId) {
+        await supabase
+          .from("job_runs")
+          .update({
+            status: "completed",
+            completed_at: new Date().toISOString(),
+            total_companies: 0,
+            total_insights: 0,
+            details: {
+              message: "All companies have recent insights",
+              triggerType: "cron",
+            },
+          })
+          .eq("id", jobRunId);
+      }
 
       return NextResponse.json({
         success: true,
@@ -73,20 +97,28 @@ export async function GET(req: NextRequest) {
 
     const duration = Date.now() - startTime;
 
-    // Log success
-    await supabase.from("cron_logs").insert({
-      job_type: "company-insights",
-      status: "success",
-      details: {
-        companyId: company.id,
-        companyName: company.name,
-        insightId: insight.id,
-        triggerType: "cron",
-        duration,
-        estimatedCost: insight.generationCostEstimate,
-        researchQualityScore: insight.researchQualityScore,
-      },
-    });
+    // Update job_runs with success (unified job tracking)
+    if (jobRunId) {
+      await supabase
+        .from("job_runs")
+        .update({
+          status: "completed",
+          completed_at: new Date().toISOString(),
+          company_id: company.id,
+          total_companies: 1,
+          total_insights: 1,
+          details: {
+            companyId: company.id,
+            companyName: company.name,
+            insightId: insight.id,
+            triggerType: "cron",
+            duration,
+            estimatedCost: insight.generationCostEstimate,
+            researchQualityScore: insight.researchQualityScore,
+          },
+        })
+        .eq("id", jobRunId);
+    }
 
     // Check if there are more companies to process
     const nextCompany = await getNextCompanyForInsight();
@@ -105,17 +137,22 @@ export async function GET(req: NextRequest) {
     const errorMessage = error instanceof Error ? error.message : "Unknown error";
     console.error("Company insights cron error:", error);
 
-    // Log failure
-    await supabase.from("cron_logs").insert({
-      job_type: "company-insights",
-      status: "error",
-      error_message: errorMessage,
-      details: {
-        companyId: companyId || null,
-        triggerType: "cron",
-        duration: Date.now() - startTime,
-      },
-    });
+    // Update job_runs with failure (unified job tracking)
+    if (jobRunId) {
+      await supabase
+        .from("job_runs")
+        .update({
+          status: "failed",
+          completed_at: new Date().toISOString(),
+          error_message: errorMessage,
+          details: {
+            companyId: companyId || null,
+            triggerType: "cron",
+            duration: Date.now() - startTime,
+          },
+        })
+        .eq("id", jobRunId);
+    }
 
     return NextResponse.json(
       { error: errorMessage },

--- a/web/app/api/cron/report/route.ts
+++ b/web/app/api/cron/report/route.ts
@@ -192,17 +192,19 @@ export async function GET(req: NextRequest) {
 
   const supabase = createAdminClient();
   
-  // Create cron log entry
-  const { data: cronLog } = await supabase
-    .from("cron_logs")
+  // Create job_runs entry for tracking (unified job tracking system)
+  const { data: jobRun } = await supabase
+    .from("job_runs")
     .insert({
       job_type: "report",
+      trigger_type: "cron",
+      scope: "all",
       status: "running",
       started_at: new Date().toISOString(),
     })
     .select("id")
     .single();
-  const cronLogId = cronLog?.id;
+  const jobRunId = jobRun?.id;
 
   try {
     // First, generate company insights (process one company per week)
@@ -380,14 +382,15 @@ export async function GET(req: NextRequest) {
       }
     }
 
-    // Update cron log with success
-    if (cronLogId) {
+    // Update job_runs with success (unified job tracking)
+    if (jobRunId) {
       await supabase
-        .from("cron_logs")
+        .from("job_runs")
         .update({
-          status: "success",
+          status: "completed",
           completed_at: new Date().toISOString(),
-          insights_generated: digest.total_companies,
+          total_companies: digest.total_companies,
+          total_insights: digest.total_companies,
           details: { 
             totalJobs: digest.total_jobs,
             totalCompanies: digest.total_companies,
@@ -403,7 +406,7 @@ export async function GET(req: NextRequest) {
             companyInsight: companyInsightResult,
           },
         })
-        .eq("id", cronLogId);
+        .eq("id", jobRunId);
     }
 
     return NextResponse.json({ 
@@ -426,16 +429,16 @@ export async function GET(req: NextRequest) {
     });
   } catch (error) {
     console.error("Report cron error:", error);
-    // Update cron log with error
-    if (cronLogId) {
+    // Update job_runs with error (unified job tracking)
+    if (jobRunId) {
       await supabase
-        .from("cron_logs")
+        .from("job_runs")
         .update({
-          status: "error",
+          status: "failed",
           completed_at: new Date().toISOString(),
           error_message: error instanceof Error ? error.message : "Unknown error",
         })
-        .eq("id", cronLogId);
+        .eq("id", jobRunId);
     }
     throw error;
   }

--- a/web/supabase/migrations/20260125000000_unified_job_tracking.sql
+++ b/web/supabase/migrations/20260125000000_unified_job_tracking.sql
@@ -1,0 +1,67 @@
+-- ============================================================================
+-- Unified Job Tracking Migration
+-- ============================================================================
+-- Migrates all cron jobs to use job_runs table exclusively.
+-- Expands job_type CHECK constraint and adds details JSONB column.
+-- Then drops the deprecated cron_logs table.
+-- ============================================================================
+
+-- ============================================================================
+-- Step 1: Expand job_runs.job_type CHECK constraint
+-- ============================================================================
+-- Current valid types: 'collect', 'analyze'
+-- Adding: 'report', 'company-insights', 'insight-generation'
+
+-- Drop existing constraint
+ALTER TABLE job_runs 
+DROP CONSTRAINT IF EXISTS job_runs_job_type_check;
+
+-- Add expanded constraint with all job types
+ALTER TABLE job_runs 
+ADD CONSTRAINT job_runs_job_type_check 
+CHECK (job_type IN ('collect', 'analyze', 'report', 'company-insights', 'insight-generation'));
+
+-- Add comment explaining job types
+COMMENT ON COLUMN job_runs.job_type IS 
+'Type of job: collect (job scraping), analyze (AI analysis), report (weekly digest), company-insights (scheduled insight generation), insight-generation (manual insight generation)';
+
+-- ============================================================================
+-- Step 2: Add details JSONB column to job_runs (if not exists)
+-- ============================================================================
+-- Stores job-specific metadata that doesn't fit in standard columns
+
+ALTER TABLE job_runs 
+ADD COLUMN IF NOT EXISTS details JSONB DEFAULT '{}';
+
+COMMENT ON COLUMN job_runs.details IS 
+'Job-specific metadata as JSONB. Examples: {digestId, totalJobs, emailSent, recipients} for report jobs, {insightId, estimatedCost, researchQualityScore} for insight jobs';
+
+-- ============================================================================
+-- Step 3: Add index for details column (GIN for JSONB queries)
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS idx_job_runs_details 
+ON job_runs USING GIN (details);
+
+-- ============================================================================
+-- Step 4: Drop cron_logs table and related objects
+-- ============================================================================
+-- cron_logs is now deprecated - all jobs use job_runs
+
+-- Drop indexes first
+DROP INDEX IF EXISTS idx_cron_logs_job_type;
+DROP INDEX IF EXISTS idx_cron_logs_started_at;
+DROP INDEX IF EXISTS idx_cron_logs_status;
+
+-- Drop RLS policies
+DROP POLICY IF EXISTS "Admins can view cron logs" ON cron_logs;
+
+-- Drop the table
+DROP TABLE IF EXISTS cron_logs;
+
+-- ============================================================================
+-- Step 5: Update comments for clarity
+-- ============================================================================
+
+COMMENT ON TABLE job_runs IS 
+'Unified job tracking table for all scheduled and manual jobs. Replaces deprecated cron_logs table. All cron jobs (collect, report, company-insights) and manual operations (analyze, insight-generation) create records here.';


### PR DESCRIPTION
## Summary

Consolidates all job tracking from the deprecated `cron_logs` table to `job_runs` for unified monitoring and status tracking across all job types (collect, analyze, report, company-insights, insight-generation).

**Problem:** Report jobs were showing as "stuck running" in the admin dashboard because they wrote to `cron_logs` while the dashboard read from `job_runs`.

**Solution:** Migrate all cron jobs and manual operations to use the `job_runs` table exclusively, then remove `cron_logs`.

## Changes

### Database Migration (`20260125000000_unified_job_tracking.sql`)
- ✅ Expand `job_runs.job_type` CHECK constraint to include: 'report', 'company-insights', 'insight-generation'
- ✅ Add `details` JSONB column for job-specific metadata
- ✅ Drop deprecated `cron_logs` table and all related indexes/policies

### API Routes
- ✅ **Report cron job** (`/api/cron/report`) - Now uses job_runs with proper status mapping
- ✅ **Company insights cron** (`/api/cron/company-insights`) - Migrated to job_runs
- ✅ **Manual insight generation** (`/api/companies/[id]/insights`) - Now tracks in job_runs
- ✅ **Admin stats route** - Updated to query job_runs for all job types
- ✅ **Admin cron logs route** - Updated to handle all job types correctly

### Documentation
- ✅ Updated `CLAUDE.md` with comprehensive job tracking guidelines
- ✅ Updated all cron troubleshooting docs to reference `job_runs`
- ✅ Removed obsolete issue files

## Test Plan

- [ ] Run database migration in Supabase
- [ ] Verify report cron job creates `job_runs` entry with status 'running' → 'completed'
- [ ] Verify company insights cron creates proper entries
- [ ] Check admin dashboard displays all job types correctly
- [ ] Verify admin stats shows "Last Weekly Report" correctly
- [ ] Test manual insight generation creates proper job_runs entry
- [ ] Confirm build passes locally (`npm run build`)

## Impact

- **Fixes:** Admin dashboard showing report jobs stuck in "running" status
- **Improves:** Unified job tracking across all scheduled and manual operations
- **Simplifies:** Single source of truth for all job execution history
- **Removes:** Technical debt from maintaining two separate logging systems

## Breaking Changes

None - this is a behind-the-scenes refactor. The `cron_logs` table is dropped but was only used internally.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies job execution tracking across the app by standardizing on `job_runs` and removing `cron_logs`.
> 
> - **DB migration**: Expands `job_runs.job_type` (adds `report`, `company-insights`, `insight-generation`), adds `details` JSONB + GIN index, and drops `cron_logs` with related indexes/policies
> - **Cron/ops writes**: `api/cron/report`, `api/cron/company-insights`, and manual `api/companies/[id]/insights` now create/update `job_runs` with proper status mapping and metadata
> - **Admin reads**: `api/admin/stats` and `api/admin/cron-logs` now query `job_runs`, preserve actual `job_type`, and map statuses to legacy success/error where needed
> - **Docs**: `CLAUDE.md` and cron docs updated to reference `job_runs` and new verification queries
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ced8f0c791cf53e31ad21b9052c7e0baebaac2d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->