### PR TITLE
Reduce Gemini API costs by switching Pro→Flash and tightening token budgets

### DIFF
--- a/web/app/api/companies/[id]/insights/[insightId]/chat/route.ts
+++ b/web/app/api/companies/[id]/insights/[insightId]/chat/route.ts
@@ -105,7 +105,7 @@ export async function POST(
       model: "gemini-3-flash-preview",
       generationConfig: {
         temperature: 0.7,
-        maxOutputTokens: 64000,
+        maxOutputTokens: 16384,
       },
     });
 

--- a/web/app/api/insights/[id]/chat/route.ts
+++ b/web/app/api/insights/[id]/chat/route.ts
@@ -123,23 +123,22 @@ ${job.description_text || "No description available"}
 
 Your role is to answer follow-up questions about this insight, provide deeper analysis, and help the user understand the strategic implications. Use web search when needed to get the latest information about the company.`;
 
-    // Initialize Gemini with fallback (pro -> flash)
+    // Initialize Gemini — use Flash for cost efficiency (supports Google Search grounding)
     const key = process.env.GEMINI_API_KEY;
     if (!key) {
       return NextResponse.json({ error: "Gemini API key not configured" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(key);
-    
-    // Try pro model first, fallback to flash if quota exceeded
-    let model = genAI.getGenerativeModel({
-      model: "gemini-pro-latest",
+
+    const model = genAI.getGenerativeModel({
+      model: "gemini-3-flash-preview",
       // @ts-expect-error - googleSearch tool exists at runtime but types may be outdated
       tools: [{ googleSearch: {} }],
       systemInstruction: systemPrompt,
       generationConfig: {
         temperature: 0.7,
-        maxOutputTokens: 64000,
+        maxOutputTokens: 16384,
       },
     });
 
@@ -150,34 +149,12 @@ Your role is to answer follow-up questions about this insight, provide deeper an
     }));
 
     // Start chat with history
-    let chat = model.startChat({
+    const chat = model.startChat({
       history: history as any,
     });
 
-    // Stream the response with error handling
-    let stream;
-    try {
-      stream = await chat.sendMessageStream(question);
-    } catch (error: any) {
-      // If we get a quota error during generation, try flash model as fallback
-      if (error?.status === 429 || error?.message?.includes("quota") || error?.message?.includes("limit") || error?.message?.includes("exceeded")) {
-        console.warn(`gemini-pro-latest quota exceeded: ${error.message}. Falling back to gemini-3-flash-preview.`);
-        model = genAI.getGenerativeModel({
-          model: "gemini-3-flash-preview",
-          systemInstruction: systemPrompt,
-          generationConfig: {
-            temperature: 0.7,
-            maxOutputTokens: 64000,
-          },
-        });
-        chat = model.startChat({
-          history: history as any,
-        });
-        stream = await chat.sendMessageStream(question);
-      } else {
-        throw error;
-      }
-    }
+    // Stream the response
+    const stream = await chat.sendMessageStream(question);
 
     // Create a readable stream for the response
     const encoder = new TextEncoder();

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "1.7.3",
+    "date": "2026-04-12",
+    "changes": [
+      { "type": "improvement", "description": "Switched company news fetching and chat from Gemini Pro to Flash, significantly reducing daily AI costs while maintaining quality." },
+      { "type": "improvement", "description": "Tightened maxOutputTokens across all Gemini calls and reduced job description sizes sent for extraction to cut per-job token costs." }
+    ]
+  },
+  {
     "version": "1.7.2",
     "date": "2026-03-28",
     "changes": [

--- a/web/lib/ai/strategy-analysis.ts
+++ b/web/lib/ai/strategy-analysis.ts
@@ -170,7 +170,7 @@ export async function analyzeCompanyStrategy(
       model: "gemini-3-flash-preview",
       generationConfig: {
         temperature: 0.3,
-        maxOutputTokens: 64000,
+        maxOutputTokens: 8192,
         responseMimeType: "application/json",
       },
     });

--- a/web/lib/analysis/company-news.ts
+++ b/web/lib/analysis/company-news.ts
@@ -217,13 +217,14 @@ async function fetchFreshNewsContext(companyName: string): Promise<CompanyNewsCo
   try {
     const genAI = new GoogleGenerativeAI(key);
     
-    // Use Gemini Pro with grounding for web search
+    // Use Gemini Flash with grounding for web search (Flash supports Google Search
+    // and is significantly cheaper than Pro — company-research.ts already uses this pattern)
     const model = genAI.getGenerativeModel({
-      model: "gemini-pro-latest",
+      model: "gemini-3-flash-preview",
       // @ts-expect-error - googleSearch tool exists at runtime but types may be outdated
-      tools: [{ googleSearch: {} }], // Enable grounding
+      tools: [{ googleSearch: {} }],
       generationConfig: {
-        temperature: 0.3, // Lower temperature for more factual extraction
+        temperature: 0.3,
         maxOutputTokens: 4000,
         responseMimeType: "application/json",
       },

--- a/web/lib/analysis/company-research.ts
+++ b/web/lib/analysis/company-research.ts
@@ -175,7 +175,7 @@ export async function detectCompanyType(
       model: "gemini-3-flash-preview",
       generationConfig: {
         temperature: 0.1,
-        maxOutputTokens: 64000,
+        maxOutputTokens: 256,
         responseMimeType: "application/json",
       },
     });

--- a/web/lib/analysis/structure.ts
+++ b/web/lib/analysis/structure.ts
@@ -49,9 +49,9 @@ export const JobStructureSchema = z.object({
 export type JobStructure = z.infer<typeof JobStructureSchema>;
 
 const GEMINI_REQUEST_TIMEOUT_MS = 30000;
-const MAX_STAGE1_DESCRIPTION_CHARS = 8000;
-const MIN_STAGE1_DESCRIPTION_CHARS = 4000;
-const STAGE1_RETRY_DESCRIPTION_STEP = 2000;
+const MAX_STAGE1_DESCRIPTION_CHARS = 6000;
+const MIN_STAGE1_DESCRIPTION_CHARS = 3000;
+const STAGE1_RETRY_DESCRIPTION_STEP = 1500;
 const MAX_STAGE1_OUTPUT_TOKENS = 4096;
 
 // Extended type for database insertion (flattened salary fields)

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.7.0",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.7.0",
+      "version": "1.7.3",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -2848,6 +2848,66 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.7.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
The two biggest cost drivers were company news fetching and chat, both
using gemini-pro-latest unnecessarily. Flash already supports Google
Search grounding (proven in company-research.ts) so the switch is safe.

Changes:
- company-news.ts: gemini-pro-latest → gemini-3-flash-preview
- insights chat: gemini-pro-latest → gemini-3-flash-preview, remove
  Pro→Flash fallback logic (no longer needed)
- detectCompanyType: maxOutputTokens 64000 → 256 (response is ~50 tokens)
- strategy-analysis: maxOutputTokens 64000 → 8192
- chat endpoints: maxOutputTokens 64000 → 16384
- structure.ts: reduce description char limits (8000→6000, 4000→3000)
  to cut per-job input tokens on the highest-volume operation
- Bump version to 1.7.3, update changelog

https://claude.ai/code/session_019S4Rf46oGcURaYSQDgfTqD