### PR TITLE
Fix missing department and function data for Questrade jobs

### DIFF
--- a/.github/workflows/scrape-heavy.yml
+++ b/.github/workflows/scrape-heavy.yml
@@ -38,4 +38,5 @@ jobs:
           TASK_ID: ${{ inputs.task_id }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
         run: npx tsx scripts/scrape-heavy.ts

--- a/web/scripts/backfill-silver-layer.ts
+++ b/web/scripts/backfill-silver-layer.ts
@@ -140,6 +140,7 @@ async function main() {
           tech_stack: structure.tech_stack,
           keywords: structure.keywords || [],
           standardized_department: structure.standardized_department,
+          function_category: structure.function_category,
           normalized_title: normalizedTitle,
           // Clean invalid department values (set to null)
           department: cleanedDepartment,


### PR DESCRIPTION
## Summary
- Add `GEMINI_API_KEY` to the GitHub Actions heavy scraper workflow — it was missing, causing AI extraction (department, function_category, seniority, etc.) to silently fail for all browser-scraped companies
- Fix `backfill-silver-layer.ts` to include `function_category` in its database update

## Root Cause
Questrade uses the Dayforce ATS, which is classified as a browser scraper and offloaded to GitHub Actions. The `scrape-heavy.yml` workflow was missing `GEMINI_API_KEY` from its env vars, so `extractJobStructure()` returned `null` immediately — leaving all Silver Layer fields unpopulated.

## Test plan
- [x] Backfill ran successfully — all 25 active Questrade jobs now have `function_category`, `standardized_department`, and `seniority_level`
- [x] `npm run build` passes
- [ ] Verify next daily cron populates Silver Layer data for Questrade automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)