### PR TITLE
Fix Tangerine enrichment and stabilize collect run resumption

### DIFF
--- a/web/app/api/cron/collect/route.ts
+++ b/web/app/api/cron/collect/route.ts
@@ -41,27 +41,50 @@ export async function GET(req: NextRequest) {
     console.log(`Processing ${companies.length} companies:`, companies.map(c => `${c.name} (${c.ats_type})`));
 
     // Phase 1: Collection
-    const jobRunId = await createJobRun({
-      jobType: 'collect',
-      triggerType: 'cron',
-      companyIds: companies.map(c => c.id),
-    });
+    // Resume an existing in-flight collect run first to avoid starving tail companies.
+    const { data: existingRun } = await supabase
+      .from("job_runs")
+      .select("id")
+      .eq("job_type", "collect")
+      .in("status", ["pending", "running"])
+      .order("started_at", { ascending: true, nullsFirst: true })
+      .limit(1)
+      .maybeSingle();
 
-    console.log(`Created job run: ${jobRunId}`);
+    const jobRunId =
+      existingRun?.id ??
+      (await createJobRun({
+        jobType: "collect",
+        triggerType: "cron",
+        companyIds: companies.map((c) => c.id),
+      }));
+
+    console.log(
+      existingRun?.id
+        ? `Resuming collect job run: ${jobRunId}`
+        : `Created job run: ${jobRunId}`
+    );
 
     const result = await executeCollectionJob(jobRunId);
 
     console.log("Collection completed:", result.stats);
 
-    // Phase 2: Analysis (auto-triggered if there are new jobs to analyze)
-    await triggerAnalysisJobIfNeeded(jobRunId);
+    // Only trigger follow-on work once all collection tasks are terminal.
+    if (result.status === "completed") {
+      // Phase 2: Analysis (auto-triggered if there are new jobs to analyze)
+      await triggerAnalysisJobIfNeeded(jobRunId);
 
-    // Phase 3: News cache refresh (async, non-blocking)
-    // Pre-warms the cache for weekly digest generation
-    refreshNewsCacheForActiveCompanies(jobRunId, {
-      parallelism: 2,
-      skipIfCached: true,
-    }).catch((err) => console.error("News cache refresh error:", err));
+      // Phase 3: News cache refresh (async, non-blocking)
+      // Pre-warms the cache for weekly digest generation
+      refreshNewsCacheForActiveCompanies(jobRunId, {
+        parallelism: 2,
+        skipIfCached: true,
+      }).catch((err) => console.error("News cache refresh error:", err));
+    } else {
+      console.log(
+        `Collection job ${jobRunId} still in progress; skipping analysis/news until completion`
+      );
+    }
 
     return NextResponse.json({
       success: true,

--- a/web/lib/jobs/processor.ts
+++ b/web/lib/jobs/processor.ts
@@ -105,6 +105,7 @@ async function extractAndUpdateStructure(
 
     // Validate and clean department field - set to null if invalid
     const cleanedDepartment = isValidDepartment(rawDepartment) ? rawDepartment : null;
+    const finalDepartment = cleanedDepartment || structure.standardized_department || null;
 
     // Handle location: always use AI-extracted location from description
     // Validate scraper-provided location - if invalid, set to null
@@ -145,8 +146,8 @@ async function extractAndUpdateStructure(
         standardized_department: structure.standardized_department,
         function_category: structure.function_category,
         normalized_title: normalizedTitle,
-        // Clean invalid department values (set to null)
-        department: cleanedDepartment,
+        // Prefer validated source department, fallback to standardized extraction
+        department: finalDepartment,
         // Store structured location (always from AI extraction)
         location_structured: locationStructured,
         // Use formatted location from structured data, or cleaned scraper location, or null

--- a/web/lib/jobs/runner.ts
+++ b/web/lib/jobs/runner.ts
@@ -77,10 +77,11 @@ export async function executeCollectionJob(jobRunId: string): Promise<JobRunResu
     .update({
       status: 'running',
       started_at: new Date().toISOString(),
+      completed_at: null,
     })
     .eq('id', jobRunId);
 
-  // Get all tasks for this job run (with retry logic to handle async creation)
+  // Get resumable tasks for this job run (pending/failed only)
   let tasks: Array<{ id: string }> | null = null;
   let attempts = 0;
   const maxAttempts = 10;
@@ -90,6 +91,7 @@ export async function executeCollectionJob(jobRunId: string): Promise<JobRunResu
       .from('job_run_tasks')
       .select('id')
       .eq('job_run_id', jobRunId)
+      .in('status', ['pending', 'failed'])
       .order('started_at', { ascending: true, nullsFirst: true });
     
     if (error) {
@@ -108,14 +110,14 @@ export async function executeCollectionJob(jobRunId: string): Promise<JobRunResu
     }
   }
 
-  if (!tasks || tasks.length === 0) {
+  if (!tasks) {
     throw new Error(`No tasks found for job run ${jobRunId} after ${maxAttempts} attempts`);
   }
 
   let completedCount = 0;
   let failedCount = 0;
 
-  // Process each task
+  // Process resumable tasks
   for (const task of tasks) {
     try {
       await processCollectionTask(task.id);
@@ -129,15 +131,28 @@ export async function executeCollectionJob(jobRunId: string): Promise<JobRunResu
     await updateJobRunStats(jobRunId);
   }
 
-  // Determine final status
-  const finalStatus = failedCount === 0 ? 'completed' : failedCount === tasks.length ? 'failed' : 'completed';
+  // Determine final status from all task states
+  const { data: taskStatuses, error: statusError } = await supabase
+    .from('job_run_tasks')
+    .select('status')
+    .eq('job_run_id', jobRunId);
+
+  if (statusError) {
+    throw new Error(`Failed to determine job run status: ${statusError.message}`);
+  }
+
+  const hasPendingOrRunning = (taskStatuses ?? []).some(
+    (task) => task.status === 'pending' || task.status === 'running'
+  );
+  const hasFailed = (taskStatuses ?? []).some((task) => task.status === 'failed');
+  const finalStatus = hasPendingOrRunning ? 'running' : hasFailed ? 'failed' : 'completed';
 
   // Update job run status
   await supabase
     .from('job_runs')
     .update({
       status: finalStatus,
-      completed_at: new Date().toISOString(),
+      completed_at: finalStatus === 'running' ? null : new Date().toISOString(),
     })
     .eq('id', jobRunId);
 

--- a/web/lib/scrapers/scotiabank.ts
+++ b/web/lib/scrapers/scotiabank.ts
@@ -79,7 +79,25 @@ export async function fetchScotiabankJobs(
   console.log(
     `[scotiabank] Scraped ${allJobs.length} jobs for ${atsIdentifier}`
   );
-  return allJobs;
+
+  // Fetch job detail pages to populate description fields.
+  // This is required for downstream structure extraction (department/function).
+  try {
+    const enriched = await enrichScotiabankJobDescriptions(allJobs, 4);
+    const withDescriptions = enriched.filter(
+      (job) => !!job.description_text && job.description_text.trim().length > 0
+    ).length;
+    console.log(
+      `[scotiabank] Enriched descriptions for ${withDescriptions}/${enriched.length} jobs`
+    );
+    return enriched;
+  } catch (error) {
+    console.warn(
+      "[scotiabank] Description enrichment failed, continuing with listing data only:",
+      error
+    );
+    return allJobs;
+  }
 }
 
 /**
@@ -247,26 +265,11 @@ export async function enrichScotiabankJobDescriptions(
 
           const html = await res.text();
 
-          // Extract job description from the detail page
-          const descMatch = html.match(
-            /<div[^>]*class="[^"]*jobdescription[^"]*"[^>]*>([\s\S]*?)<\/div>\s*(?:<div|<\/section|<\/article)/i
-          );
-
-          if (descMatch) {
-            const descHtml = descMatch[1].trim();
-            return {
-              ...job,
-              description_html: descHtml,
-              description_text: htmlToText(descHtml),
-            };
-          }
-
-          // Fallback: try broader content area
-          const contentMatch = html.match(
-            /<div[^>]*id="job-description"[^>]*>([\s\S]*?)<\/div>/i
-          );
-          if (contentMatch) {
-            const descHtml = contentMatch[1].trim();
+          // Extract job description from the detail page.
+          // SuccessFactors pages commonly render description in a span with
+          // itemprop="description" and nested span tags.
+          const descHtml = extractScotiabankDescriptionHtml(html);
+          if (descHtml) {
             return {
               ...job,
               description_html: descHtml,
@@ -290,4 +293,55 @@ export async function enrichScotiabankJobDescriptions(
   }
 
   return enriched;
+}
+
+function extractScotiabankDescriptionHtml(html: string): string | null {
+  const descriptionByItemprop = extractBalancedSpanInnerHtml(
+    html,
+    /<span[^>]*itemprop="description"[^>]*>/i
+  );
+  if (descriptionByItemprop) {
+    return descriptionByItemprop.replace(/<img[^>]*>/gi, "").trim();
+  }
+
+  const descriptionByClass = extractBalancedSpanInnerHtml(
+    html,
+    /<span[^>]*class="[^"]*jobdescription[^"]*"[^>]*>/i
+  );
+  if (descriptionByClass) {
+    return descriptionByClass.replace(/<img[^>]*>/gi, "").trim();
+  }
+
+  return null;
+}
+
+function extractBalancedSpanInnerHtml(
+  html: string,
+  openingSpanRegex: RegExp
+): string | null {
+  const openingMatch = openingSpanRegex.exec(html);
+  if (!openingMatch || openingMatch.index < 0) return null;
+
+  const openingIndex = openingMatch.index;
+  const openingTagEnd = html.indexOf(">", openingIndex);
+  if (openingTagEnd < 0) return null;
+
+  const spanTagRegex = /<span\b[^>]*>|<\/span>/gi;
+  spanTagRegex.lastIndex = openingTagEnd + 1;
+
+  let depth = 1;
+  let match: RegExpExecArray | null;
+  while ((match = spanTagRegex.exec(html)) !== null) {
+    if (match[0].startsWith("</span")) {
+      depth -= 1;
+    } else {
+      depth += 1;
+    }
+
+    if (depth === 0) {
+      return html.slice(openingTagEnd + 1, match.index);
+    }
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- fix Scotiabank/Tangerine description parsing so detail pages populate `description_text`, enabling downstream department/function extraction
- fallback `department` to extracted `standardized_department` when ATS does not provide a raw department value
- make `/api/cron/collect` resume an existing in-flight collect run and only trigger analysis/news after collection is fully complete

## Test plan
- [x] `npm run build` passes in `web/`
- [x] Run targeted Tangerine collection and verify scraper logs `Enriched descriptions for 24/24 jobs`
- [x] Verify recent Tangerine rows populate `department` and `function_category`
- [x] Confirm branch diff only includes the four intended files

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes job-run orchestration and status transitions for cron collection, which could impact scheduling/resumption behavior and downstream analysis triggering if edge cases are missed.
> 
> **Overview**
> Stabilizes cron-driven collection by reusing an existing in-flight `collect` `job_run` and deferring analysis/news-cache refresh until collection is fully complete.
> 
> Makes `executeCollectionJob` resumable by only processing `pending`/`failed` tasks and by deriving the run’s final status from *all* task statuses (leaving the run `running` when work remains). Also improves data quality by enriching Scotiabank/Tangerine listings with detail-page `description_text` via more robust span parsing, and by falling back `job_postings.department` to the extracted `standardized_department` when the raw department is missing/invalid.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4ce6e951a14a32713078d0a19f95220763fb8f5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->