### PR TITLE
Reimagine dashboard as intelligence-first experience

### DIFF
--- a/web/app/(dashboard)/page.tsx
+++ b/web/app/(dashboard)/page.tsx
@@ -1,174 +1,157 @@
 /**
- * Dashboard Page - Main entry point after login.
+ * Dashboard Page - Intelligence-first competitive intelligence dashboard.
  *
- * Features:
- * - Interactive stats cards with drill-down
- * - Trend visualizations (Posting velocity & Function mix)
- * - Companies overview with card/table toggle
- * - Strategic highlights from most recent weekly digest
+ * Layout:
+ * - ROW 0: Time Range Selector (right-aligned)
+ * - ROW 1: Stat Cards with sparklines
+ * - ROW 2: Weekly Intel Banner (AI digest narrative)
+ * - ROW 3: Net Hiring Flow chart (full width)
+ * - ROW 4: Competitive Matrix (2/3) + Function Mix donut (1/3)
+ * - ROW 5: Hot Roles Feed (1/2) + Strategy Signals (1/2)
  */
 
+import { Suspense } from "react";
 import { createClient } from "@/lib/supabase/server";
-import { startOfWeek, subDays, subWeeks } from "date-fns";
-import { CompaniesOverview } from "@/components/dashboard/CompaniesOverview";
-import { StrategicHighlights } from "@/components/dashboard/StrategicHighlights";
 import { StatsCards } from "@/components/dashboard/StatsCards";
-import { PostingTrendChart } from "@/components/dashboard/charts/PostingTrendChart";
+import { TimeRangeSelector } from "@/components/dashboard/TimeRangeSelector";
+import { WeeklyIntelBanner } from "@/components/dashboard/WeeklyIntelBanner";
+import { NetHiringFlowChart } from "@/components/dashboard/charts/PostingTrendChart";
 import { FunctionBreakdownContainer } from "@/components/dashboard/charts/FunctionBreakdownContainer";
-import { getPostingTrends, getRawFunctionData } from "@/lib/dashboard-queries";
-import { transformCompanyData, transformDigestHighlights, CompanyRow, DigestCompanyRow } from "@/lib/dashboard-transformers";
+import { CompetitiveMatrix } from "@/components/dashboard/CompaniesOverview";
+import { StrategySignals } from "@/components/dashboard/StrategicHighlights";
+import { HotRolesFeed } from "@/components/dashboard/HotRolesFeed";
+import {
+  getCompanyBackfillCutoffs,
+  getPostingTrends,
+  getRawFunctionData,
+  getNetHiringFlow,
+  getCompetitiveMatrixData,
+  getLatestDigest,
+  getHotRoles,
+  getNetThisWeek,
+} from "@/lib/dashboard-queries";
 
