### PR TITLE
Add releases page and changelog system

### DIFF
--- a/.github/ISSUES/105-release-area-and-auto-changelog.md
+++ b/.github/ISSUES/105-release-area-and-auto-changelog.md
@@ -1,0 +1,51 @@
+# 105 – Release Area in App + Auto Changelog + Agent Rules
+
+## TL;DR
+
+Add a visible “Release” or “Changelog” area in the app that shows what changed in each release, plus tooling/process to automatically maintain that log. Document in agent rules (e.g. CLAUDE.md / .cursor/rules) so agents always update the release log when shipping changes.
+
+## Current vs Expected
+
+| Current | Expected |
+|--------|----------|
+| No dedicated release/changelog surface in the app. | Clear release area in the app (e.g. /releases or section in settings/about) listing versions and changes. |
+| Changelog/release notes are ad hoc or absent. | Automated or semi-automated log of changes (e.g. from conventional commits, PR titles, or a single source-of-truth file). |
+| Agent rules don’t mention releases. | Agent rules explicitly require updating the release log when making user-facing or notable changes. |
+
+## Key Requirements
+
+### 1. Release area in the application
+- Dedicated UI: e.g. `/releases`, `/changelog`, or a “Releases” section in dashboard/settings/about.
+- Display version (or date) and a list of changes per release.
+- Notion-style, consistent with rest of app; readable and scannable.
+
+### 2. Underlying updates for automatic change log
+- **Option A:** Single source of truth (e.g. `CHANGELOG.md` or `web/content/releases.json`) that a script or CI can use to drive the in-app release area.
+- **Option B:** Derive from git (e.g. conventional commits, tags, or release branches) and generate the log at build time or via a script.
+- **Option C:** Hybrid: maintain a minimal hand-written log (or PR-based notes) and have a script aggregate it into the format consumed by the app.
+- Decide where the canonical log lives (repo root vs `web/`) and how the app loads it (static file, API, or build-time injection).
+
+### 3. Agent rules
+- Add a short “Release / Changelog” subsection to `CLAUDE.md` (and optionally `.cursor/rules/` if used).
+- Rules should state: when making user-facing or otherwise notable changes, update the release log (and where to update it: file path + format).
+- Optionally: link to a one-line “how to add an entry” (e.g. “Add a bullet under the current version in `CHANGELOG.md`”).
+
+## Relevant Files
+
+- `CLAUDE.md` – Add release/changelog instructions for agents.
+- `.cursor/rules/` – If present, add or extend a rule for release-log updates.
+- New or existing: `CHANGELOG.md` or `web/content/releases.json` (or equivalent) – canonical change log.
+- New: `web/app/(dashboard)/releases/page.tsx` (or equivalent) – Release area UI.
+- Possibly: `web/scripts/` or root script – script to generate or validate the log from git/source.
+- `web/lib/` or `web/app/api/` – If changelog is loaded via API or build step.
+
+## Risks / Notes
+
+- If the log is generated from git, ensure merge squashing or commit style doesn’t drop important entries; may need to rely on PR titles or a hand-maintained file instead.
+- Keep format simple (e.g. Markdown or JSON) so both humans and the app can read it without heavy tooling.
+
+## Labels
+
+- **Type:** feature
+- **Priority:** normal
+- **Effort:** medium

--- a/.github/ISSUES/106-newsletter-tone-stratechery-style.md
+++ b/.github/ISSUES/106-newsletter-tone-stratechery-style.md
@@ -1,0 +1,52 @@
+# 106 – Newsletter Tone: Stratechery-Style Professional Analysis
+
+## TL;DR
+
+Adjust the weekly digest newsletter tone to be less cheeky and more objective while staying readable—a blend of professional analysis and insight in the vein of Ben Thompson's Stratechery. The audience is primarily professionals interested in the fintech industry.
+
+## Current vs Expected
+
+| Current | Expected |
+|--------|----------|
+| "Witty, punchy, conversational"; "Use emojis effectively"; headlines like "hits the gas", "raids the Street". | Objective, analytical tone with clear strategic insight; fewer emojis and less slang. |
+| TLDR-style that leans playful and attention-grabbing. | Stratechery-style: evidence-based, interpretive, and professional without being dry or corporate. |
+| Prompt encourages "punchy" and "smart" with cheeky pattern cues (e.g. "battening down the hatches"). | Prompt steers toward concise analysis, strategic interpretation, and what-it-means framing suitable for industry professionals. |
+
+## Key Requirements
+
+### 1. Tone calibration (not a full rewrite)
+- **Less:** Witty one-liners, heavy emoji use, colloquial phrases ("hits the gas", "raids the Street"), "punchy" as primary goal.
+- **More:** Clear strategic interpretation, cause-and-effect reasoning, objective framing ("X suggests Y"; "the hiring mix indicates…").
+- **Keep:** Concise, scannable format; insight over generic summary; no corporate jargon.
+- **Reference:** Stratechery—analytical, structured, and insightful without being stuffy or overly formal.
+
+### 2. Prompt updates in digest generation
+- **`web/lib/analysis/digest.ts`:**
+  - **TLDR_PROMPT:** Revise the system/role line and style guidelines (e.g. "witty … punchy … Use emojis effectively") to "professional analyst … objective and insightful … emojis optional and minimal."
+  - Update headline/body examples from cheeky to analytical (e.g. "Wealthsimple accelerates hiring in wealth and crypto" vs "Wealthsimple hits the gas").
+  - Adjust "Pattern Detection" to emphasize strategic interpretation rather than catchy phrases.
+  - Keep JSON output shape and self-check; tune the self-check for "would a fintech professional find this analytically useful?"
+  - **GLOBAL_SUMMARY_PROMPT:** Align tone—"elite fintech analyst" is fine; add explicit guidance for objective, cross-company synthesis and optional/minimal emoji.
+
+### 3. Email template (if tone is embedded there)
+- **`web/lib/email/templates/weekly-digest.tsx`:** If any copy or labels are cheeky or informal, align with the new tone (e.g. section titles, call-to-action text). Otherwise no change.
+
+### 4. Optional: one-shot examples in prompt
+- Consider adding 1–2 example headline/body pairs in the desired Stratechery-like style so the model has a clear target (e.g. analytical headline + 2–3 sentence interpretation).
+
+## Relevant Files
+
+- `web/lib/analysis/digest.ts` – `TLDR_PROMPT`, `GLOBAL_SUMMARY_PROMPT`, and any other tone-bearing strings.
+- `web/lib/email/templates/weekly-digest.tsx` – Digest email layout/copy; adjust only if it reinforces the old tone.
+
+## Risks / Notes
+
+- Shifting tone may change output length or structure slightly; spot-check a few generated digests after changes.
+- If future features (e.g. company-filtered digest) reuse the same prompts, the new tone will apply consistently.
+- Stratechery is a useful reference for "professional but not boring"; avoid making the copy stiff or generic.
+
+## Labels
+
+- **Type:** improvement
+- **Priority:** normal
+- **Effort:** small–medium