-export default async function DashboardPage() {
+const RANGE_TO_DAYS: Record<string, number> = {
+  "2w": 14,
+  "1m": 30,
+  "3m": 90,
+  "6m": 180,
+};
+
+export default async function DashboardPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ range?: string }>;
+}) {
+  const params = await searchParams;
+  const range = params.range || "3m";
+  const days = RANGE_TO_DAYS[range] ?? 90;
+
   const supabase = await createClient();
 
-  // Date calculations
-  const now = new Date();
-  const startOfToday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
-  const sevenDaysAgo = subDays(now, 7).toISOString();
-  const fourteenDaysAgo = subDays(now, 14).toISOString();
-  const startOfWeekDate = startOfWeek(now, { weekStartsOn: 1 });
-  const startOfLastWeekDate = startOfWeek(subWeeks(now, 1), { weekStartsOn: 1 });
+  // Fetch backfill cutoffs first (needed by most queries)
+  const cutoffs = await getCompanyBackfillCutoffs();
 
   // Fetch all data in parallel
   const [
     { count: activeJobs },
-    { count: newToday },
-    { count: insightsCount },
-    { count: thisWeek },
-    { count: lastWeek },
-    { data: companiesRaw },
-    { data: companyInsightsRaw },
+    netThisWeek,
     postingTrends,
+    netHiringFlow,
     rawFunctionData,
+    competitiveMatrix,
+    latestDigest,
+    hotRoles,
+    { data: companiesRaw },
   ] = await Promise.all([
-    // Active jobs count
+    // Active jobs count (current snapshot, no backfill filter needed)
     supabase
       .from("job_postings")
       .select("*, companies!inner(is_active)", { count: "exact", head: true })
       .eq("is_active", true)
       .eq("companies.is_active", true),
-    // New today count
-    supabase
-      .from("job_postings")
-      .select("*, companies!inner(is_active)", { count: "exact", head: true })
-      .gte("first_seen_date", startOfToday.toISOString())
-      .eq("companies.is_active", true),
-    // Company insights count (last 7 days) - kept for stats
-    supabase
-      .from("company_insights")
-      .select("*", { count: "exact", head: true })
-      .gte("generated_at", sevenDaysAgo),
-    // This week new jobs
-    supabase
-      .from("job_postings")
-      .select("*, companies!inner(is_active)", { count: "exact", head: true })
-      .gte("first_seen_date", startOfWeekDate.toISOString())
-      .eq("companies.is_active", true),
-    // Last week new jobs (for trend calculation)
-    supabase
-      .from("job_postings")
-      .select("*, companies!inner(is_active)", { count: "exact", head: true })
-      .gte("first_seen_date", startOfLastWeekDate.toISOString())
-      .lt("first_seen_date", startOfWeekDate.toISOString())
-      .eq("companies.is_active", true),
-    // All active companies with job counts
+    // Net new/closed this week
+    getNetThisWeek(cutoffs),
+    // Posting trends for sparkline
+    getPostingTrends(days, cutoffs),
+    // Net hiring flow chart data
+    getNetHiringFlow(days, cutoffs),
+    // Raw function data for donut chart
+    getRawFunctionData(days, cutoffs),
+    // Competitive matrix
+    getCompetitiveMatrixData(cutoffs),
+    // Latest digest
+    getLatestDigest(),
+    // Hot roles feed
+    getHotRoles(cutoffs),
+    // Companies for filter dropdown
     supabase
       .from("companies")
-      .select(`
-        id,
-        name,
-        slug,
-        country,
-        ats_type,
-        job_postings!left(id, is_active, title, first_seen_date)
-      `)
+      .select("id, name")
       .eq("is_active", true)
       .order("name"),
-    // Most recent weekly digest and company summaries
-    (async () => {
-      // Get most recent digest by week_start
-      const { data: latestDigest } = await supabase
-        .from("weekly_digests")
-        .select("id, generated_at, week_start, week_end")
-        .order("week_start", { ascending: false })
-        .limit(1)
-        .single();
-
-      if (!latestDigest) {
-        return { data: null };
-      }
-
-      // Get company summaries for this digest, filtered by active companies
-      const { data: digestCompanies } = await supabase
-        .from("weekly_digest_companies")
-        .select(`
-          id,
-          company_id,
-          headline,
-          body,
-          new_job_count,
-          companies!inner(id, name, slug, is_active)
-        `)
-        .eq("digest_id", latestDigest.id)
-        .eq("companies.is_active", true)
-        .order("new_job_count", { ascending: false });
-
-      // Return with digest metadata
-      return {
-        data: {
-          digest: latestDigest,
-          companies: digestCompanies || [],
-        },
-      };
-    })(),
-    // New Trend Data
-    getPostingTrends(90), // Last 3 months
-    getRawFunctionData(90), // Last 3 months raw data for client-side filtering
   ]);
 
-  // Transform data
-  const companies = transformCompanyData(companiesRaw as CompanyRow[]);
-  const digestResponse = companyInsightsRaw as { digest: { generated_at: string; week_start: string; week_end: string }; companies: DigestCompanyRow[] } | null;
-  const strategicHighlights = transformDigestHighlights(digestResponse);
-  const trackedCompanyCount = companies.length;
+  // Compute derived values
+  const avgWeeklyVelocity =
+    postingTrends.length > 0
+      ? Math.round(
+          postingTrends.reduce((sum, t) => sum + t.count, 0) /
+            postingTrends.length
+        )
+      : 0;
 
-  // Prepare simple company list for filter
-  const companyList = (companiesRaw as CompanyRow[] ?? []).map(c => ({ id: c.id, name: c.name }));
+  const companiesTracked = companiesRaw?.length ?? 0;
+
+  // Sparkline: use last 8 weeks of posting trend data
+  const sparklineData = postingTrends.slice(-8).map((t) => t.count);
+
+  // Company list for filter
+  const companyList = (companiesRaw ?? []).map((c) => ({
+    id: c.id,
+    name: c.name,
+  }));
 
   return (
     <div className="space-y-6 sm:space-y-8">
-      {/* Quick Stats - Interactive */}
-      <StatsCards
-        activeJobs={activeJobs ?? 0}
-        newToday={newToday ?? 0}
-        insightsCount={insightsCount ?? 0}
-        newThisWeek={thisWeek ?? 0}
-        newLastWeek={lastWeek ?? 0}
-      />
-
-      {/* Main Trends Grid */}
-      <div className="grid gap-6 md:grid-cols-3">
-        {/* Posting Velocity - Takes 2/3 width */}
-        <PostingTrendChart data={postingTrends} />
-
-        {/* Function Mix - Takes 1/3 width */}
-        <FunctionBreakdownContainer rawData={rawFunctionData} companies={companyList} />
+      {/* ROW 0: Time Range Selector */}
+      <div className="flex justify-end">
+        <Suspense fallback={null}>
+          <TimeRangeSelector currentRange={range} />
+        </Suspense>
       </div>
 
-      {/* Main Content Grid - Stacks on mobile, 50/50 split on desktop */}
-      <div className="flex flex-col gap-6 sm:gap-8 lg:grid lg:grid-cols-2">
-        {/* Strategic Highlights - Promoted to equal footing */}
-        <div className="lg:col-span-1">
-          <StrategicHighlights
-            insights={strategicHighlights}
-            trackedCompanyCount={trackedCompanyCount}
-          />
-        </div>
+      {/* ROW 1: Stat Cards */}
+      <StatsCards
+        activeJobs={activeJobs ?? 0}
+        netThisWeek={netThisWeek}
+        avgWeeklyVelocity={avgWeeklyVelocity}
+        companiesTracked={companiesTracked}
+        sparklineData={sparklineData}
+      />
 
-        {/* Companies Overview */}
-        <div className="lg:col-span-1">
-          <CompaniesOverview companies={companies} />
-        </div>
+      {/* ROW 2: Weekly Intel Banner */}
+      <WeeklyIntelBanner digest={latestDigest} />
+
+      {/* ROW 3: Net Hiring Flow Chart */}
+      <NetHiringFlowChart data={netHiringFlow} />
+
+      {/* ROW 4: Competitive Matrix (2/3) + Function Mix donut (1/3) */}
+      <div className="grid gap-6 lg:grid-cols-3">
+        <CompetitiveMatrix
+          data={competitiveMatrix}
+          className="lg:col-span-2"
+        />
+        <FunctionBreakdownContainer
+          rawData={rawFunctionData}
+          companies={companyList}
+        />
+      </div>
+
+      {/* ROW 5: Hot Roles Feed (1/2) + Strategy Signals (1/2) */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <HotRolesFeed roles={hotRoles} />
+        <StrategySignals digest={latestDigest} />
       </div>
     </div>
   );

--- a/web/components/dashboard/CompaniesOverview.tsx
+++ b/web/components/dashboard/CompaniesOverview.tsx
@@ -1,29 +1,14 @@
 "use client";
 
-/**
- * CompaniesOverview - Displays tracked companies with Notion-style card/table toggle.
- * 
- * Shows:
- * - Company name and country
- * - Active job count
- * - Recent job highlights
- * - Link to company detail page
- */
-
-import * as React from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { Building2, MapPin, Briefcase, TrendingUp, ArrowRight } from "lucide-react";
 import {
-  NotionCard,
-  NotionCardContent,
-  NotionCardTitle,
-  NotionCardDescription,
-  NotionCardFooter,
-  NotionCardTag,
-  NotionCardMetric,
-} from "@/components/ui/notion-card";
-import { ViewToggle, useViewPreference, ViewMode } from "@/components/ui/view-toggle";
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Table,
   TableBody,
@@ -32,166 +17,134 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { CATEGORY_GROUPS } from "@/lib/analysis/function-categories";
+import type { CompetitiveMatrixRow } from "@/lib/dashboard-queries";
 
-/** Company data structure */
-export interface CompanyOverviewData {
-  id: string;
-  name: string;
-  slug: string;
-  country: string;
-  activeJobCount: number;
-  recentHighlight?: string | null;
-  atsType: string;
-}
+const DISPLAY_GROUPS = Object.keys(CATEGORY_GROUPS).filter(
+  (g) => g !== "Other"
+);
 
-interface CompaniesOverviewProps {
-  companies: CompanyOverviewData[];
+const GROUP_SHORT_LABELS: Record<string, string> = {
+  Engineering: "Eng",
+  "Product & Design": "Prod",
+  "Data & Analytics": "Data",
+  "Risk, Legal & Compliance": "Risk",
+  "Go-To-Market": "GTM",
+  "Finance & Strategy": "Fin",
+  "Operations & People": "Ops",
+};
+
+export function CompetitiveMatrix({
+  data,
+  className,
+}: {
+  data: CompetitiveMatrixRow[];
   className?: string;
-}
-
-/**
- * Main CompaniesOverview component with view toggle
- */
-export function CompaniesOverview({ companies, className }: CompaniesOverviewProps) {
-  const [view, setView] = useViewPreference("dashboard-companies", "card");
-
-  return (
-    <div className={cn("space-y-4", className)}>
-      {/* Header with view toggle */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-lg font-semibold">Companies Being Tracked</h2>
+}) {
+  if (data.length === 0) {
+    return (
+      <Card className={className}>
+        <CardHeader>
+          <CardTitle>Competitive Matrix</CardTitle>
+          <CardDescription>Active jobs by company and function</CardDescription>
+        </CardHeader>
+        <CardContent>
           <p className="text-sm text-muted-foreground">
-            {companies.length} active companies
+            No data available yet.
           </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className={className}>
+      <CardHeader>
+        <CardTitle>Competitive Matrix</CardTitle>
+        <CardDescription>
+          Active jobs by company and function group
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto -mx-6">
+          <div className="min-w-[600px] px-6">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="sticky left-0 bg-card z-10 min-w-[120px]">
+                    Company
+                  </TableHead>
+                  {DISPLAY_GROUPS.map((group) => (
+                    <TableHead
+                      key={group}
+                      className="text-center text-xs whitespace-nowrap px-2"
+                    >
+                      {GROUP_SHORT_LABELS[group] || group}
+                    </TableHead>
+                  ))}
+                  <TableHead className="text-center text-xs">Total</TableHead>
+                  <TableHead className="text-center text-xs">WoW</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data.map((row) => (
+                  <TableRow key={row.companyId}>
+                    <TableCell className="sticky left-0 bg-card z-10">
+                      <Link
+                        href={`/companies/${row.companySlug}`}
+                        className="font-medium text-sm hover:text-primary hover:underline"
+                      >
+                        {row.companyName}
+                      </Link>
+                    </TableCell>
+                    {DISPLAY_GROUPS.map((group) => {
+                      const cell = row.groups[group];
+                      const count = cell?.current || 0;
+                      const change = cell?.change || 0;
+                      return (
+                        <TableCell
+                          key={group}
+                          className={cn(
+                            "text-center text-xs tabular-nums px-2",
+                            change > 0 && "bg-green-50 dark:bg-green-950/30",
+                            change < 0 && "bg-red-50 dark:bg-red-950/30"
+                          )}
+                        >
+                          {count > 0 ? (
+                            count
+                          ) : (
+                            <span className="text-muted-foreground/40">
+                              —
+                            </span>
+                          )}
+                        </TableCell>
+                      );
+                    })}
+                    <TableCell className="text-center font-semibold text-sm">
+                      {row.total}
+                    </TableCell>
+                    <TableCell className="text-center text-xs">
+                      <span
+                        className={cn(
+                          "font-medium",
+                          row.weekChange > 0 && "text-green-600",
+                          row.weekChange < 0 && "text-red-600",
+                          row.weekChange === 0 && "text-muted-foreground"
+                        )}
+                      >
+                        {row.weekChange > 0 ? "+" : ""}
+                        {row.weekChange}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         </div>
-        <ViewToggle view={view} onViewChange={setView} />
-      </div>
-
-      {/* Content based on view mode */}
-      {view === "card" ? (
-        <CompaniesCardView companies={companies} />
-      ) : (
-        <CompaniesTableView companies={companies} />
-      )}
-    </div>
+      </CardContent>
+    </Card>
   );
 }
 
-/**
- * Card view - Notion-style cards in a grid
- */
-function CompaniesCardView({ companies }: { companies: CompanyOverviewData[] }) {
-  if (companies.length === 0) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        No companies being tracked yet.
-      </div>
-    );
-  }
-
-  return (
-    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {companies.map((company) => (
-        <Link key={company.id} href={`/companies/${company.slug}`}>
-          <NotionCard className="h-full">
-            <NotionCardContent className="flex-1">
-              {/* Company icon and name */}
-              <div className="flex items-start gap-3">
-                <div className="flex-shrink-0 w-10 h-10 rounded-lg bg-primary/10 flex items-center justify-center">
-                  <Building2 className="h-5 w-5 text-primary" />
-                </div>
-                <div className="flex-1 min-w-0">
-                  <NotionCardTitle>{company.name}</NotionCardTitle>
-                  <div className="flex items-center gap-1 mt-1 text-xs text-muted-foreground">
-                    <MapPin className="h-3 w-3" />
-                    <span>{company.country}</span>
-                  </div>
-                </div>
-              </div>
-
-              {/* Job count metric */}
-              <div className="flex items-center gap-2 mt-4">
-                <Briefcase className="h-4 w-4 text-muted-foreground" />
-                <span className="text-2xl font-bold">{company.activeJobCount}</span>
-                <span className="text-sm text-muted-foreground">active jobs</span>
-              </div>
-
-              {/* Recent highlight */}
-              {company.recentHighlight && (
-                <NotionCardDescription className="mt-3 text-xs">
-                  <TrendingUp className="inline h-3 w-3 mr-1" />
-                  {company.recentHighlight}
-                </NotionCardDescription>
-              )}
-
-              {/* Footer with tags */}
-              <NotionCardFooter className="mt-auto pt-4">
-                <NotionCardTag>{company.atsType}</NotionCardTag>
-                <ArrowRight className="h-3 w-3 ml-auto opacity-0 group-hover:opacity-100 transition-opacity" />
-              </NotionCardFooter>
-            </NotionCardContent>
-          </NotionCard>
-        </Link>
-      ))}
-    </div>
-  );
-}
-
-/**
- * Table view - Traditional table layout
- */
-function CompaniesTableView({ companies }: { companies: CompanyOverviewData[] }) {
-  if (companies.length === 0) {
-    return (
-      <div className="text-center py-8 text-muted-foreground">
-        No companies being tracked yet.
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-lg border">
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Company</TableHead>
-            <TableHead>Country</TableHead>
-            <TableHead className="text-right">Active Jobs</TableHead>
-            <TableHead>Recent Activity</TableHead>
-            <TableHead></TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {companies.map((company) => (
-            <TableRow key={company.id}>
-              <TableCell>
-                <div className="flex items-center gap-2">
-                  <Building2 className="h-4 w-4 text-muted-foreground" />
-                  <span className="font-medium">{company.name}</span>
-                </div>
-              </TableCell>
-              <TableCell>{company.country}</TableCell>
-              <TableCell className="text-right font-semibold">
-                {company.activeJobCount}
-              </TableCell>
-              <TableCell className="max-w-xs truncate text-sm text-muted-foreground">
-                {company.recentHighlight || "—"}
-              </TableCell>
-              <TableCell>
-                <Link
-                  href={`/companies/${company.slug}`}
-                  className="text-primary text-sm hover:underline"
-                >
-                  View →
-                </Link>
-              </TableCell>
-            </TableRow>
-          ))}
-        </TableBody>
-      </Table>
-    </div>
-  );
-}
-
-export default CompaniesOverview;
+export default CompetitiveMatrix;

--- a/web/components/dashboard/HotRolesFeed.tsx
+++ b/web/components/dashboard/HotRolesFeed.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import Link from "next/link";
+import {
+  differenceInMinutes,
+  differenceInHours,
+  differenceInDays,
+  differenceInWeeks,
+} from "date-fns";
+import { Briefcase } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { HotRole } from "@/lib/dashboard-queries";
+
+/** Compact relative time: "5m", "3h", "2d", "1w" */
+function compactTimeAgo(date: Date): string {
+  const now = new Date();
+  const mins = differenceInMinutes(now, date);
+  if (mins < 60) return `${mins}m`;
+  const hrs = differenceInHours(now, date);
+  if (hrs < 24) return `${hrs}h`;
+  const days = differenceInDays(now, date);
+  if (days < 7) return `${days}d`;
+  const weeks = differenceInWeeks(now, date);
+  return `${weeks}w`;
+}
+
+export function HotRolesFeed({ roles }: { roles: HotRole[] }) {
+  if (roles.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Briefcase className="h-4 w-4" />
+            Hot Roles
+          </CardTitle>
+          <CardDescription>Most recent job postings</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No recent postings yet.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Briefcase className="h-4 w-4" />
+          Hot Roles
+        </CardTitle>
+        <CardDescription>Most recent job postings</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="max-h-[400px] overflow-y-auto space-y-0.5 -mx-2">
+          {roles.map((role) => (
+            <Link
+              key={role.id}
+              href={`/companies/${role.companySlug}`}
+              className="grid grid-cols-[2.5rem_auto_1fr] items-baseline gap-x-2 rounded-md px-2 py-1.5 text-sm hover:bg-muted/50 transition-colors"
+            >
+              <span className="text-xs text-muted-foreground tabular-nums text-right">
+                {compactTimeAgo(new Date(role.firstSeenDate))}
+              </span>
+              <span className="font-medium text-muted-foreground whitespace-nowrap">
+                {role.companyName}
+              </span>
+              <span className="truncate">{role.title}</span>
+            </Link>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/components/dashboard/StatsCards.tsx
+++ b/web/components/dashboard/StatsCards.tsx
@@ -1,93 +1,117 @@
 import Link from "next/link";
 import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { ReactNode } from "react";
 
-export interface StatCardData {
+interface StatCardDef {
   label: string;
-  value: number | string;
+  value: ReactNode;
+  subtitle?: string;
   href?: string;
-  trend?: {
-    value: number;
-    label: string; // e.g. "vs last week"
-    direction: "up" | "down" | "neutral";
-  };
+  sparkline?: number[];
+}
+
+function Sparkline({ data, className }: { data: number[]; className?: string }) {
+  if (data.length < 2) return null;
+
+  const max = Math.max(...data);
+  const min = Math.min(...data);
+  const range = max - min || 1;
+  const width = 60;
+  const height = 20;
+
+  const points = data.map((value, i) => {
+    const x = (i / (data.length - 1)) * width;
+    const y = height - ((value - min) / range) * (height - 2) - 1;
+    return `${x},${y}`;
+  });
+
+  const pathD = `M ${points.join(" L ")}`;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      className={cn("text-primary", className)}
+      viewBox={`0 0 ${width} ${height}`}
+    >
+      <path
+        d={pathD}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
 }
 
 export function StatsCards({
   activeJobs,
-  newToday,
-  insightsCount,
-  newThisWeek,
-  newLastWeek,
+  netThisWeek,
+  avgWeeklyVelocity,
+  companiesTracked,
+  sparklineData,
 }: {
   activeJobs: number;
-  newToday: number;
-  insightsCount: number;
-  newThisWeek: number;
-  newLastWeek: number;
+  netThisWeek: { newCount: number; closedCount: number };
+  avgWeeklyVelocity: number;
+  companiesTracked: number;
+  sparklineData: number[];
 }) {
-  // Calculate trend for "New This Week"
-  let weekTrendValue = 0;
-  let weekTrendDirection: "up" | "down" | "neutral" = "neutral";
+  const net = netThisWeek.newCount - netThisWeek.closedCount;
 
-  if (newLastWeek > 0) {
-    weekTrendValue = Math.round(((newThisWeek - newLastWeek) / newLastWeek) * 100);
-    weekTrendDirection = weekTrendValue > 0 ? "up" : weekTrendValue < 0 ? "down" : "neutral";
-  } else if (newThisWeek > 0) {
-    // Growth from zero
-    weekTrendValue = 100;
-    weekTrendDirection = "up";
-  }
-  
-  const stats: StatCardData[] = [
-    { 
-      label: "Active Jobs", 
+  const stats: StatCardDef[] = [
+    {
+      label: "Active Jobs",
       value: activeJobs,
-      href: "/jobs?status=active"
+      href: "/jobs?status=active",
+      sparkline: sparklineData,
     },
-    { 
-      label: "New Today", 
-      value: newToday,
-      href: "/jobs?date=today"
-    },
-    { 
-      label: "Insights", 
-      value: insightsCount,
-      href: "/digests"
-    },
-    { 
-      label: "New This Week", 
-      value: newThisWeek,
+    {
+      label: "Net This Week",
+      value: (
+        <span>
+          <span className="text-green-600">+{netThisWeek.newCount}</span>
+          <span className="text-muted-foreground mx-1">/</span>
+          <span className="text-red-500">-{netThisWeek.closedCount}</span>
+        </span>
+      ),
+      subtitle: `Net ${net >= 0 ? "+" : ""}${net}`,
       href: "/jobs?date=week",
-      trend: {
-        value: Math.abs(weekTrendValue),
-        label: "vs last week",
-        direction: weekTrendDirection
-      }
+    },
+    {
+      label: "Avg Weekly Velocity",
+      value: avgWeeklyVelocity,
+      subtitle: "new postings/week",
+    },
+    {
+      label: "Companies Tracked",
+      value: companiesTracked,
+      href: "/companies",
     },
   ];
 
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
-      {stats.map(({ label, value, href, trend }) => {
+      {stats.map(({ label, value, subtitle, href, sparkline }) => {
         const Content = (
-          <Card className={cn("h-full transition-colors", href && "hover:bg-muted/50")}>
+          <Card
+            className={cn("h-full transition-colors", href && "hover:bg-muted/50")}
+          >
             <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <span className="text-sm font-medium text-muted-foreground">{label}</span>
+              <span className="text-sm font-medium text-muted-foreground">
+                {label}
+              </span>
+              {sparkline && sparkline.length >= 2 && (
+                <Sparkline data={sparkline} />
+              )}
             </CardHeader>
             <CardContent>
               <div className="text-2xl font-bold">{value}</div>
-              {trend && (
-                <p className="text-xs text-muted-foreground mt-1">
-                  <span className={cn(
-                    "font-medium",
-                    trend.direction === "up" && "text-green-600",
-                    trend.direction === "down" && "text-red-600"
-                  )}>
-                    {trend.direction === "up" ? "↑" : trend.direction === "down" ? "↓" : ""} {trend.value}%
-                  </span>
-                  {" "}{trend.label}
-                </p>
+              {subtitle && (
+                <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
               )}
             </CardContent>
           </Card>

--- a/web/components/dashboard/StrategicHighlights.tsx
+++ b/web/components/dashboard/StrategicHighlights.tsx
@@ -1,303 +1,135 @@
-"use client";
-
-/**
- * StrategicHighlights - Dashboard component showing company highlights from weekly digest.
- * 
- * Displays company summaries from the most recent weekly digest, matching the format
- * of the "Company Highlights" section in the weekly digest email and viewer.
- * 
- * Features:
- * - Pulls from weekly_digest_companies (TLDR-style company summaries)
- * - Shows punchy headlines and body text from digest
- * - Expandable cards that show full details inline (accordion pattern)
- * - Links to company detail pages within expanded content
- * 
- * @see /web/lib/analysis/digest.ts for digest generation
- */
-
-import * as React from "react";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
-import { formatDistanceToNow } from "date-fns";
-import { Sparkles, ChevronRight, ChevronDown, TrendingUp, ExternalLink } from "lucide-react";
+import { TrendingUp, ArrowRight } from "lucide-react";
 import {
-  NotionCard,
-  NotionCardContent,
-  NotionCardTitle,
-  NotionCardDescription,
-  NotionCardFooter,
-  NotionCardTag,
-} from "@/components/ui/notion-card";
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { LatestDigest } from "@/lib/dashboard-queries";
 
-// ============================================================================
-// Types
-// ============================================================================
+export function StrategySignals({
+  digest,
+}: {
+  digest: LatestDigest | null;
+}) {
+  const trends = digest?.industryTrends?.slice(0, 3) ?? [];
+  const signals = digest?.strategySignals?.slice(0, 3) ?? [];
 
-/**
- * Strategic insight data for display in highlights panel
- */
-export interface StrategicHighlight {
-  /** Unique insight ID */
-  id: string;
-  /** Company ID */
-  companyId: string;
-  /** Company name for display */
-  companyName: string;
-  /** Company slug for URL */
-  companySlug: string;
-  /** When the insight was generated */
-  generatedAt: string;
-  /** Punchy headline with emoji (e.g., "🎯 Koho doubles down on SMB") */
-  headline: string | null;
-  /** One-liner explaining strategic signal */
-  keySignal: string | null;
-  /** 1-10 significance ranking */
-  significanceScore: number | null;
-  /** Confidence level */
-  confidence: "high" | "medium" | "low";
-  /** Executive summary excerpt for fallback */
-  executiveSummary: string;
-}
-
-interface StrategicHighlightsProps {
-  /** List of strategic insights to display */
-  insights: StrategicHighlight[];
-  /** Number of tracked companies (for header display) */
-  trackedCompanyCount: number;
-  /** Optional CSS classes */
-  className?: string;
-}
-
-// ============================================================================
-// Component
-// ============================================================================
-
-/**
- * Strategic highlights panel for dashboard
- */
-export function StrategicHighlights({
-  insights,
-  trackedCompanyCount,
-  className,
-}: StrategicHighlightsProps) {
-  // Sort by job count (if available from digest) or date
-  // Digest summaries are already sorted by new_job_count, but we'll maintain order
-  const sortedInsights = React.useMemo(() => {
-    return [...insights]
-      .sort((a, b) => {
-        // Primary: significance score if available (descending)
-        const scoreA = a.significanceScore ?? 0;
-        const scoreB = b.significanceScore ?? 0;
-        if (scoreB !== scoreA && scoreA > 0 && scoreB > 0) return scoreB - scoreA;
-        // Secondary: date (most recent first)
-        return new Date(b.generatedAt).getTime() - new Date(a.generatedAt).getTime();
-      })
-      .slice(0, 6); // Limit to top 6
-  }, [insights]);
-
-  // Empty state
-  if (sortedInsights.length === 0) {
+  if (trends.length === 0 && signals.length === 0) {
     return (
-      <div className={cn("space-y-4", className)}>
-        <HighlightsHeader trackedCompanyCount={trackedCompanyCount} />
-        <EmptyState />
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Strategy Signals
+          </CardTitle>
+          <CardDescription>Industry trends and strategic alignments</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">
+            No strategy signals available yet. Check back after the next digest.
+          </p>
+        </CardContent>
+      </Card>
     );
   }
 
   return (
-    <div className={cn("space-y-4", className)}>
-      <HighlightsHeader trackedCompanyCount={trackedCompanyCount} />
-      
-      {/* Insight cards */}
-      <div className="space-y-3">
-        {sortedInsights.map((insight) => (
-          <HighlightCard key={insight.id} insight={insight} />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// ============================================================================
-// Sub-components
-// ============================================================================
-
-/**
- * Header with title and link to full insights page
- */
-function HighlightsHeader({ trackedCompanyCount }: { trackedCompanyCount: number }) {
-  return (
-    <div className="flex items-center justify-between">
-      <div>
-        <h2 className="text-lg font-semibold flex items-center gap-2">
-          <Sparkles className="h-5 w-5 text-amber-500" />
-          Strategic Highlights
-        </h2>
-        <p className="text-sm text-muted-foreground">
-          Key moves from {trackedCompanyCount} tracked {trackedCompanyCount === 1 ? "company" : "companies"}
-        </p>
-      </div>
-      <Link
-        href="/digests"
-        className="text-sm text-primary hover:underline flex items-center gap-1"
-      >
-        View all <ChevronRight className="h-3 w-3" />
-      </Link>
-    </div>
-  );
-}
-
-/**
- * Empty state when no insights are available
- */
-function EmptyState() {
-  return (
-    <div className="rounded-lg border border-dashed p-8 text-center">
-      <TrendingUp className="h-8 w-8 mx-auto text-muted-foreground mb-2" />
-      <p className="text-sm text-muted-foreground">
-        No weekly digest highlights yet. Check back after the next digest is generated!
-      </p>
-    </div>
-  );
-}
-
-/**
- * Individual highlight card with expandable details
- * 
- * Displays:
- * - Punchy headline (or fallback)
- * - Key signal or summary excerpt
- * - Company name and confidence badge
- * - Expandable full summary with link to company page
- */
-function HighlightCard({ insight }: { insight: StrategicHighlight }) {
-  const [isExpanded, setIsExpanded] = React.useState(false);
-
-  // Confidence badge styles
-  const confidenceStyles = {
-    high: "bg-green-100 text-green-800 dark:bg-green-900/50 dark:text-green-300",
-    medium: "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/50 dark:text-yellow-300",
-    low: "bg-red-100 text-red-800 dark:bg-red-900/50 dark:text-red-300",
-  };
-
-  // Significance badge styles (high scores get special treatment)
-  const getSignificanceBadge = (score: number | null) => {
-    if (!score) return null;
-    if (score >= 8) {
-      return (
-        <NotionCardTag className="bg-amber-100 text-amber-800 dark:bg-amber-900/50 dark:text-amber-300">
-          Major
-        </NotionCardTag>
-      );
-    }
-    if (score >= 6) {
-      return (
-        <NotionCardTag className="bg-blue-100 text-blue-800 dark:bg-blue-900/50 dark:text-blue-300">
-          Notable
-        </NotionCardTag>
-      );
-    }
-    return null;
-  };
-
-  // Use headline if available, otherwise create a fallback
-  const displayHeadline = insight.headline || `📊 ${insight.companyName} strategic update`;
-
-  // Use key signal if available, otherwise use first sentence of executive summary
-  const displaySignal = insight.keySignal || 
-    insight.executiveSummary.split(".")[0].slice(0, 100) + "...";
-
-  // Calculate relative time
-  const relativeTime = formatDistanceToNow(new Date(insight.generatedAt), { addSuffix: true });
-
-  // Link to company page
-  const companyLink = `/companies/${insight.companySlug}`;
-
-  return (
-    <NotionCard className="transition-shadow hover:shadow-md">
-      <NotionCardContent className="space-y-2">
-        {/* Clickable header area */}
-        <button
-          type="button"
-          onClick={() => setIsExpanded(!isExpanded)}
-          className="w-full text-left focus:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 rounded-sm"
-        >
-          <div className="flex items-start justify-between gap-2">
-            <div className="flex-1 min-w-0">
-              {/* Headline - the star of the show */}
-              <NotionCardTitle className="text-sm font-semibold leading-snug">
-                {displayHeadline}
-              </NotionCardTitle>
-
-              {/* Key signal / description - collapsed view */}
-              {!isExpanded && (
-                <NotionCardDescription className="text-xs line-clamp-2 text-muted-foreground mt-1">
-                  {displaySignal}
-                </NotionCardDescription>
-              )}
-            </div>
-            
-            {/* Expand/collapse indicator */}
-            <div className="shrink-0 mt-0.5">
-              <ChevronDown 
-                className={cn(
-                  "h-4 w-4 text-muted-foreground transition-transform duration-200",
-                  isExpanded && "rotate-180"
-                )} 
-              />
-            </div>
-          </div>
-        </button>
-
-        {/* Expanded content */}
-        <div 
-          className={cn(
-            "overflow-hidden transition-all duration-200 ease-in-out",
-            isExpanded ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
-          )}
-        >
-          <div className="pt-2 space-y-3 border-t">
-            {/* Full summary */}
-            <p className="text-sm text-muted-foreground leading-relaxed">
-              {insight.executiveSummary}
-            </p>
-            
-            {/* Link to company page */}
-            <Link 
-              href={companyLink}
-              className="inline-flex items-center gap-1.5 text-xs font-medium text-primary hover:underline"
-            >
-              View {insight.companyName}
-              <ExternalLink className="h-3 w-3" />
-            </Link>
-          </div>
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0">
+        <div className="space-y-1">
+          <CardTitle className="flex items-center gap-2">
+            <TrendingUp className="h-4 w-4" />
+            Strategy Signals
+          </CardTitle>
+          <CardDescription>Industry trends and strategic alignments</CardDescription>
         </div>
+        {digest && (
+          <Link
+            href={`/digests/${digest.id}`}
+            className="text-xs text-primary hover:underline flex items-center gap-1 shrink-0"
+          >
+            Full digest <ArrowRight className="h-3 w-3" />
+          </Link>
+        )}
+      </CardHeader>
+      <CardContent>
+        <div className="max-h-[400px] overflow-y-auto space-y-5">
+          {/* Industry Trends */}
+          {trends.length > 0 && (
+            <div className="space-y-3">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Industry Trends
+              </p>
+              {trends.map((trend, i) => (
+                <div key={i} className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">{trend.trend}</span>
+                    {trend.direction && (
+                      <span
+                        className={cn(
+                          "text-xs px-1.5 py-0.5 rounded",
+                          trend.direction === "up"
+                            ? "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300"
+                            : trend.direction === "down"
+                              ? "bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-300"
+                              : "bg-muted text-muted-foreground"
+                        )}
+                      >
+                        {trend.direction}
+                      </span>
+                    )}
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {trend.explanation}
+                  </p>
+                  {trend.companies?.length > 0 && (
+                    <p className="text-xs text-muted-foreground">
+                      Companies: {trend.companies.join(", ")}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
 
-        {/* Footer with metadata */}
-        <NotionCardFooter className="flex items-center justify-between pt-2">
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">
-              {insight.companyName}
-            </span>
-            <span className="text-xs text-muted-foreground">·</span>
-            <span className="text-xs text-muted-foreground">
-              {relativeTime}
-            </span>
-          </div>
-          <div className="flex items-center gap-1">
-            {getSignificanceBadge(insight.significanceScore)}
-            {/* Only show confidence badge if significance score exists (not digest summaries) */}
-            {insight.significanceScore !== null && (
-              <NotionCardTag className={cn("text-xs", confidenceStyles[insight.confidence])}>
-                {insight.confidence}
-              </NotionCardTag>
-            )}
-          </div>
-        </NotionCardFooter>
-      </NotionCardContent>
-    </NotionCard>
+          {/* Strategy Signals */}
+          {signals.length > 0 && (
+            <div className="space-y-3">
+              <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                Strategic Alignments
+              </p>
+              {signals.map((signal, i) => (
+                <div key={i} className="space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium">
+                      {signal.company}
+                    </span>
+                    <span
+                      className={cn(
+                        "text-xs px-1.5 py-0.5 rounded",
+                        signal.alignment === "strong"
+                          ? "bg-green-100 text-green-700 dark:bg-green-900/50 dark:text-green-300"
+                          : signal.alignment === "moderate"
+                            ? "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-300"
+                            : "bg-muted text-muted-foreground"
+                      )}
+                    >
+                      {signal.alignment}
+                    </span>
+                  </div>
+                  <p className="text-xs text-muted-foreground">
+                    {signal.signal}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }
-
-export default StrategicHighlights;

--- a/web/components/dashboard/TimeRangeSelector.tsx
+++ b/web/components/dashboard/TimeRangeSelector.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const RANGES = [
+  { label: "2W", value: "2w" },
+  { label: "1M", value: "1m" },
+  { label: "3M", value: "3m" },
+  { label: "6M", value: "6m" },
+] as const;
+
+export function TimeRangeSelector({ currentRange }: { currentRange: string }) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const handleChange = (range: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (range === "3m") {
+      params.delete("range");
+    } else {
+      params.set("range", range);
+    }
+    const query = params.toString();
+    router.push(query ? `/?${query}` : "/");
+  };
+
+  return (
+    <div className="inline-flex items-center rounded-lg border bg-muted p-1 text-muted-foreground">
+      {RANGES.map(({ label, value }) => (
+        <button
+          key={value}
+          onClick={() => handleChange(value)}
+          className={cn(
+            "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium transition-all",
+            currentRange === value
+              ? "bg-background text-foreground shadow-sm"
+              : "hover:bg-background/50 hover:text-foreground"
+          )}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/components/dashboard/WeeklyIntelBanner.tsx
+++ b/web/components/dashboard/WeeklyIntelBanner.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link";
+import { formatDistanceToNow } from "date-fns";
+import { Sparkles, ArrowRight } from "lucide-react";
+import type { LatestDigest } from "@/lib/dashboard-queries";
+
+export function WeeklyIntelBanner({ digest }: { digest: LatestDigest | null }) {
+  if (!digest || !digest.globalSummary) {
+    return (
+      <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+        No weekly digest available yet. Check back after the first digest is
+        generated.
+      </div>
+    );
+  }
+
+  const { globalSummary } = digest;
+  const relativeTime = formatDistanceToNow(new Date(digest.generatedAt), {
+    addSuffix: true,
+  });
+
+  return (
+    <div className="rounded-lg border bg-primary/5 p-5">
+      <div className="flex items-start gap-3">
+        <Sparkles className="h-5 w-5 text-primary mt-0.5 shrink-0" />
+        <div className="flex-1 min-w-0 space-y-1">
+          <p className="font-semibold text-sm leading-snug">
+            {globalSummary.headline || "Weekly Intelligence Summary"}
+          </p>
+          {globalSummary.key_insight && (
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {globalSummary.key_insight}
+            </p>
+          )}
+          <div className="flex items-center gap-3 pt-1">
+            <Link
+              href={`/digests/${digest.id}`}
+              className="inline-flex items-center gap-1 text-xs font-medium text-primary hover:underline"
+            >
+              Read full digest <ArrowRight className="h-3 w-3" />
+            </Link>
+            <span className="text-xs text-muted-foreground">
+              {relativeTime}
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/components/dashboard/charts/FunctionBreakdownChart.tsx
+++ b/web/components/dashboard/charts/FunctionBreakdownChart.tsx
@@ -1,115 +1,80 @@
 "use client";
 
-import { useMemo } from "react";
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Legend,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from "recharts";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { FunctionTrend } from "@/lib/dashboard-queries";
-import { FUNCTION_GROUP_COLORS } from "@/lib/constants";
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip } from "recharts";
+import type { DonutDataPoint } from "@/lib/dashboard-queries";
 
-export function FunctionBreakdownChart({ data, headless = false }: { data: FunctionTrend[], headless?: boolean }) {
-  // Get all unique keys from data except 'date' and 'period' to know which bars to render
-  const allKeys = useMemo(() => {
-    return data.reduce((keys, item) => {
-      Object.keys(item).forEach(key => {
-        if (key !== 'date' && key !== 'period' && !keys.includes(key)) {
-          keys.push(key);
-        }
-      });
-      return keys;
-    }, [] as string[]).sort();
-  }, [data]);
+export function FunctionBreakdownChart({
+  data,
+}: {
+  data: DonutDataPoint[];
+}) {
+  const total = data.reduce((sum, d) => sum + d.value, 0);
 
-  const ChartContent = (
-    <div className="h-[300px] w-full">
-      <ResponsiveContainer width="100%" height="100%">
-        <BarChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
-          <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-muted" />
-          <XAxis 
-            dataKey="period" 
-            stroke="#888888" 
-            fontSize={12} 
-            tickLine={false} 
-            axisLine={false} 
-          />
-          <YAxis
-            stroke="#888888"
-            fontSize={12}
-            tickLine={false}
-            axisLine={false}
-            tickFormatter={(value) => `${value}`}
-          />
-          <Tooltip
-            cursor={{ fill: 'transparent' }}
-            content={({ active, payload, label }) => {
-              if (active && payload && payload.length) {
-                // Calculate total for this period
-                const total = payload.reduce((sum, entry) => sum + (Number(entry.value) || 0), 0);
-                
-                return (
-                  <div className="rounded-lg border bg-background p-2 shadow-sm">
-                    <div className="mb-2 font-bold text-sm flex justify-between gap-4">
-                      <span>{label}</span>
-                      <span className="text-muted-foreground">Total: {total}</span>
-                    </div>
-                    {payload.map((entry: any) => (
-                      <div key={entry.name} className="flex items-center justify-between gap-4 text-xs">
-                        <div className="flex items-center gap-1">
-                          <div 
-                            className="h-2 w-2 rounded-full" 
-                            style={{ backgroundColor: entry.color }}
-                          />
-                          <span className="text-muted-foreground">{entry.name}</span>
-                        </div>
-                        <span className="font-mono font-medium">{entry.value}</span>
-                      </div>
-                    ))}
-                  </div>
-                );
-              }
-              return null;
-            }}
-          />
-          <Legend 
-            wrapperStyle={{ fontSize: '12px', paddingTop: '10px' }}
-            iconType="circle"
-          />
-          {allKeys.map((key) => (
-            <Bar
-              key={key}
-              dataKey={key}
-              stackId="a"
-              fill={FUNCTION_GROUP_COLORS[key as keyof typeof FUNCTION_GROUP_COLORS] || FUNCTION_GROUP_COLORS["Other"]}
-              radius={[0, 0, 0, 0]}
-              maxBarSize={50}
-            />
-          ))}
-        </BarChart>
-      </ResponsiveContainer>
-    </div>
-  );
-
-  if (headless) {
-    return ChartContent;
+  if (data.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[300px] text-sm text-muted-foreground">
+        No function data available.
+      </div>
+    );
   }
 
   return (
-    <Card className="col-span-1">
-      <CardHeader>
-        <CardTitle>Function Mix</CardTitle>
-        <CardDescription>Hiring distribution by function group</CardDescription>
-      </CardHeader>
-      <CardContent className="pl-2">
-        {ChartContent}
-      </CardContent>
-    </Card>
+    <div className="flex flex-col h-[300px]">
+      <div className="flex-1 min-h-0">
+        <ResponsiveContainer width="100%" height="100%">
+          <PieChart>
+            <Pie
+              data={data}
+              cx="50%"
+              cy="50%"
+              innerRadius="55%"
+              outerRadius="85%"
+              paddingAngle={2}
+              dataKey="value"
+              stroke="none"
+            >
+              {data.map((entry, index) => (
+                <Cell key={index} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              content={({ active, payload }) => {
+                if (active && payload && payload.length) {
+                  const d = payload[0].payload as DonutDataPoint;
+                  const pct = total > 0 ? Math.round((d.value / total) * 100) : 0;
+                  return (
+                    <div className="rounded-lg border bg-background p-2 shadow-sm text-sm">
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="h-2 w-2 rounded-full"
+                          style={{ backgroundColor: d.color }}
+                        />
+                        <span className="font-medium">{d.name}</span>
+                      </div>
+                      <p className="text-muted-foreground mt-0.5">
+                        {d.value} jobs ({pct}%)
+                      </p>
+                    </div>
+                  );
+                }
+                return null;
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </div>
+      <div className="flex flex-wrap gap-x-3 gap-y-1 justify-center mt-2 text-xs px-2">
+        {data.map((entry) => (
+          <div key={entry.name} className="flex items-center gap-1">
+            <div
+              className="h-2 w-2 rounded-full shrink-0"
+              style={{ backgroundColor: entry.color }}
+            />
+            <span className="text-muted-foreground">{entry.name}</span>
+            <span className="font-mono tabular-nums">{entry.value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/web/components/dashboard/charts/FunctionBreakdownContainer.tsx
+++ b/web/components/dashboard/charts/FunctionBreakdownContainer.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { format, parseISO, startOfMonth } from "date-fns";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Select,
   SelectContent,
@@ -11,53 +16,45 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FunctionBreakdownChart } from "./FunctionBreakdownChart";
-import { RawFunctionData, FunctionTrend } from "@/lib/dashboard-queries";
+import type { RawFunctionData, DonutDataPoint } from "@/lib/dashboard-queries";
 import { getCategoryGroup, RoleCategory } from "@/lib/analysis/function-categories";
+import { FUNCTION_GROUP_COLORS } from "@/lib/constants";
 
 interface FunctionBreakdownContainerProps {
   rawData: RawFunctionData[];
   companies: { id: string; name: string }[];
 }
 
-export function FunctionBreakdownContainer({ rawData, companies }: FunctionBreakdownContainerProps) {
+export function FunctionBreakdownContainer({
+  rawData,
+  companies,
+}: FunctionBreakdownContainerProps) {
   const [selectedCompanyId, setSelectedCompanyId] = useState<string>("all");
 
-  const chartData = useMemo(() => {
-    // 1. Filter data
-    const filteredData = selectedCompanyId === "all"
-      ? rawData
-      : rawData.filter(d => d.company_id === selectedCompanyId);
+  const donutData: DonutDataPoint[] = useMemo(() => {
+    const filteredData =
+      selectedCompanyId === "all"
+        ? rawData
+        : rawData.filter((d) => d.company_id === selectedCompanyId);
 
-    // 2. Aggregate data
-    const periodMap = new Map<string, Record<string, number>>();
+    const groupCounts = new Map<string, number>();
 
-    filteredData.forEach((job) => {
-      if (!job.first_seen_date || !job.function_category) return;
-
-      const date = parseISO(job.first_seen_date);
-      // Group by month for cleaner high-level trends
-      const periodStart = startOfMonth(date);
-      const periodKey = periodStart.toISOString();
-
+    for (const job of filteredData) {
+      if (!job.function_category) continue;
       const group = getCategoryGroup(job.function_category as RoleCategory);
+      groupCounts.set(group, (groupCounts.get(group) || 0) + 1);
+    }
 
-      if (!periodMap.has(periodKey)) {
-        periodMap.set(periodKey, {});
-      }
-
-      const periodCounts = periodMap.get(periodKey)!;
-      periodCounts[group] = (periodCounts[group] || 0) + 1;
-    });
-
-    // 3. Convert to array
-    return Array.from(periodMap.entries())
-      .map(([date, counts]) => ({
-        date,
-        period: format(parseISO(date), "MMM yyyy"),
-        ...counts,
-      } as FunctionTrend))
-      .sort((a, b) => a.date.localeCompare(b.date));
-
+    return Array.from(groupCounts.entries())
+      .map(([name, value]) => ({
+        name,
+        value,
+        color:
+          FUNCTION_GROUP_COLORS[
+            name as keyof typeof FUNCTION_GROUP_COLORS
+          ] || FUNCTION_GROUP_COLORS["Other"],
+      }))
+      .sort((a, b) => b.value - a.value);
   }, [rawData, selectedCompanyId]);
 
   return (
@@ -65,10 +62,13 @@ export function FunctionBreakdownContainer({ rawData, companies }: FunctionBreak
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <div className="space-y-1">
           <CardTitle>Function Mix</CardTitle>
-          <CardDescription>Hiring distribution by function group</CardDescription>
+          <CardDescription>Current hiring distribution</CardDescription>
         </div>
         <div className="w-[180px]">
-          <Select value={selectedCompanyId} onValueChange={setSelectedCompanyId}>
+          <Select
+            value={selectedCompanyId}
+            onValueChange={setSelectedCompanyId}
+          >
             <SelectTrigger>
               <SelectValue placeholder="All Companies" />
             </SelectTrigger>
@@ -83,19 +83,8 @@ export function FunctionBreakdownContainer({ rawData, companies }: FunctionBreak
           </Select>
         </div>
       </CardHeader>
-      <CardContent className="pl-2 flex-1 min-h-0">
-        {/* Pass data to the chart component, but we need to strip the Card wrapper from the Chart component first 
-            OR we can just render the chart content here. 
-            Actually, FunctionBreakdownChart renders its own Card. 
-            I should modify FunctionBreakdownChart to NOT render a Card, or use composition.
-            
-            Strategy: I will modify FunctionBreakdownChart to accept a `className` and optionally `hideHeader` prop, 
-            or better yet, just extract the chart part. 
-            
-            For now, I will render the chart component but I need to handle the double Card wrapping.
-            Let's modify FunctionBreakdownChart to be a pure chart renderer or make it flexible.
-        */}
-        <FunctionBreakdownChart data={chartData} headless />
+      <CardContent className="flex-1 min-h-0">
+        <FunctionBreakdownChart data={donutData} />
       </CardContent>
     </Card>
   );

--- a/web/components/dashboard/charts/PostingTrendChart.tsx
+++ b/web/components/dashboard/charts/PostingTrendChart.tsx
@@ -2,87 +2,135 @@
 
 import {
   Area,
-  AreaChart,
+  ComposedChart,
   CartesianGrid,
+  Line,
   ResponsiveContainer,
   Tooltip,
   XAxis,
   YAxis,
 } from "recharts";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { WeeklyTrend } from "@/lib/dashboard-queries";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type { NetHiringFlowPoint } from "@/lib/dashboard-queries";
 
-export function PostingTrendChart({ data }: { data: WeeklyTrend[] }) {
+export function NetHiringFlowChart({
+  data,
+}: {
+  data: NetHiringFlowPoint[];
+}) {
   return (
-    <Card className="col-span-2">
+    <Card>
       <CardHeader>
-        <CardTitle>Posting Velocity</CardTitle>
-        <CardDescription>New job postings per week over the last 3 months</CardDescription>
+        <CardTitle>Net Hiring Flow</CardTitle>
+        <CardDescription>
+          New vs closed job postings per week
+        </CardDescription>
       </CardHeader>
       <CardContent className="pl-2">
         <div className="h-[300px] w-full">
-          <ResponsiveContainer width="100%" height="100%">
-            <AreaChart data={data} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
-              <defs>
-                <linearGradient id="colorCount" x1="0" y1="0" x2="0" y2="1">
-                  <stop offset="5%" stopColor="#2563eb" stopOpacity={0.3} />
-                  <stop offset="95%" stopColor="#2563eb" stopOpacity={0} />
-                </linearGradient>
-              </defs>
-              <XAxis 
-                dataKey="label" 
-                stroke="#888888" 
-                fontSize={12} 
-                tickLine={false} 
-                axisLine={false}
-              />
-              <YAxis
-                stroke="#888888"
-                fontSize={12}
-                tickLine={false}
-                axisLine={false}
-                tickFormatter={(value) => `${value}`}
-              />
-              <CartesianGrid strokeDasharray="3 3" vertical={false} className="stroke-muted" />
-              <Tooltip
-                content={({ active, payload }) => {
-                  if (active && payload && payload.length) {
-                    return (
-                      <div className="rounded-lg border bg-background p-2 shadow-sm">
-                        <div className="grid grid-cols-2 gap-2">
-                          <div className="flex flex-col">
-                            <span className="text-[0.70rem] uppercase text-muted-foreground">
-                              Week
-                            </span>
-                            <span className="font-bold text-muted-foreground">
-                              {payload[0].payload.label}
-                            </span>
-                          </div>
-                          <div className="flex flex-col">
-                            <span className="text-[0.70rem] uppercase text-muted-foreground">
-                              New Jobs
-                            </span>
-                            <span className="font-bold">
-                              {payload[0].value}
-                            </span>
+          {data.length === 0 ? (
+            <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+              No data available for this time range.
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart
+                data={data}
+                margin={{ top: 10, right: 30, left: 0, bottom: 0 }}
+              >
+                <defs>
+                  <linearGradient id="colorNew" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+                  </linearGradient>
+                  <linearGradient
+                    id="colorClosed"
+                    x1="0"
+                    y1="0"
+                    x2="0"
+                    y2="1"
+                  >
+                    <stop offset="5%" stopColor="#ef4444" stopOpacity={0.2} />
+                    <stop offset="95%" stopColor="#ef4444" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <XAxis
+                  dataKey="label"
+                  stroke="#888888"
+                  fontSize={12}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <YAxis
+                  stroke="#888888"
+                  fontSize={12}
+                  tickLine={false}
+                  axisLine={false}
+                />
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  vertical={false}
+                  className="stroke-muted"
+                />
+                <Tooltip
+                  content={({ active, payload }) => {
+                    if (active && payload && payload.length) {
+                      const d = payload[0].payload as NetHiringFlowPoint;
+                      return (
+                        <div className="rounded-lg border bg-background p-3 shadow-sm text-sm">
+                          <p className="font-medium mb-1">Week of {d.label}</p>
+                          <div className="space-y-0.5">
+                            <p className="text-green-600">+{d.newJobs} new</p>
+                            <p className="text-red-500">
+                              -{d.closedJobs} closed
+                            </p>
+                            <p className="font-semibold border-t pt-1 mt-1">
+                              Net {d.net >= 0 ? "+" : ""}
+                              {d.net}
+                            </p>
                           </div>
                         </div>
-                      </div>
-                    );
-                  }
-                  return null;
-                }}
-              />
-              <Area
-                type="monotone"
-                dataKey="count"
-                stroke="#2563eb"
-                strokeWidth={2}
-                fillOpacity={1}
-                fill="url(#colorCount)"
-              />
-            </AreaChart>
-          </ResponsiveContainer>
+                      );
+                    }
+                    return null;
+                  }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="newJobs"
+                  stroke="#22c55e"
+                  strokeWidth={2}
+                  fillOpacity={1}
+                  fill="url(#colorNew)"
+                  name="New"
+                />
+                <Area
+                  type="monotone"
+                  dataKey="closedJobs"
+                  stroke="#ef4444"
+                  strokeWidth={1.5}
+                  fillOpacity={1}
+                  fill="url(#colorClosed)"
+                  name="Closed"
+                />
+                <Line
+                  type="monotone"
+                  dataKey="net"
+                  stroke="#2563eb"
+                  strokeWidth={2}
+                  strokeDasharray="4 2"
+                  dot={false}
+                  name="Net"
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          )}
         </div>
       </CardContent>
     </Card>

--- a/web/lib/dashboard-queries.ts
+++ b/web/lib/dashboard-queries.ts
@@ -1,17 +1,19 @@
 import { createClient } from "@/lib/supabase/server";
-import { getCategoryGroup, RoleCategory } from "@/lib/analysis/function-categories";
-import { startOfWeek, format, subDays, parseISO, startOfMonth } from "date-fns";
+import {
+  getCategoryGroup,
+  RoleCategory,
+  CATEGORY_GROUPS,
+} from "@/lib/analysis/function-categories";
+import { startOfWeek, format, subDays, parseISO, addHours } from "date-fns";
+
+// ============================================================================
+// Types
+// ============================================================================
 
 export interface WeeklyTrend {
-  date: string; // ISO date string for start of week
-  label: string; // Formatted label (e.g., "Jan 24")
+  date: string;
+  label: string;
   count: number;
-}
-
-export interface FunctionTrend {
-  period: string; // Label for the period (e.g., "Jan 2024" or "Wk 1")
-  date: string; // ISO date for sorting
-  [key: string]: string | number; // Dynamic keys for category groups
 }
 
 export interface RawFunctionData {
@@ -20,37 +22,144 @@ export interface RawFunctionData {
   first_seen_date: string;
 }
 
+export interface FunctionTrend {
+  period: string;
+  date: string;
+  [key: string]: string | number;
+}
+
+export interface NetHiringFlowPoint {
+  date: string;
+  label: string;
+  newJobs: number;
+  closedJobs: number;
+  net: number;
+}
+
+export interface CompetitiveMatrixRow {
+  companyId: string;
+  companyName: string;
+  companySlug: string;
+  groups: Record<string, { current: number; change: number }>;
+  total: number;
+  weekChange: number;
+}
+
+export interface HotRole {
+  id: string;
+  title: string;
+  companyName: string;
+  companySlug: string;
+  firstSeenDate: string;
+  functionCategory: string | null;
+}
+
+export interface LatestDigest {
+  id: string;
+  weekStart: string;
+  weekEnd: string;
+  generatedAt: string;
+  globalSummary: {
+    headline?: string;
+    key_insight?: string;
+    body?: string;
+  } | null;
+  industryTrends: Array<{
+    trend: string;
+    explanation: string;
+    companies: string[];
+    direction: string;
+  }>;
+  strategySignals: Array<{
+    company: string;
+    alignment: string;
+    signal: string;
+    detail: string;
+    interpretation?: string;
+  }>;
+}
+
+export interface DailyJobCount {
+  date: string;
+  count: number;
+}
+
+export interface DonutDataPoint {
+  name: string;
+  value: number;
+  color: string;
+  [key: string]: string | number;
+}
+
+// ============================================================================
+// Backfill Filtering
+// ============================================================================
+
 /**
- * Get job posting volume trends grouped by week for the last X days
+ * Get per-company backfill cutoff dates.
+ * Jobs posted within 48h of a company's created_at are considered backfill.
  */
-export async function getPostingTrends(days: number = 90): Promise<WeeklyTrend[]> {
+export async function getCompanyBackfillCutoffs(): Promise<Map<string, Date>> {
+  const supabase = await createClient();
+  const { data } = await supabase
+    .from("companies")
+    .select("id, created_at")
+    .eq("is_active", true);
+
+  const cutoffs = new Map<string, Date>();
+  for (const company of data ?? []) {
+    if (company.created_at) {
+      cutoffs.set(company.id, addHours(new Date(company.created_at), 48));
+    }
+  }
+  return cutoffs;
+}
+
+function isBackfill(
+  companyId: string,
+  firstSeenDate: string | null,
+  cutoffs: Map<string, Date>
+): boolean {
+  if (!firstSeenDate) return false;
+  const cutoff = cutoffs.get(companyId);
+  if (!cutoff) return false;
+  return new Date(firstSeenDate) < cutoff;
+}
+
+// ============================================================================
+// Query Functions
+// ============================================================================
+
+/**
+ * Get job posting volume trends grouped by week, excluding backfill.
+ */
+export async function getPostingTrends(
+  days: number,
+  cutoffs: Map<string, Date>
+): Promise<WeeklyTrend[]> {
   const supabase = await createClient();
   const startDate = subDays(new Date(), days).toISOString();
 
   const { data: jobs, error } = await supabase
     .from("job_postings")
-    .select("first_seen_date")
+    .select("company_id, first_seen_date")
     .gte("first_seen_date", startDate)
     .order("first_seen_date", { ascending: true });
 
-  if (error) {
-    console.error("Error fetching posting trends:", error);
-    return [];
-  }
+  if (error || !jobs) return [];
 
-  // Group by week
   const weeklyMap = new Map<string, number>();
-  
-  jobs.forEach((job) => {
-    if (!job.first_seen_date) return;
+
+  for (const job of jobs) {
+    if (!job.first_seen_date) continue;
+    if (isBackfill(job.company_id, job.first_seen_date, cutoffs)) continue;
+
     const date = parseISO(job.first_seen_date);
     const weekStart = startOfWeek(date, { weekStartsOn: 1 });
     const key = weekStart.toISOString();
-    
     weeklyMap.set(key, (weeklyMap.get(key) || 0) + 1);
-  });
+  }
 
-  // Convert to array and sort
   return Array.from(weeklyMap.entries())
     .map(([date, count]) => ({
       date,
@@ -61,9 +170,12 @@ export async function getPostingTrends(days: number = 90): Promise<WeeklyTrend[]
 }
 
 /**
- * Get raw function category data for client-side filtering
+ * Get raw function category data for client-side filtering, excluding backfill.
  */
-export async function getRawFunctionData(days: number = 90): Promise<RawFunctionData[]> {
+export async function getRawFunctionData(
+  days: number,
+  cutoffs: Map<string, Date>
+): Promise<RawFunctionData[]> {
   const supabase = await createClient();
   const startDate = subDays(new Date(), days).toISOString();
 
@@ -74,59 +186,333 @@ export async function getRawFunctionData(days: number = 90): Promise<RawFunction
     .not("function_category", "is", null)
     .not("first_seen_date", "is", null);
 
-  if (error) {
-    console.error("Error fetching raw function data:", error);
-    return [];
-  }
+  if (error || !jobs) return [];
 
-  return jobs as RawFunctionData[];
+  return (jobs as RawFunctionData[]).filter(
+    (job) => !isBackfill(job.company_id, job.first_seen_date, cutoffs)
+  );
 }
 
 /**
- * Get function category trends grouped by month for the last X days
+ * Get net hiring flow data: new vs closed jobs per week.
  */
-export async function getFunctionTrends(days: number = 90): Promise<FunctionTrend[]> {
+export async function getNetHiringFlow(
+  days: number,
+  cutoffs: Map<string, Date>
+): Promise<NetHiringFlowPoint[]> {
   const supabase = await createClient();
   const startDate = subDays(new Date(), days).toISOString();
 
-  const { data: jobs, error } = await supabase
-    .from("job_postings")
-    .select("first_seen_date, function_category")
-    .gte("first_seen_date", startDate)
-    .not("function_category", "is", null);
+  const [{ data: newJobs }, { data: closedJobs }] = await Promise.all([
+    supabase
+      .from("job_postings")
+      .select("company_id, first_seen_date")
+      .gte("first_seen_date", startDate)
+      .not("first_seen_date", "is", null),
+    supabase
+      .from("job_postings")
+      .select("company_id, first_seen_date, closed_date")
+      .gte("closed_date", startDate)
+      .not("closed_date", "is", null),
+  ]);
 
-  if (error) {
-    console.error("Error fetching function trends:", error);
-    return [];
+  const weeklyNew = new Map<string, number>();
+  const weeklyClosed = new Map<string, number>();
+
+  for (const job of newJobs ?? []) {
+    if (!job.first_seen_date) continue;
+    if (isBackfill(job.company_id, job.first_seen_date, cutoffs)) continue;
+
+    const weekStart = startOfWeek(parseISO(job.first_seen_date), {
+      weekStartsOn: 1,
+    });
+    const key = weekStart.toISOString();
+    weeklyNew.set(key, (weeklyNew.get(key) || 0) + 1);
   }
 
-  // Group by month and category group
-  const periodMap = new Map<string, Record<string, number>>();
-  
-  jobs.forEach((job) => {
-    if (!job.first_seen_date || !job.function_category) return;
-    
-    const date = parseISO(job.first_seen_date);
-    // Group by month for cleaner high-level trends
-    const periodStart = startOfMonth(date); 
-    const periodKey = periodStart.toISOString();
-    
-    const group = getCategoryGroup(job.function_category as RoleCategory);
-    
-    if (!periodMap.has(periodKey)) {
-      periodMap.set(periodKey, {});
-    }
-    
-    const periodCounts = periodMap.get(periodKey)!;
-    periodCounts[group] = (periodCounts[group] || 0) + 1;
-  });
+  for (const job of closedJobs ?? []) {
+    if (!job.closed_date) continue;
+    if (isBackfill(job.company_id, job.first_seen_date, cutoffs)) continue;
 
-  // Convert to array suitable for Recharts
-  return Array.from(periodMap.entries())
-    .map(([date, counts]) => ({
-      date,
-      period: format(parseISO(date), "MMM yyyy"),
-      ...counts,
-    }))
+    const weekStart = startOfWeek(parseISO(job.closed_date), {
+      weekStartsOn: 1,
+    });
+    const key = weekStart.toISOString();
+    weeklyClosed.set(key, (weeklyClosed.get(key) || 0) + 1);
+  }
+
+  const allWeeks = new Set([...weeklyNew.keys(), ...weeklyClosed.keys()]);
+
+  return Array.from(allWeeks)
+    .map((date) => {
+      const n = weeklyNew.get(date) || 0;
+      const c = weeklyClosed.get(date) || 0;
+      return {
+        date,
+        label: format(parseISO(date), "MMM d"),
+        newJobs: n,
+        closedJobs: c,
+        net: n - c,
+      };
+    })
     .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Get competitive matrix data: active jobs per company per function group.
+ * Includes ALL active companies, even those with uncategorized jobs.
+ */
+export async function getCompetitiveMatrixData(
+  cutoffs: Map<string, Date>
+): Promise<CompetitiveMatrixRow[]> {
+  const supabase = await createClient();
+  const oneWeekAgo = subDays(new Date(), 7).toISOString();
+
+  // Fetch all active companies and all active jobs (including uncategorized)
+  const [{ data: allCompanies }, { data: jobs }] = await Promise.all([
+    supabase
+      .from("companies")
+      .select("id, name, slug")
+      .eq("is_active", true),
+    supabase
+      .from("job_postings")
+      .select(
+        "company_id, function_category, first_seen_date, is_active, companies!inner(id, name, slug, is_active)"
+      )
+      .eq("is_active", true)
+      .eq("companies.is_active", true),
+  ]);
+
+  // Seed the map with all active companies so none are missing
+  const companyMap = new Map<
+    string,
+    {
+      name: string;
+      slug: string;
+      uncategorized: number;
+      groups: Record<string, { current: number; newThisWeek: number }>;
+    }
+  >();
+
+  for (const c of allCompanies ?? []) {
+    companyMap.set(c.id, {
+      name: c.name,
+      slug: c.slug,
+      uncategorized: 0,
+      groups: {},
+    });
+  }
+
+  // Group jobs by company and function group
+  for (const job of jobs ?? []) {
+    const company = Array.isArray(job.companies)
+      ? job.companies[0]
+      : job.companies;
+    if (!company) continue;
+
+    // Ensure company entry exists (in case allCompanies missed it)
+    if (!companyMap.has(job.company_id)) {
+      companyMap.set(job.company_id, {
+        name: (company as { name: string }).name,
+        slug: (company as { slug: string }).slug,
+        uncategorized: 0,
+        groups: {},
+      });
+    }
+
+    const entry = companyMap.get(job.company_id)!;
+
+    if (!job.function_category) {
+      // Count uncategorized jobs toward total but not in any group column
+      entry.uncategorized++;
+      continue;
+    }
+
+    const group = getCategoryGroup(job.function_category as RoleCategory);
+
+    if (!entry.groups[group]) {
+      entry.groups[group] = { current: 0, newThisWeek: 0 };
+    }
+    entry.groups[group].current++;
+
+    if (
+      job.first_seen_date &&
+      job.first_seen_date >= oneWeekAgo &&
+      !isBackfill(job.company_id, job.first_seen_date, cutoffs)
+    ) {
+      entry.groups[group].newThisWeek++;
+    }
+  }
+
+  // Get closed this week for WoW change
+  const { data: closedThisWeek } = await supabase
+    .from("job_postings")
+    .select("company_id, function_category")
+    .gte("closed_date", oneWeekAgo);
+
+  const closedByCompanyGroup = new Map<string, Record<string, number>>();
+  let closedUncategorized = new Map<string, number>();
+  for (const job of closedThisWeek ?? []) {
+    if (!job.function_category) {
+      closedUncategorized.set(
+        job.company_id,
+        (closedUncategorized.get(job.company_id) || 0) + 1
+      );
+      continue;
+    }
+    const group = getCategoryGroup(job.function_category as RoleCategory);
+    if (!closedByCompanyGroup.has(job.company_id)) {
+      closedByCompanyGroup.set(job.company_id, {});
+    }
+    const groups = closedByCompanyGroup.get(job.company_id)!;
+    groups[group] = (groups[group] || 0) + 1;
+  }
+
+  const functionGroups = Object.keys(CATEGORY_GROUPS).filter(
+    (g) => g !== "Other"
+  );
+
+  return Array.from(companyMap.entries())
+    .map(([companyId, data]) => {
+      const groups: Record<string, { current: number; change: number }> = {};
+      let total = data.uncategorized; // Include uncategorized in total
+      let weekChange = -(closedUncategorized.get(companyId) || 0);
+
+      for (const group of functionGroups) {
+        const current = data.groups[group]?.current || 0;
+        const newThisWeek = data.groups[group]?.newThisWeek || 0;
+        const closedThisWeekCount =
+          closedByCompanyGroup.get(companyId)?.[group] || 0;
+        const change = newThisWeek - closedThisWeekCount;
+
+        groups[group] = { current, change };
+        total += current;
+        weekChange += change;
+      }
+
+      // Include "Other" if present
+      if (data.groups["Other"]) {
+        const otherNew = data.groups["Other"].newThisWeek || 0;
+        const otherClosed =
+          closedByCompanyGroup.get(companyId)?.["Other"] || 0;
+        groups["Other"] = {
+          current: data.groups["Other"].current,
+          change: otherNew - otherClosed,
+        };
+        total += data.groups["Other"].current;
+        weekChange += groups["Other"].change;
+      }
+
+      return {
+        companyId,
+        companyName: data.name,
+        companySlug: data.slug,
+        groups,
+        total,
+        weekChange,
+      };
+    })
+    .filter((row) => row.total > 0) // Only show companies with active jobs
+    .sort((a, b) => b.total - a.total);
+}
+
+/**
+ * Get the latest weekly digest with global_summary, industry_trends, strategy_signals.
+ */
+export async function getLatestDigest(): Promise<LatestDigest | null> {
+  const supabase = await createClient();
+
+  const { data: digest } = await supabase
+    .from("weekly_digests")
+    .select(
+      "id, global_summary, industry_trends, strategy_signals, week_start, week_end, generated_at"
+    )
+    .order("week_start", { ascending: false })
+    .limit(1)
+    .single();
+
+  if (!digest) return null;
+
+  return {
+    id: digest.id,
+    weekStart: digest.week_start,
+    weekEnd: digest.week_end,
+    generatedAt: digest.generated_at,
+    globalSummary: digest.global_summary as LatestDigest["globalSummary"],
+    industryTrends:
+      (digest.industry_trends as LatestDigest["industryTrends"]) || [],
+    strategySignals:
+      (digest.strategy_signals as LatestDigest["strategySignals"]) || [],
+  };
+}
+
+/**
+ * Get most recent active job postings for the hot roles feed, excluding backfill.
+ */
+export async function getHotRoles(
+  cutoffs: Map<string, Date>,
+  limit: number = 15
+): Promise<HotRole[]> {
+  const supabase = await createClient();
+
+  const { data: jobs } = await supabase
+    .from("job_postings")
+    .select(
+      "id, title, company_id, first_seen_date, function_category, companies!inner(name, slug, is_active)"
+    )
+    .eq("is_active", true)
+    .eq("companies.is_active", true)
+    .order("first_seen_date", { ascending: false })
+    .limit(50); // Fetch extra to account for backfill filtering
+
+  if (!jobs) return [];
+
+  return jobs
+    .filter(
+      (job) => !isBackfill(job.company_id, job.first_seen_date, cutoffs)
+    )
+    .slice(0, limit)
+    .map((job) => {
+      const company = Array.isArray(job.companies)
+        ? job.companies[0]
+        : job.companies;
+      return {
+        id: job.id,
+        title: job.title,
+        companyName: (company as { name: string })?.name ?? "Unknown",
+        companySlug: (company as { slug: string })?.slug ?? "",
+        firstSeenDate: job.first_seen_date,
+        functionCategory: job.function_category,
+      };
+    });
+}
+
+/**
+ * Get net new/closed jobs this week, excluding backfill from new count.
+ */
+export async function getNetThisWeek(
+  cutoffs: Map<string, Date>
+): Promise<{ newCount: number; closedCount: number }> {
+  const supabase = await createClient();
+  const weekStart = startOfWeek(new Date(), { weekStartsOn: 1 }).toISOString();
+
+  const [{ data: newJobs }, { count: closedCount }] = await Promise.all([
+    supabase
+      .from("job_postings")
+      .select("company_id, first_seen_date")
+      .gte("first_seen_date", weekStart),
+    supabase
+      .from("job_postings")
+      .select("*", { count: "exact", head: true })
+      .gte("closed_date", weekStart),
+  ]);
+
+  const filteredNew = (newJobs ?? []).filter(
+    (job) => !isBackfill(job.company_id, job.first_seen_date, cutoffs)
+  );
+
+  return {
+    newCount: filteredNew.length,
+    closedCount: closedCount ?? 0,
+  };
 }

--- a/web/lib/dashboard-transformers.ts
+++ b/web/lib/dashboard-transformers.ts
@@ -1,7 +1,7 @@
-import { CompanyOverviewData } from "@/components/dashboard/CompaniesOverview";
-import { StrategicHighlight } from "@/components/dashboard/StrategicHighlights";
+// Dashboard data transformers
+// Note: Most transformation logic has moved into dashboard-queries.ts
+// This file is retained for potential shared transform utilities.
 
-// Types for Supabase data
 export interface CompanyRow {
   id: string;
   name: string;
@@ -18,147 +18,13 @@ export interface JobPostingRow {
   first_seen_date: string | null;
 }
 
-export interface CompanyInsightRow {
-  id: string;
-  company_id: string;
-  generated_at: string;
-  headline: string | null;
-  key_signal: string | null;
-  significance_score: number | null;
-  confidence: "high" | "medium" | "low";
-  executive_summary: string;
-  companies?: { id: string; name: string; slug: string }[] | { id: string; name: string; slug: string };
-}
-
 export interface DigestCompanyRow {
   id: string;
   company_id: string;
   headline: string;
   body: string;
   new_job_count: number;
-  companies?: { id: string; name: string; slug: string }[] | { id: string; name: string; slug: string };
-}
-
-/**
- * Transforms raw company data into the overview format
- */
-export function transformCompanyData(companiesRaw: CompanyRow[] | null): CompanyOverviewData[] {
-  const companies = (companiesRaw ?? []).map((company) => {
-    // Count active jobs
-    const jobs = Array.isArray(company.job_postings) ? company.job_postings : [];
-    const activeJobCount = jobs.filter((j) => j.is_active).length;
-    
-    // Get most recent job title as highlight
-    const sortedJobs = jobs
-      .filter((j) => j.is_active)
-      .sort((a, b) => 
-        new Date(b.first_seen_date || 0).getTime() - new Date(a.first_seen_date || 0).getTime()
-      );
-    const recentHighlight = sortedJobs.length > 0
-      ? `Latest: ${sortedJobs[0].title}`
-      : null;
-
-    return {
-      id: company.id,
-      name: company.name,
-      slug: company.slug,
-      country: company.country,
-      activeJobCount,
-      recentHighlight,
-      atsType: company.ats_type,
-    };
-  });
-
-  // Sort companies by job count descending
-  return companies.sort((a, b) => b.activeJobCount - a.activeJobCount);
-}
-
-/**
- * Transforms raw insight data into strategic highlights
- * Deduplicates by company_id, keeping the most significant/recent one
- */
-export function transformStrategicHighlights(insightsRaw: CompanyInsightRow[] | null): StrategicHighlight[] {
-  const insightsMap = new Map<string, CompanyInsightRow>();
-  
-  for (const item of (insightsRaw ?? [])) {
-    const existing = insightsMap.get(item.company_id);
-    if (!existing) {
-      insightsMap.set(item.company_id, item);
-    } else {
-      // Keep the one with higher significance_score, or more recent if scores are equal
-      const existingScore = existing.significance_score ?? 0;
-      const itemScore = item.significance_score ?? 0;
-      if (itemScore > existingScore || 
-          (itemScore === existingScore && new Date(item.generated_at) > new Date(existing.generated_at))) {
-        insightsMap.set(item.company_id, item);
-      }
-    }
-  }
-
-  // Convert to array and sort by significance_score, limit to top 10
-  return Array.from(insightsMap.values())
-    .sort((a, b) => {
-      const scoreA = a.significance_score ?? 0;
-      const scoreB = b.significance_score ?? 0;
-      if (scoreB !== scoreA) return scoreB - scoreA;
-      return new Date(b.generated_at).getTime() - new Date(a.generated_at).getTime();
-    })
-    .slice(0, 10)
-    .map((item) => {
-      const company = Array.isArray(item.companies) 
-        ? item.companies[0] 
-        : item.companies;
-      
-      return {
-        id: item.id,
-        companyId: item.company_id,
-        companyName: company?.name ?? "Unknown",
-        companySlug: company?.slug ?? "",
-        generatedAt: item.generated_at,
-        headline: item.headline,
-        keySignal: item.key_signal,
-        significanceScore: item.significance_score,
-        confidence: item.confidence,
-        executiveSummary: item.executive_summary,
-      };
-    });
-}
-
-/**
- * Transforms weekly digest company summaries into strategic highlights format
- * Matches the format used in the weekly digest "Company Highlights" section
- */
-export function transformDigestHighlights(
-  digestData: { digest: { generated_at: string; week_start: string; week_end: string }; companies: DigestCompanyRow[] } | null
-): StrategicHighlight[] {
-  if (!digestData || !digestData.companies || digestData.companies.length === 0) {
-    return [];
-  }
-
-  const { digest, companies } = digestData;
-
-  return companies.map((item) => {
-    const company = Array.isArray(item.companies) 
-      ? item.companies[0] 
-      : item.companies;
-
-    // Extract first sentence from body for keySignal fallback
-    const firstSentence = item.body.split(".")[0].trim();
-    const keySignal = firstSentence.length > 0 && firstSentence.length < 150 
-      ? firstSentence + (item.body.includes(".") ? "." : "")
-      : item.body.slice(0, 150) + (item.body.length > 150 ? "..." : "");
-
-    return {
-      id: item.id,
-      companyId: item.company_id,
-      companyName: company?.name ?? "Unknown",
-      companySlug: company?.slug ?? "",
-      generatedAt: digest.generated_at,
-      headline: item.headline,
-      keySignal: keySignal,
-      significanceScore: null, // Digest summaries don't have significance scores
-      confidence: "medium" as const, // Default confidence for digest summaries
-      executiveSummary: item.body,
-    };
-  });
+  companies?:
+    | { id: string; name: string; slug: string }[]
+    | { id: string; name: string; slug: string };
 }


### PR DESCRIPTION
## Summary

- **Backfill filtering**: Jobs within 48h of company creation excluded from all charts/metrics, eliminating misleading velocity spikes when new companies are added
- **Time range selector**: URL-based `?range=2w|1m|3m|6m` (default 3m) controls all dashboard data
- **Net Hiring Flow chart**: Replaces Posting Velocity — shows green (new) and red (closed) areas with dashed net line, per-week tooltips
- **Competitive Matrix heatmap**: Replaces Companies Overview — companies × 7 function groups with WoW change coloring, all active companies included
- **Function Mix donut**: Converts stacked bar chart to donut/pie with company filter retained
- **Weekly Intel Banner**: Surfaces `global_summary.headline` + `key_insight` from latest digest with link to full digest
- **Hot Roles feed**: 15 most recent postings with compact relative timestamps (6h, 2d, 1w)
- **Strategy Signals panel**: Industry trends + strategic alignments from digest data
- **Redesigned stat cards**: Active Jobs (sparkline), Net This Week (+/-), Avg Weekly Velocity, Companies Tracked

## New layout

```
ROW 0: Time Range Selector (right-aligned)
ROW 1: Stat Cards (4 across, sparklines)
ROW 2: Weekly Intel Banner (full width)
ROW 3: Net Hiring Flow chart (full width)
ROW 4: Competitive Matrix (2/3) + Function Mix donut (1/3)
ROW 5: Hot Roles Feed (1/2) + Strategy Signals (1/2)
```

## Test plan

- [ ] Verify time range selector changes all chart/query data
- [ ] Verify backfill spike is gone from charts (especially after adding a new company)
- [ ] Verify Weekly Intel Banner shows digest content or graceful empty state
- [ ] Verify Competitive Matrix includes all companies (including Tangerine)
- [ ] Verify Hot Roles feed columns don't overlap
- [ ] Verify all links work (company pages, digest pages)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)