--- a/.github/ISSUES/107-feature-request-submission.md
+++ b/.github/ISSUES/107-feature-request-submission.md
@@ -1,0 +1,105 @@
+# 107 – Feature Request Submission System
+
+## TL;DR
+
+Add a first-class feature request submission capability accessible from the main navigation menu. Users can submit, view, and track feature requests. UX design (agent) should review optimal visual placement and interaction patterns in the navigation bar.
+
+## Current vs Expected
+
+| Current | Expected |
+|---------|----------|
+| No way for users to submit feature requests in-app. | Prominent "Feature Requests" or "Feedback" entry point in main navigation menu. |
+| Feature requests likely handled via email or external channels. | In-app submission form with title, description, category, and optional voting/status tracking. |
+| Navigation menu has: Dashboard, Jobs, Companies, Weekly Digests, Admin. | Navigation includes feature requests as a first-class menu item (placement TBD by UX review). |
+
+## Key Requirements
+
+### 1. Database schema
+- **New table:** `feature_requests`
+  - `id` (UUID, PK)
+  - `user_id` (UUID, FK → profiles)
+  - `title` (TEXT)
+  - `description` (TEXT)
+  - `category` (TEXT) - e.g., "dashboard", "jobs", "companies", "digests", "other"
+  - `status` (TEXT) - e.g., "submitted", "under_review", "planned", "in_progress", "completed", "rejected"
+  - `priority` (TEXT, optional) - "low", "normal", "high"
+  - `votes` (INTEGER, default 0) - if voting is implemented
+  - `created_at` (TIMESTAMPTZ)
+  - `updated_at` (TIMESTAMPTZ)
+  - `admin_notes` (TEXT, optional) - internal notes
+- **RLS policies:** Users can create/view all requests; admins can update status/notes
+- **Indexes:** `user_id`, `status`, `created_at`, `category`
+
+### 2. Navigation integration (UX review required)
+- **Placement:** Add to `DashboardNav.tsx` `navLinks` array
+  - Options: standalone link, dropdown menu item, or icon button
+  - Consider: position (before/after Weekly Digests?), label ("Feature Requests" vs "Feedback" vs icon-only)
+  - Mobile: Include in hamburger menu
+- **Visual treatment:** UX agent should review:
+  - Icon choice (e.g., MessageSquare, Lightbulb, Sparkles)
+  - Color/accent treatment (primary, secondary, muted)
+  - Badge/indicator if admin responses exist
+  - Whether it should be more prominent than other nav items
+
+### 3. Feature request pages
+- **`web/app/(dashboard)/feature-requests/page.tsx`** - List view
+  - Show all requests (filterable by status, category)
+  - User's submitted requests highlighted
+  - Sort by: newest, votes (if implemented), status
+  - "Submit Request" button/CTA
+- **`web/app/(dashboard)/feature-requests/new/page.tsx`** - Submission form
+  - Title input
+  - Description textarea (rich text optional)
+  - Category dropdown
+  - Submit button
+  - Success confirmation
+- **`web/app/(dashboard)/feature-requests/[id]/page.tsx`** - Detail view
+  - Full request details
+  - Status badge
+  - Admin response/notes (if admin)
+  - Edit/delete (if user's own request and status allows)
+
+### 4. API routes
+- **`web/app/api/feature-requests/route.ts`**
+  - `GET` - List requests (with filters, pagination)
+  - `POST` - Create new request
+- **`web/app/api/feature-requests/[id]/route.ts`**
+  - `GET` - Get single request
+  - `PATCH` - Update request (admin only for status/notes; user for own title/description)
+  - `DELETE` - Delete request (user's own, or admin)
+
+### 5. Admin interface (optional, phase 2)
+- Admin page or section to manage requests
+- Update status, add notes, mark as completed
+- Could extend existing `/admin` page
+
+## Relevant Files
+
+- **Database:** New migration `web/supabase/migrations/[timestamp]_feature_requests.sql`
+- **Navigation:** `web/components/layout/DashboardNav.tsx` - Add nav link (placement TBD by UX review)
+- **Pages:** 
+  - `web/app/(dashboard)/feature-requests/page.tsx` - List view
+  - `web/app/(dashboard)/feature-requests/new/page.tsx` - Submission form
+  - `web/app/(dashboard)/feature-requests/[id]/page.tsx` - Detail view
+- **API:** 
+  - `web/app/api/feature-requests/route.ts`
+  - `web/app/api/feature-requests/[id]/route.ts`
+- **Components:** 
+  - `web/components/feature-requests/FeatureRequestList.tsx`
+  - `web/components/feature-requests/FeatureRequestForm.tsx`
+  - `web/components/feature-requests/FeatureRequestCard.tsx`
+- **Types:** `web/lib/types/feature-requests.ts` (if needed)
+
+## Risks / Notes
+
+- **UX placement critical:** This is a first-class feature, so navigation placement and visual treatment matter. UX agent should review before implementation.
+- **Voting system:** Consider adding voting (users can upvote requests) to prioritize popular features. Can be phase 2 if not in initial scope.
+- **Notifications:** Consider email notifications when admin updates status (phase 2).
+- **Integration:** Could integrate with GitHub Issues or Linear for admin workflow, but start with in-app for simplicity.
+- **Spam prevention:** Consider rate limiting or CAPTCHA for submissions (if needed).
+
+## Labels
+
+- **Type:** feature
+- **Priority:** high (first-class citizen requirement)
+- **Effort:** medium-large (database, API, UI, navigation integration)

--- a/.github/PLANS/jobs-table-ux-improvements.md
+++ b/.github/PLANS/jobs-table-ux-improvements.md
@@ -1,0 +1,116 @@
+# Jobs Table UX Improvements
+
+Plan for improving the All Jobs page and JobHistoryView component usability.
+
+---
+
+## 1. Sortable Column Headers (Primary)
+
+Add clickable column headers to the jobs table with visual sort indicators.
+
+### Current Architecture
+
+Data flows in [web/components/companies/JobHistoryView.tsx](web/components/companies/JobHistoryView.tsx):
+
+```
+jobs (props) → filteredJobs (filters) → paginatedJobs (pagination) → JobsTableView
+```
+
+### Implementation
+
+- Add `sortKey` and `sortDirection` ("asc" | "desc") state; default: `firstSeenDate` desc
+- Insert sort step: `filteredJobs` → `sortedJobs` → `paginatedJobs`
+- Reset `currentPage` to 1 when sort changes
+- Pass `sortKey`, `sortDirection`, `onSortClick(key)` to `JobsTableView`
+- Map columns to JobData fields with appropriate comparators (string: localeCompare, date: timestamp, boolean: false-first)
+- Make TableHead elements clickable with `ArrowUp`/`ArrowDown`/`ArrowUpDown` icons and `aria-sort`
+- Null values sort to end in both directions
+
+---
+
+## 2. Additional Usability Improvements
+
+### High impact, low effort
+
+**2.1 Clear-search button in search input**
+
+- Show an X (or similar) button inside the search field when it has content
+- Clicking clears the search immediately
+- Matches common UX pattern; avoids extra "Clear filters" click when only search is active
+
+**2.2 Filter pills / active filter chips**
+
+- Display applied filters as dismissible chips below the filter row (e.g., "Active", "Last 30 Days", "Wealthsimple")
+- Each chip has its own X to remove that filter
+- Improves at-a-glance visibility of what is applied and makes it easier to remove individual filters
+
+**2.3 Whole row clickable**
+
+- Make the entire table row navigate to the job detail (not only the title link)
+- Keeps title and company as links for middle-click/open-in-tab; row click uses primary navigation
+- Improves target size and reduces misclicks, especially on mobile
+
+**2.4 Items-per-page selector**
+
+- Add a dropdown (e.g., 12, 24, 48, 100) so users can control how many jobs appear per page
+- With ~479 jobs, 24/page = 20 pages; 48 or 100 reduces pagination friction
+- Optionally persist preference in localStorage (similar to view toggle)
+
+### Medium impact, medium effort
+
+**2.5 Sticky table header**
+
+- Use `position: sticky; top: 0` on the table header row when in table view
+- Keeps column labels visible when scrolling long lists
+- Improves orientation in large datasets
+
+**2.6 Export filtered results (CSV)**
+
+- Add "Export" button that downloads current filtered/sorted results as CSV
+- Supports competitive intel workflows (analysis in Excel/Sheets, sharing with team)
+- Client-side generation from `filteredJobs`/`sortedJobs`; no API change
+
+**2.7 Persist sort preference**
+
+- Save `sortKey` and `sortDirection` in localStorage (key: `jobs-sort-${companySlug}`)
+- Restore on mount so users return to their preferred view
+- Mirrors existing `useViewPreference` pattern for view toggle
+
+### Nice to have
+
+**2.8 URL state for filters and sort**
+
+- Sync search, status, time, company, sort, and page to URL query params
+- Enables shareable/bookmarkable filtered views and back-button behavior
+- Requires `useSearchParams` and `useRouter`; consider for a later iteration
+
+**2.9 Jump-to-page input**
+
+- For many pages (e.g., 20), add an input to jump directly to a page number
+- Reduces repetitive "Next" clicks for users who know which page they want
+
+**2.10 Data freshness indicator**
+
+- Show "Data as of [date]" or "Last updated [time]" near the job count
+- Builds trust and clarifies how current the data is
+
+---
+
+## Implementation Priority
+
+| Phase | Scope | Effort |
+|-------|-------|--------|
+| 1 | Sortable columns | 1–2 hrs |
+| 2 | Clear-search button, filter pills, whole-row click, items-per-page | 2–3 hrs |
+| 3 | Sticky header, export CSV, persist sort | 1–2 hrs |
+| 4 | URL state, jump-to-page, freshness indicator | 2–3 hrs |
+
+---
+
+## File to Modify
+
+All changes are localized to:
+
+- [web/components/companies/JobHistoryView.tsx](web/components/companies/JobHistoryView.tsx)
+
+No changes to the jobs page route or API are required.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,6 +166,33 @@ Each company needs: `name`, `slug`, `country`, `ats_type`, `ats_identifier`
 2. Add to factory in `src/scrapers/__init__.py`
 3. For web scrapers: add to `web/lib/scrapers/`
 
+## Release / Changelog
+
+**Every user-facing or notable change MUST include a changelog update.**
+
+### How to update
+1. Open `web/data/releases.json`
+2. Add a bullet to the current version's `changes` array, or create a new version entry if shipping a version bump
+3. Use the correct change type: `"feature"` (new functionality), `"fix"` (bug fix), `"improvement"` (enhancement to existing feature)
+4. Keep descriptions to one sentence
+
+### When to bump the version
+- **patch** (1.0.x): bug fixes only
+- **minor** (1.x.0): new features or improvements
+- **major** (x.0.0): breaking changes or major redesigns
+- Bump in both `web/package.json` and `web/data/releases.json`
+
+### What counts as "notable"
+- Any new page, feature, or UI component
+- Bug fixes that affected user-visible behavior
+- Performance improvements users would notice
+- Changes to the email digest format
+
+### What does NOT need a changelog entry
+- Internal refactors with no user-visible effect
+- Dev tooling, CI/CD, or test changes
+- Dependency updates (unless they change behavior)
+
 ## AI Model Requirements
 
 **IMPORTANT: Always use the latest Gemini 3 models. Never use Gemini 2.x or older.**

--- a/web/app/(dashboard)/releases/page.tsx
+++ b/web/app/(dashboard)/releases/page.tsx
@@ -1,0 +1,23 @@
+import { releases } from "@/lib/releases";
+import { ReleaseEntry } from "@/components/releases/ReleaseEntry";
+
+export const metadata = {
+  title: "Releases | The Fintech Talent Brief",
+};
+
+export default function ReleasesPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-8">
+      <h1 className="text-2xl font-bold tracking-tight">Releases</h1>
+      <p className="mt-1 text-sm text-muted-foreground">
+        Product updates and improvements
+      </p>
+
+      <div className="mt-6 divide-y divide-border">
+        {releases.map((release, i) => (
+          <ReleaseEntry key={release.version} release={release} isLatest={i === 0} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/app/api/cron/report/route.ts
+++ b/web/app/api/cron/report/route.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/analysis/company-insights";
 import { getWeeklyData, generateWeeklyReport, WeeklyDigest } from "@/lib/analysis/digest";
 import { WeeklyDigestEmail } from "@/lib/email/templates/weekly-digest";
+import { getLatestVersion } from "@/lib/releases";
 import { requireCronAuth } from "@/lib/cron/auth";
 
 export const maxDuration = 300; // Increased to handle company insights and AI generation
@@ -295,7 +296,7 @@ export async function GET(req: NextRequest) {
               from,
               to: user.email,
               subject,
-              react: WeeklyDigestEmail({ digest, digestId: savedDigestId, appUrl }),
+              react: WeeklyDigestEmail({ digest, digestId: savedDigestId, appUrl, version: getLatestVersion() }),
             }));
 
             // Send batch using Resend Batch API

--- a/web/components/layout/UserMenu.tsx
+++ b/web/components/layout/UserMenu.tsx
@@ -1,18 +1,38 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { createClient } from "@/lib/supabase/client";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import { Button } from "@/components/ui/button";
+import { CircleUser } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { getLatestVersion } from "@/lib/releases";
+
+const LATEST_VERSION = getLatestVersion();
 
 export function UserMenu({ email }: { email: string | undefined }) {
   const router = useRouter();
+  const pathname = usePathname();
   const supabase = createClient();
+  const [hasNewRelease, setHasNewRelease] = useState(false);
+
+  useEffect(() => {
+    const lastSeen = localStorage.getItem("last_seen_release_version");
+    setHasNewRelease(lastSeen !== LATEST_VERSION);
+  }, []);
+
+  useEffect(() => {
+    if (pathname === "/releases") {
+      localStorage.setItem("last_seen_release_version", LATEST_VERSION);
+      setHasNewRelease(false);
+    }
+  }, [pathname]);
 
   async function signOut() {
     await supabase.auth.signOut();
@@ -23,14 +43,24 @@ export function UserMenu({ email }: { email: string | undefined }) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" size="sm">
-          {email || "Account"}
+        <Button variant="ghost" size="icon" className="h-8 w-8">
+          <CircleUser className="h-5 w-5" />
+          <span className="sr-only">{email || "Account"}</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">
         <DropdownMenuItem asChild>
           <a href="/settings">Settings</a>
         </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <a href="/releases" className="flex items-center gap-1.5">
+            Releases
+            {hasNewRelease && (
+              <span className="h-1.5 w-1.5 rounded-full bg-blue-500" />
+            )}
+          </a>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         <DropdownMenuItem onClick={signOut}>Sign out</DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/web/components/releases/ChangeBadge.tsx
+++ b/web/components/releases/ChangeBadge.tsx
@@ -1,0 +1,23 @@
+import type { Change } from "@/lib/releases";
+
+const badgeStyles: Record<Change["type"], string> = {
+  feature: "bg-emerald-50 text-emerald-700",
+  fix: "bg-amber-50 text-amber-700",
+  improvement: "bg-blue-50 text-blue-700",
+};
+
+const badgeLabels: Record<Change["type"], string> = {
+  feature: "Feature",
+  fix: "Fix",
+  improvement: "Improvement",
+};
+
+export function ChangeBadge({ type }: { type: Change["type"] }) {
+  return (
+    <span
+      className={`inline-block rounded px-1.5 py-0.5 text-[11px] font-medium leading-none ${badgeStyles[type]}`}
+    >
+      {badgeLabels[type]}
+    </span>
+  );
+}

--- a/web/components/releases/ReleaseEntry.tsx
+++ b/web/components/releases/ReleaseEntry.tsx
@@ -1,0 +1,51 @@
+import type { Release } from "@/lib/releases";
+import { ChangeBadge } from "./ChangeBadge";
+
+function formatDate(dateStr: string): string {
+  const date = new Date(dateStr + "T00:00:00");
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+
+  if (diffDays === 0) return "Today";
+  if (diffDays === 1) return "Yesterday";
+  if (diffDays < 7) return `${diffDays} days ago`;
+
+  return date.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+export function ReleaseEntry({
+  release,
+  isLatest,
+}: {
+  release: Release;
+  isLatest: boolean;
+}) {
+  return (
+    <div className="py-6">
+      <div className="flex items-center gap-2">
+        <h2 className="text-base font-semibold">v{release.version}</h2>
+        {isLatest && (
+          <span className="rounded bg-foreground px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-background">
+            Latest
+          </span>
+        )}
+      </div>
+      <p className="mt-0.5 text-sm text-muted-foreground">
+        {formatDate(release.date)}
+      </p>
+      <ul className="mt-4 space-y-2">
+        {release.changes.map((change, i) => (
+          <li key={i} className="flex items-start gap-2 text-sm">
+            <ChangeBadge type={change.type} />
+            <span>{change.description}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,0 +1,12 @@
+[
+  {
+    "version": "1.0.0",
+    "date": "2026-02-16",
+    "changes": [
+      { "type": "feature", "description": "Release history page and newsletter footer" },
+      { "type": "feature", "description": "Rebrand to The Fintech Talent Brief" },
+      { "type": "feature", "description": "Stratechery-style analyst briefing format for weekly digests" },
+      { "type": "feature", "description": "Intelligence-first dashboard redesign" }
+    ]
+  }
+]

--- a/web/lib/email/templates/weekly-digest.tsx
+++ b/web/lib/email/templates/weekly-digest.tsx
@@ -16,6 +16,7 @@ interface WeeklyDigestEmailProps {
   digest: WeeklyDigest;
   digestId: string;  // NEW - for deep linking
   appUrl?: string;
+  version?: string;
 }
 
 /**
@@ -109,7 +110,7 @@ function CompanySection({ company, appUrl = "https://fintech-talent-brief.vercel
  * 
  * Clean, minimal design with TLDR-style AI commentary for each company
  */
-export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-talent-brief.vercel.app" }: WeeklyDigestEmailProps) {
+export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-talent-brief.vercel.app", version }: WeeklyDigestEmailProps) {
   const dateRange = formatDateRange(digest.week_start, digest.week_end);
   const previewText = `The Fintech Talent Brief: ${digest.total_jobs} new jobs across ${digest.total_companies} companies this week`;
   const digestUrl = `${appUrl}/digests/${digestId}`;
@@ -259,6 +260,15 @@ export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-
             <Text style={footerMuted}>
               The Fintech Talent Brief | Hiring Intelligence for Fintech
             </Text>
+            {version && (
+              <Text style={footerVersion}>
+                v{version}
+                {" \u2013 "}
+                <Link href={`${appUrl}/releases`} style={footerVersionLink}>
+                  See what&apos;s new
+                </Link>
+              </Text>
+            )}
           </Section>
         </Container>
       </Body>
@@ -431,6 +441,19 @@ const footerMuted: React.CSSProperties = {
   color: "#9ca3af",
   fontSize: "12px",
   margin: "0",
+};
+
+const footerVersion: React.CSSProperties = {
+  color: "#c0c0c0",
+  fontSize: "11px",
+  margin: "8px 0 0",
+  textAlign: "center" as const,
+};
+
+const footerVersionLink: React.CSSProperties = {
+  color: "#9ca3af",
+  fontSize: "11px",
+  textDecoration: "underline",
 };
 
 export default WeeklyDigestEmail;

--- a/web/lib/releases.ts
+++ b/web/lib/releases.ts
@@ -1,0 +1,18 @@
+import releasesData from "@/data/releases.json";
+
+export interface Change {
+  type: "feature" | "fix" | "improvement";
+  description: string;
+}
+
+export interface Release {
+  version: string;
+  date: string;
+  changes: Change[];
+}
+
+export const releases: Release[] = releasesData as Release[];
+
+export function getLatestVersion(): string {
+  return releases[0]?.version ?? "0.0.0";
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Adds a `/releases` page with structured changelog UI (version entries, change type badges)
- Adds new-release indicator dot in the user menu that clears when visiting the releases page
- Includes app version in weekly digest email footer with "See what's new" link
- Bumps version to 1.0.0 with changelog guidelines added to CLAUDE.md
- Adds issue docs (#105–#107) and jobs table UX improvement plan

## Test plan
- [ ] Visit `/releases` and verify changelog renders with version entries and badges
- [ ] Check user menu shows blue dot indicator for new release, clears after visiting `/releases`
- [ ] Verify weekly digest email footer shows version and "See what's new" link
- [ ] Run `npm run build` to confirm no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)