### PR TITLE
Interactive digest deep links + auth redirect fix

### DIFF
--- a/web/app/(auth)/login/page.tsx
+++ b/web/app/(auth)/login/page.tsx
@@ -48,6 +48,8 @@ function GoogleIcon({ className }: { className?: string }) {
 export default function LoginPage() {
   const searchParams = useSearchParams();
   const { signInWithGoogle, isLoading, error, setError } = useGoogleAuth();
+  const nextPath = searchParams.get("next");
+  const handleSignIn = () => signInWithGoogle(nextPath);
 
   // Check for OAuth error parameters in URL
   useEffect(() => {
@@ -85,7 +87,7 @@ export default function LoginPage() {
           <div className="flex flex-col gap-3 sm:flex-row">
             <Button
               size="lg"
-              onClick={signInWithGoogle}
+              onClick={handleSignIn}
               disabled={isLoading}
               className="h-12 px-8 text-base"
             >
@@ -102,7 +104,7 @@ export default function LoginPage() {
             <Button
               variant="outline"
               size="lg"
-              onClick={signInWithGoogle}
+              onClick={handleSignIn}
               disabled={isLoading}
               className="h-12 px-8 text-base gap-2"
             >

--- a/web/app/(dashboard)/digests/[id]/page.tsx
+++ b/web/app/(dashboard)/digests/[id]/page.tsx
@@ -150,7 +150,7 @@ export default async function DigestDetailPage({
       )}
 
       {/* Digest Content */}
-      <DigestViewer digest={digestData} />
+      <DigestViewer digest={digestData} digestId={id} />
     </div>
   );
 }

--- a/web/app/(dashboard)/jobs/page.tsx
+++ b/web/app/(dashboard)/jobs/page.tsx
@@ -1,8 +1,17 @@
 /**
  * Jobs Page
- * 
+ *
  * Shows all job postings across all companies with search and filters.
  * Uses the same JobHistoryView component as company pages.
+ *
+ * Accepts query parameters so that deep links from the weekly digest email
+ * can land users in a pre-filtered view with a context banner for
+ * orientation. Supported params:
+ *   - status, time, date (legacy)
+ *   - theme (role theme id)
+ *   - company (company slug)
+ *   - inDigest (weekly_digests UUID — scopes to the digest's captured jobs)
+ *   - from, to (ISO date strings)
  */
 
 import { redirect } from "next/navigation";
@@ -13,6 +22,11 @@ type JobsPageSearchParams = {
   status?: string;
   time?: string;
   date?: string;
+  theme?: string;
+  company?: string;
+  inDigest?: string;
+  from?: string;
+  to?: string;
 };
 
 type JobRow = {
@@ -28,6 +42,11 @@ type JobRow = {
     | { id: string; name: string; slug: string }
     | { id: string; name: string; slug: string }[]
     | null;
+};
+
+type DigestCompanyRow = {
+  company_id: string;
+  job_ids: unknown;
 };
 
 function getInitialStatus(status?: string): "all" | "active" | "inactive" {
@@ -53,6 +72,14 @@ function getInitialTimeFilter(
   return "all";
 }
 
+/** Parse an ISO date param and return the normalized string, or null if invalid. */
+function parseIsoDateParam(value?: string): string | null {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return value;
+}
+
 export default async function JobsPage({
   searchParams,
 }: {
@@ -63,14 +90,101 @@ export default async function JobsPage({
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect("/login");
 
-  const initialStatus = getInitialStatus(params.status);
-  const initialTimeFilter = getInitialTimeFilter(params.time, params.date);
+  const themeParam = params.theme?.trim() || null;
+  const companyParam = params.company?.trim() || null;
+  const inDigestParam = params.inDigest?.trim() || null;
+  const fromParam = parseIsoDateParam(params.from);
+  const toParam = parseIsoDateParam(params.to);
+
+  // When viewing a digest snapshot, the job_ids list is already the scope —
+  // we must show closed jobs as well because the digest is a historical
+  // frame, so force status to "all" regardless of the incoming status param.
+  const initialStatus = inDigestParam
+    ? "all"
+    : getInitialStatus(params.status);
+
+  // Explicit from/to overrides the preset time filter (mutually exclusive).
+  const initialTimeFilter =
+    fromParam || toParam
+      ? "all"
+      : getInitialTimeFilter(params.time, params.date);
+
+  // If inDigest is present, look up the job_ids captured by that digest (or
+  // the single matching company's job_ids if company is also set).
+  let digestJobIds: string[] | null = null;
+  if (inDigestParam) {
+    let companyId: string | null = null;
+    if (companyParam) {
+      const { data: companyRow } = await supabase
+        .from("companies")
+        .select("id")
+        .eq("slug", companyParam)
+        .maybeSingle();
+      companyId = companyRow?.id ?? null;
+    }
+
+    let digestCompaniesQuery = supabase
+      .from("weekly_digest_companies")
+      .select("company_id, job_ids")
+      .eq("digest_id", inDigestParam);
+
+    if (companyParam && companyId) {
+      digestCompaniesQuery = digestCompaniesQuery.eq("company_id", companyId);
+    }
+
+    const { data: digestCompanyRows } = await digestCompaniesQuery;
+
+    const jobIdSet = new Set<string>();
+    for (const row of (digestCompanyRows ?? []) as DigestCompanyRow[]) {
+      const rawIds = Array.isArray(row.job_ids) ? row.job_ids : [];
+      for (const id of rawIds) {
+        if (typeof id === "string" && id) jobIdSet.add(id);
+      }
+    }
+    digestJobIds = Array.from(jobIdSet);
+  }
 
   // Fetch all jobs with company information
-  const { data: jobsRaw } = await supabase
+  let jobsQuery = supabase
     .from("job_postings")
-    .select("id, title, standardized_department, function_category, location, is_active, first_seen_date, url, companies(id, name, slug)")
+    .select(
+      "id, title, standardized_department, function_category, location, is_active, first_seen_date, url, companies(id, name, slug)"
+    )
     .order("first_seen_date", { ascending: false });
+
+  if (digestJobIds !== null) {
+    if (digestJobIds.length === 0) {
+      // Digest exists but captured nothing (or doesn't exist). Short-circuit
+      // to an empty list — the banner will still render and show 0 of 0.
+      const emptyJobs: JobData[] = [];
+      return (
+        <div className="space-y-6">
+          <div>
+            <h1 className="text-3xl font-bold">All Jobs</h1>
+            <p className="text-sm text-muted-foreground mt-1">
+              Browse job postings across all companies
+            </p>
+          </div>
+          <JobHistoryView
+            jobs={emptyJobs}
+            companySlug="all"
+            initialStatus={initialStatus}
+            initialTimeFilter={initialTimeFilter}
+            initialThemeFilter={themeParam}
+            initialCompanyFilter={companyParam}
+            initialInDigest={inDigestParam}
+            initialFromDate={fromParam}
+            initialToDate={toParam}
+            showHeader={true}
+            pageSize={24}
+          />
+        </div>
+      );
+    }
+    jobsQuery = jobsQuery.in("id", digestJobIds);
+  }
+
+  const { data: jobsRaw } = await jobsQuery;
 
   // Transform jobs data for JobHistoryView
   const jobs: JobData[] = ((jobsRaw ?? []) as JobRow[]).map((j) => {
@@ -102,6 +216,11 @@ export default async function JobsPage({
         companySlug="all"
         initialStatus={initialStatus}
         initialTimeFilter={initialTimeFilter}
+        initialThemeFilter={themeParam}
+        initialCompanyFilter={companyParam}
+        initialInDigest={inDigestParam}
+        initialFromDate={fromParam}
+        initialToDate={toParam}
         showHeader={true}
         pageSize={24}
       />

--- a/web/app/auth/callback/route.ts
+++ b/web/app/auth/callback/route.ts
@@ -6,7 +6,24 @@ export async function GET(request: Request) {
   const code = searchParams.get("code");
   const error_description = searchParams.get("error_description");
   const error_code = searchParams.get("error");
-  const rawNext = searchParams.get("next");
+
+  // `next` may arrive as a query param (legacy) or via the auth_next cookie
+  // (set by use-google-auth before the OAuth redirect to keep redirectTo clean).
+  const rawNext =
+    searchParams.get("next") ??
+    (() => {
+      try {
+        const encoded = request.headers
+          .get("cookie")
+          ?.split("; ")
+          .find((c) => c.startsWith("auth_next="))
+          ?.split("=")[1];
+        return encoded ? decodeURIComponent(encoded) : null;
+      } catch {
+        return null;
+      }
+    })();
+
   // Only honor same-origin relative paths — never follow external URLs.
   const next =
     rawNext && rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/";
@@ -37,7 +54,9 @@ export async function GET(request: Request) {
     }
 
     if (data.session) {
-      return NextResponse.redirect(`${origin}${next}`);
+      const response = NextResponse.redirect(`${origin}${next}`);
+      response.cookies.delete("auth_next");
+      return response;
     }
   }
 

--- a/web/app/auth/callback/route.ts
+++ b/web/app/auth/callback/route.ts
@@ -6,7 +6,10 @@ export async function GET(request: Request) {
   const code = searchParams.get("code");
   const error_description = searchParams.get("error_description");
   const error_code = searchParams.get("error");
-  const next = searchParams.get("next") ?? "/";
+  const rawNext = searchParams.get("next");
+  // Only honor same-origin relative paths — never follow external URLs.
+  const next =
+    rawNext && rawNext.startsWith("/") && !rawNext.startsWith("//") ? rawNext : "/";
   const origin = new URL(request.url).origin;
 
   // Handle OAuth errors from Supabase

--- a/web/components/auth/AuthHeader.tsx
+++ b/web/components/auth/AuthHeader.tsx
@@ -7,6 +7,7 @@ import { Sparkles } from "lucide-react";
 
 export function AuthHeader() {
   const { signInWithGoogle, isLoading } = useGoogleAuth();
+  const handleSignIn = () => signInWithGoogle();
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8 bg-background/80 backdrop-blur-sm border-b border-border/40">
@@ -22,14 +23,14 @@ export function AuthHeader() {
       <div className="flex items-center gap-2 sm:gap-4">
         <Button 
           variant="ghost" 
-          onClick={signInWithGoogle}
+          onClick={handleSignIn}
           disabled={isLoading}
           className="text-muted-foreground hover:text-foreground hidden sm:flex"
         >
           Log in
         </Button>
         <Button 
-          onClick={signInWithGoogle}
+          onClick={handleSignIn}
           disabled={isLoading}
           className="font-medium"
         >

--- a/web/components/companies/JobHistoryView.tsx
+++ b/web/components/companies/JobHistoryView.tsx
@@ -51,6 +51,7 @@ import {
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { getCategoryLabel, getCategoryGroup, ROLE_CATEGORIES, type RoleCategory } from "@/lib/analysis/function-categories";
+import { classifyJob, getThemeLabel } from "@/lib/analysis/role-themes";
 
 /** Job posting data structure */
 export interface JobData {
@@ -76,6 +77,22 @@ interface JobHistoryViewProps {
   initialStatus?: "all" | "active" | "inactive";
   /** Initial time filter */
   initialTimeFilter?: TimeFilter;
+  /**
+   * Initial role theme filter (from URL). Not exposed as a dropdown —
+   * URL-driven only, surfaced to the user via the digest context banner.
+   */
+  initialThemeFilter?: string | null;
+  /** Initial company filter (company slug, or null). Seeds the existing dropdown. */
+  initialCompanyFilter?: string | null;
+  /**
+   * When set, indicates the page was entered from a weekly digest with this
+   * digest UUID. Used by the context banner to read "from this digest".
+   */
+  initialInDigest?: string | null;
+  /** Initial from-date filter (ISO string) applied to first_seen_date. */
+  initialFromDate?: string | null;
+  /** Initial to-date filter (ISO string) applied to first_seen_date. */
+  initialToDate?: string | null;
   /** Items per page */
   pageSize?: number;
 }
@@ -97,6 +114,11 @@ export function JobHistoryView({
   showHeader = true,
   initialStatus = "all",
   initialTimeFilter = "all",
+  initialThemeFilter = null,
+  initialCompanyFilter = null,
+  initialInDigest = null,
+  initialFromDate = null,
+  initialToDate = null,
   pageSize = 12,
 }: JobHistoryViewProps) {
   const router = useRouter();
@@ -105,10 +127,24 @@ export function JobHistoryView({
   const [searchQuery, setSearchQuery] = React.useState("");
   const [statusFilter, setStatusFilter] = React.useState<StatusFilter>(initialStatus);
   const [timeFilter, setTimeFilter] = React.useState<TimeFilter>(initialTimeFilter);
-  const [companyFilter, setCompanyFilter] = React.useState<string>("all");
+  const [companyFilter, setCompanyFilter] = React.useState<string>(
+    initialCompanyFilter ?? "all"
+  );
   const [functionFilter, setFunctionFilter] = React.useState<string>(() => {
     return searchParams.get("function") ?? "all";
   });
+  const [themeFilter, setThemeFilter] = React.useState<string | null>(
+    initialThemeFilter
+  );
+  const [fromDateFilter, setFromDateFilter] = React.useState<string | null>(
+    initialFromDate
+  );
+  const [toDateFilter, setToDateFilter] = React.useState<string | null>(
+    initialToDate
+  );
+  const [inDigestFilter, setInDigestFilter] = React.useState<string | null>(
+    initialInDigest
+  );
   const [currentPage, setCurrentPage] = React.useState(1);
 
   // Sync function filter to URL
@@ -176,8 +212,18 @@ export function JobHistoryView({
       result = result.filter((j) => !j.isActive);
     }
 
-    // Time filter
-    if (timeFilter !== "all") {
+    // Time filter — from/to overrides the preset (mutually exclusive).
+    if (fromDateFilter || toDateFilter) {
+      const fromCutoff = fromDateFilter ? new Date(fromDateFilter) : null;
+      const toCutoff = toDateFilter ? new Date(toDateFilter) : null;
+      result = result.filter((j) => {
+        if (!j.firstSeenDate) return false;
+        const seen = new Date(j.firstSeenDate);
+        if (fromCutoff && seen < fromCutoff) return false;
+        if (toCutoff && seen > toCutoff) return false;
+        return true;
+      });
+    } else if (timeFilter !== "all") {
       const now = new Date();
       let cutoffDate: Date;
 
@@ -207,6 +253,15 @@ export function JobHistoryView({
       });
     }
 
+    // Role theme filter (URL-driven, from digest deep links). Uses the
+    // shared classifier from @/lib/analysis/role-themes — no theme tags are
+    // persisted on job rows.
+    if (themeFilter) {
+      result = result.filter((j) =>
+        classifyJob(j.title, j.standardized_department).includes(themeFilter)
+      );
+    }
+
     // Search filter
     if (searchQuery.trim()) {
       const query = searchQuery.toLowerCase();
@@ -223,7 +278,18 @@ export function JobHistoryView({
     }
 
     return result;
-  }, [jobs, companySlug, companyFilter, functionFilter, statusFilter, timeFilter, searchQuery]);
+  }, [
+    jobs,
+    companySlug,
+    companyFilter,
+    functionFilter,
+    statusFilter,
+    timeFilter,
+    searchQuery,
+    themeFilter,
+    fromDateFilter,
+    toDateFilter,
+  ]);
 
   // Pagination
   const totalPages = Math.ceil(filteredJobs.length / pageSize);
@@ -235,13 +301,33 @@ export function JobHistoryView({
   // Reset to page 1 when filters change
   React.useEffect(() => {
     setCurrentPage(1);
-  }, [statusFilter, timeFilter, companyFilter, functionFilter, searchQuery]);
+  }, [
+    statusFilter,
+    timeFilter,
+    companyFilter,
+    functionFilter,
+    searchQuery,
+    themeFilter,
+    fromDateFilter,
+    toDateFilter,
+  ]);
+
+  const hasDigestContext =
+    Boolean(themeFilter) ||
+    Boolean(inDigestFilter) ||
+    Boolean(fromDateFilter) ||
+    Boolean(toDateFilter) ||
+    (companySlug === "all" && Boolean(initialCompanyFilter));
 
   const hasFilters =
     statusFilter !== "all" ||
     timeFilter !== "all" ||
     functionFilter !== "all" ||
     (companySlug === "all" && companyFilter !== "all") ||
+    Boolean(themeFilter) ||
+    Boolean(fromDateFilter) ||
+    Boolean(toDateFilter) ||
+    Boolean(inDigestFilter) ||
     searchQuery.trim();
 
   const clearFilters = () => {
@@ -250,7 +336,92 @@ export function JobHistoryView({
     setCompanyFilter("all");
     updateFunctionFilter("all");
     setSearchQuery("");
+    setThemeFilter(null);
+    setFromDateFilter(null);
+    setToDateFilter(null);
+    setInDigestFilter(null);
+    // Reset URL-level params introduced for digest deep links by navigating
+    // to the bare /jobs page.
+    if (hasDigestContext) {
+      router.push("/jobs");
+    }
   };
+
+  // Derive the display name for the active company filter (for the banner).
+  // We prefer the slug currently held in companyFilter over the initial prop
+  // so that the banner stays accurate if the user changes it via the
+  // dropdown before clearing digest context.
+  const activeCompanyName = React.useMemo(() => {
+    const slug =
+      companySlug === "all" && companyFilter !== "all"
+        ? companyFilter
+        : initialCompanyFilter;
+    if (!slug) return null;
+    const match = jobs.find((j) => j.companySlug === slug);
+    return match?.companyName ?? slug;
+  }, [jobs, initialCompanyFilter, companyFilter, companySlug]);
+
+  // Build the descriptive context-banner sentence. Fragments are assembled in
+  // a deterministic order so the resulting sentence reads naturally no
+  // matter which subset of filters is active:
+  //   "Viewing {Company}'s jobs in {Theme}, from this digest"
+  //   "Viewing jobs in {Theme}, between {from} and {to}"
+  const contextBannerFragments = React.useMemo(() => {
+    const parts: React.ReactNode[] = [];
+    if (activeCompanyName) {
+      parts.push(
+        <>
+          <span className="font-semibold text-foreground">
+            {activeCompanyName}
+          </span>
+          &rsquo;s jobs
+        </>
+      );
+    } else {
+      parts.push(<>jobs</>);
+    }
+
+    if (themeFilter) {
+      parts.push(
+        <>
+          {" "}in{" "}
+          <span className="font-semibold text-foreground">
+            {getThemeLabel(themeFilter)}
+          </span>
+        </>
+      );
+    }
+
+    if (inDigestFilter) {
+      parts.push(<>, from this digest</>);
+    } else if (fromDateFilter || toDateFilter) {
+      const fromLabel = fromDateFilter
+        ? format(new Date(fromDateFilter), "MMM d")
+        : null;
+      const toLabel = toDateFilter
+        ? format(new Date(toDateFilter), "MMM d, yyyy")
+        : null;
+      if (fromLabel && toLabel) {
+        parts.push(
+          <>
+            , between {fromLabel} and {toLabel}
+          </>
+        );
+      } else if (fromLabel) {
+        parts.push(<>, from {fromLabel} onward</>);
+      } else if (toLabel) {
+        parts.push(<>, through {toLabel}</>);
+      }
+    }
+
+    return parts;
+  }, [
+    activeCompanyName,
+    themeFilter,
+    inDigestFilter,
+    fromDateFilter,
+    toDateFilter,
+  ]);
 
   return (
     <div className={cn("space-y-4", className)}>
@@ -264,6 +435,37 @@ export function JobHistoryView({
             </p>
           </div>
           <ViewToggle view={view} onViewChange={setView} />
+        </div>
+      )}
+
+      {/* Digest context banner — shown when the user lands on /jobs from a
+          weekly-digest deep link with any of theme / company / inDigest /
+          from / to active. This is the orientation cue that makes arriving
+          from an email feel intentional instead of mysterious. */}
+      {hasDigestContext && (
+        <div className="rounded-lg border bg-muted/40 px-4 py-3">
+          <div className="flex items-start justify-between gap-4">
+            <div className="text-sm text-muted-foreground">
+              <div>
+                Viewing{" "}
+                {contextBannerFragments.map((fragment, idx) => (
+                  <React.Fragment key={idx}>{fragment}</React.Fragment>
+                ))}
+              </div>
+              <div className="mt-1 text-xs">
+                {filteredJobs.length} of {jobs.length}{" "}
+                {jobs.length === 1 ? "job" : "jobs"} match
+              </div>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={clearFilters}
+              className="shrink-0"
+            >
+              Clear filters
+            </Button>
+          </div>
         </div>
       )}
 

--- a/web/components/digests/DigestViewer.tsx
+++ b/web/components/digests/DigestViewer.tsx
@@ -1,23 +1,48 @@
 "use client";
 
-import { WeeklyDigest } from "@/lib/analysis/digest";
+import { WeeklyDigest, CompanyWeeklySummary } from "@/lib/analysis/digest";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import Link from "next/link";
 import { Building2, TrendingUp, Target, Briefcase, ExternalLink } from "lucide-react";
+import { buildDigestLink } from "@/lib/email/links";
+import { getThemeIdByLabel } from "@/lib/analysis/role-themes";
 
 interface DigestViewerProps {
   digest: WeeklyDigest;
+  digestId: string;
+}
+
+/** Resolve a company display name back to its slug via the digest payload. */
+function findCompanySlug(
+  companies: CompanyWeeklySummary[],
+  companyName: string
+): string | null {
+  const match = companies.find((entry) => entry.company_name === companyName);
+  return match?.company_slug ?? null;
 }
 
 /**
  * DigestViewer - Renders a weekly digest in the same format as the email
  * Uses relative paths for Next.js navigation (not appUrl which is for emails)
  */
-export function DigestViewer({ digest }: DigestViewerProps) {
+export function DigestViewer({ digest, digestId }: DigestViewerProps) {
   const globalSummary = digest.global_summary;
   const industryTrends = digest.industry_trends || [];
   const strategySignals = digest.strategy_signals || [];
   const notableMovements = digest.notable_movements || [];
+  const yearStartIso = `${new Date(digest.week_end).getUTCFullYear()}-01-01`;
+  const yearLabel = yearStartIso.slice(0, 4);
+
+  const jobsInDigestHref = buildDigestLink({
+    surface: "app",
+    digestId,
+    target: { kind: "jobs", inDigest: true },
+  });
+  const companiesHref = buildDigestLink({
+    surface: "app",
+    digestId,
+    target: { kind: "companies" },
+  });
 
   return (
     <div className="space-y-6">
@@ -40,7 +65,7 @@ export function DigestViewer({ digest }: DigestViewerProps) {
 
       {/* Summary Stats - Interactive */}
       <div className="grid grid-cols-2 gap-4">
-        <Link href="/jobs">
+        <Link href={jobsInDigestHref}>
           <Card className="hover:shadow-md transition-shadow cursor-pointer group">
             <CardContent className="pt-6">
               <div className="flex items-center justify-between">
@@ -51,12 +76,12 @@ export function DigestViewer({ digest }: DigestViewerProps) {
                 <Briefcase className="h-8 w-8 text-muted-foreground/30 group-hover:text-primary transition-colors" />
               </div>
               <div className="text-xs text-muted-foreground mt-2 group-hover:text-primary transition-colors">
-                Browse all jobs →
+                Browse jobs in this digest
               </div>
             </CardContent>
           </Card>
         </Link>
-        <Link href="/companies">
+        <Link href={companiesHref}>
           <Card className="hover:shadow-md transition-shadow cursor-pointer group">
             <CardContent className="pt-6">
               <div className="flex items-center justify-between">
@@ -67,7 +92,7 @@ export function DigestViewer({ digest }: DigestViewerProps) {
                 <Building2 className="h-8 w-8 text-muted-foreground/30 group-hover:text-primary transition-colors" />
               </div>
               <div className="text-xs text-muted-foreground mt-2 group-hover:text-primary transition-colors">
-                View all companies →
+                View all companies
               </div>
             </CardContent>
           </Card>
@@ -103,28 +128,71 @@ export function DigestViewer({ digest }: DigestViewerProps) {
                   </tr>
                 </thead>
                 <tbody>
-                  {industryTrends.map((trend, idx) => (
-                    <tr key={idx} className="border-b last:border-b-0">
-                      <td className="py-2.5 pr-4 font-medium">
-                        {trend.trend}
-                      </td>
-                      <td className="py-2.5 px-3 text-right tabular-nums">
-                        {trend.jobCount}
-                      </td>
-                      <td className="py-2.5 pl-4">
-                        <div className="flex flex-wrap gap-1">
-                          {trend.companies.map((company) => (
-                            <span
-                              key={company}
-                              className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-muted text-muted-foreground"
+                  {industryTrends.map((trend, idx) => {
+                    const themeId = getThemeIdByLabel(trend.trend);
+                    const trendHref = themeId
+                      ? buildDigestLink({
+                          surface: "app",
+                          digestId,
+                          target: { kind: "jobs", theme: themeId, inDigest: true },
+                        })
+                      : null;
+                    return (
+                      <tr key={idx} className="border-b last:border-b-0">
+                        <td className="py-2.5 pr-4 font-medium">
+                          {trendHref ? (
+                            <Link
+                              href={trendHref}
+                              className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
                             >
-                              {company}
-                            </span>
-                          ))}
-                        </div>
-                      </td>
-                    </tr>
-                  ))}
+                              {trend.trend}
+                            </Link>
+                          ) : (
+                            trend.trend
+                          )}
+                        </td>
+                        <td className="py-2.5 px-3 text-right tabular-nums">
+                          {trend.jobCount}
+                        </td>
+                        <td className="py-2.5 pl-4">
+                          <div className="flex flex-wrap gap-1">
+                            {trend.companies.map((companyName) => {
+                              const slug = findCompanySlug(digest.companies, companyName);
+                              if (!slug) {
+                                return (
+                                  <span
+                                    key={companyName}
+                                    className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-muted text-muted-foreground"
+                                  >
+                                    {companyName}
+                                  </span>
+                                );
+                              }
+                              const badgeHref = buildDigestLink({
+                                surface: "app",
+                                digestId,
+                                target: {
+                                  kind: "jobs",
+                                  company: slug,
+                                  ...(themeId ? { theme: themeId } : {}),
+                                  inDigest: true,
+                                },
+                              });
+                              return (
+                                <Link
+                                  key={companyName}
+                                  href={badgeHref}
+                                  className="inline-flex items-center px-2 py-0.5 rounded-full text-xs bg-muted text-muted-foreground hover:bg-muted/70 hover:text-foreground transition-colors"
+                                >
+                                  {companyName}
+                                </Link>
+                              );
+                            })}
+                          </div>
+                        </td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
@@ -143,31 +211,68 @@ export function DigestViewer({ digest }: DigestViewerProps) {
           </CardHeader>
           <CardContent>
             <div className="space-y-4">
-              {strategySignals.map((signal, idx) => (
-                <div key={idx} className="border rounded-lg p-4">
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1">
-                      <div className="font-semibold">{signal.company}</div>
-                      <div className="text-sm text-muted-foreground mt-1">
-                        {signal.signal}
+              {strategySignals.map((signal, idx) => {
+                const signalSlug = findCompanySlug(digest.companies, signal.company);
+                const companyHref = signalSlug
+                  ? buildDigestLink({
+                      surface: "app",
+                      digestId,
+                      target: { kind: "company", slug: signalSlug },
+                    })
+                  : null;
+                const signalHref = signalSlug
+                  ? buildDigestLink({
+                      surface: "app",
+                      digestId,
+                      target: { kind: "jobs", company: signalSlug, inDigest: true },
+                    })
+                  : null;
+                return (
+                  <div key={idx} className="border rounded-lg p-4">
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1">
+                        <div className="font-semibold">
+                          {companyHref ? (
+                            <Link
+                              href={companyHref}
+                              className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+                            >
+                              {signal.company}
+                            </Link>
+                          ) : (
+                            signal.company
+                          )}
+                        </div>
+                        <div className="text-sm text-muted-foreground mt-1">
+                          {signalHref ? (
+                            <Link
+                              href={signalHref}
+                              className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+                            >
+                              {signal.signal}
+                            </Link>
+                          ) : (
+                            signal.signal
+                          )}
+                        </div>
+                        <div className="text-sm mt-2">{signal.detail}</div>
+                        <div className="text-sm text-muted-foreground mt-2">
+                          {signal.interpretation}
+                        </div>
                       </div>
-                      <div className="text-sm mt-2">{signal.detail}</div>
-                      <div className="text-sm text-muted-foreground mt-2">
-                        {signal.interpretation}
-                      </div>
+                      <span className={`px-2 py-1 rounded text-xs font-medium ${
+                        signal.alignment === "aligned"
+                          ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+                          : signal.alignment === "divergent"
+                          ? "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200"
+                          : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
+                      }`}>
+                        {signal.alignment}
+                      </span>
                     </div>
-                    <span className={`px-2 py-1 rounded text-xs font-medium ${
-                      signal.alignment === "aligned" 
-                        ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
-                        : signal.alignment === "divergent"
-                        ? "bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200"
-                        : "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200"
-                    }`}>
-                      {signal.alignment}
-                    </span>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </CardContent>
         </Card>
@@ -213,36 +318,150 @@ export function DigestViewer({ digest }: DigestViewerProps) {
           </CardHeader>
           <CardContent>
             <div className="space-y-6">
-              {digest.companies.map((company) => (
-                <div key={company.company_id} className="border-b last:border-b-0 pb-6 last:pb-0">
-                  <div className="flex items-start justify-between mb-2">
-                    <Link 
-                      href={`/companies/${company.company_slug}`}
-                      className="font-semibold text-lg hover:underline flex items-center gap-2"
-                    >
-                      <Building2 className="h-4 w-4" />
-                      {company.company_name}
-                    </Link>
-                  </div>
-                  <div className="space-y-2">
-                    <div className="font-medium">{company.ai_commentary.headline}</div>
-                    <div className="text-sm text-muted-foreground">
-                      {company.ai_commentary.body}
-                    </div>
-                    <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground mt-2">
-                      <Link 
-                        href={`/companies/${company.company_slug}`}
-                        className="hover:text-primary transition-colors"
+              {digest.companies.map((company) => {
+                const slug = company.company_slug;
+                const primaryFocus =
+                  company.hiring_pattern.weekly_role_themes[0]?.label || "Various roles";
+                const primaryFocusThemeId =
+                  company.hiring_pattern.weekly_role_themes[0]?.id ?? null;
+                const newThemes = company.hiring_pattern.new_themes;
+                const isContinuing = company.hiring_pattern.continuity === "continuing";
+                const hasNewThemes = newThemes.length > 0;
+
+                const companyHref = buildDigestLink({
+                  surface: "app",
+                  digestId,
+                  target: { kind: "company", slug },
+                });
+                const newJobsHref = buildDigestLink({
+                  surface: "app",
+                  digestId,
+                  target: { kind: "jobs", company: slug, inDigest: true },
+                });
+                const yearTotalHref = buildDigestLink({
+                  surface: "app",
+                  digestId,
+                  target: { kind: "jobs", company: slug, from: yearStartIso },
+                });
+                const focusHref = primaryFocusThemeId
+                  ? buildDigestLink({
+                      surface: "app",
+                      digestId,
+                      target: {
+                        kind: "jobs",
+                        company: slug,
+                        theme: primaryFocusThemeId,
+                        inDigest: true,
+                      },
+                    })
+                  : null;
+
+                return (
+                  <div key={company.company_id} className="border-b last:border-b-0 pb-6 last:pb-0">
+                    <div className="flex items-start justify-between mb-2">
+                      <Link
+                        href={companyHref}
+                        className="font-semibold text-lg hover:underline flex items-center gap-2"
                       >
-                        {company.new_job_count} new jobs →
+                        <Building2 className="h-4 w-4" />
+                        {company.company_name}
                       </Link>
-                      <span>{company.current_open_job_count} open now</span>
-                      <span>{company.year_to_date_job_count} year-to-date before this week</span>
-                      <span>Focus: {company.hiring_pattern.weekly_role_themes[0]?.label || "Various roles"}</span>
+                    </div>
+                    <div className="space-y-2">
+                      <div className="font-medium">{company.ai_commentary.headline}</div>
+                      <div className="text-sm text-muted-foreground">
+                        {company.ai_commentary.body}
+                      </div>
+                      <div className="text-sm text-muted-foreground">
+                        {isContinuing ? (
+                          `This continues an existing hiring pattern for ${company.company_name}.`
+                        ) : hasNewThemes ? (
+                          <>
+                            {"New this week: "}
+                            {newThemes.map((themeLabel, idx) => {
+                              const themeId = getThemeIdByLabel(themeLabel);
+                              const separator = idx < newThemes.length - 1 ? ", " : ".";
+                              if (!themeId) {
+                                return (
+                                  <span key={`${themeLabel}-${idx}`}>
+                                    {themeLabel}
+                                    {separator}
+                                  </span>
+                                );
+                              }
+                              const themeHref = buildDigestLink({
+                                surface: "app",
+                                digestId,
+                                target: {
+                                  kind: "jobs",
+                                  company: slug,
+                                  theme: themeId,
+                                  inDigest: true,
+                                },
+                              });
+                              return (
+                                <span key={`${themeLabel}-${idx}`}>
+                                  <Link
+                                    href={themeHref}
+                                    className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+                                  >
+                                    {themeLabel}
+                                  </Link>
+                                  {separator}
+                                </span>
+                              );
+                            })}
+                          </>
+                        ) : (
+                          "This week's mix is close to the company's recent hiring pattern."
+                        )}
+                      </div>
+                      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground mt-2">
+                        <span>
+                          New jobs:{" "}
+                          <Link
+                            href={newJobsHref}
+                            className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+                          >
+                            {company.new_job_count}
+                          </Link>
+                        </span>
+                        <span>
+                          Open now:{" "}
+                          <Link
+                            href={companyHref}
+                            className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+                          >
+                            {company.current_open_job_count}
+                          </Link>
+                        </span>
+                        <span>
+                          {yearLabel} total:{" "}
+                          <Link
+                            href={yearTotalHref}
+                            className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+                          >
+                            {company.year_to_date_job_count}
+                          </Link>
+                        </span>
+                        <span>
+                          Focus:{" "}
+                          {focusHref ? (
+                            <Link
+                              href={focusHref}
+                              className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-foreground"
+                            >
+                              {primaryFocus}
+                            </Link>
+                          ) : (
+                            primaryFocus
+                          )}
+                        </span>
+                      </div>
                     </div>
                   </div>
-                </div>
-              ))}
+                );
+              })}
             </div>
           </CardContent>
         </Card>

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "1.8.0",
+    "date": "2026-04-14",
+    "changes": [
+      { "type": "feature", "description": "Weekly digest emails are now interactive: every company name, role theme, and stat number links through to a matching pre-filtered view in the app, with a context banner on /jobs that explains which digest slice you are viewing." },
+      { "type": "improvement", "description": "Deep links from email now preserve the destination through login, so clicking a company or theme while signed out lands on the intended page after Google sign-in." },
+      { "type": "improvement", "description": "The in-app digest viewer at /digests/[id] mirrors the email's link affordances one-to-one, so the same theme, company, and stat tokens are clickable in both surfaces." }
+    ]
+  },
+  {
     "version": "1.7.3",
     "date": "2026-04-12",
     "changes": [

--- a/web/hooks/use-google-auth.ts
+++ b/web/hooks/use-google-auth.ts
@@ -15,17 +15,18 @@ export function useGoogleAuth() {
       const supabase = createClient();
 
       // Build absolute redirect URL for OAuth callback.
-      // If `next` is provided (e.g. from an email deep link), append it so
-      // the callback route can send the user back to their intended page.
+      // NOTE: We keep redirectTo free of query params so it matches Supabase's
+      // allowed redirect URLs exactly. The `next` destination is stashed in a
+      // short-lived cookie that the callback route reads after code exchange.
       const safeNext =
         next && next.startsWith("/") && !next.startsWith("//") ? next : null;
-      const callbackPath = safeNext
-        ? `/auth/callback?next=${encodeURIComponent(safeNext)}`
-        : "/auth/callback";
+      if (safeNext && typeof document !== "undefined") {
+        document.cookie = `auth_next=${encodeURIComponent(safeNext)}; path=/; SameSite=Lax; max-age=300`;
+      }
       const redirectTo =
         typeof window !== "undefined"
-          ? `${window.location.protocol}//${window.location.host}${callbackPath}`
-          : callbackPath;
+          ? `${window.location.protocol}//${window.location.host}/auth/callback`
+          : "/auth/callback";
 
       console.log("Initiating OAuth with redirectTo:", redirectTo);
 

--- a/web/hooks/use-google-auth.ts
+++ b/web/hooks/use-google-auth.ts
@@ -7,18 +7,25 @@ export function useGoogleAuth() {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function signInWithGoogle() {
+  async function signInWithGoogle(next?: string | null) {
     try {
       setIsLoading(true);
       setError(null);
 
       const supabase = createClient();
 
-      // Build absolute redirect URL for OAuth callback
+      // Build absolute redirect URL for OAuth callback.
+      // If `next` is provided (e.g. from an email deep link), append it so
+      // the callback route can send the user back to their intended page.
+      const safeNext =
+        next && next.startsWith("/") && !next.startsWith("//") ? next : null;
+      const callbackPath = safeNext
+        ? `/auth/callback?next=${encodeURIComponent(safeNext)}`
+        : "/auth/callback";
       const redirectTo =
         typeof window !== "undefined"
-          ? `${window.location.protocol}//${window.location.host}/auth/callback`
-          : "/auth/callback";
+          ? `${window.location.protocol}//${window.location.host}${callbackPath}`
+          : callbackPath;
 
       console.log("Initiating OAuth with redirectTo:", redirectTo);
 

--- a/web/lib/analysis/digest.ts
+++ b/web/lib/analysis/digest.ts
@@ -13,6 +13,13 @@ import {
   type WeeklyDigestAiConfig,
 } from "@/lib/ai/prompt-config";
 import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  aggregateRoleThemes,
+  type RoleThemeSummary,
+} from "@/lib/analysis/role-themes";
+
+export type { RoleThemeSummary } from "@/lib/analysis/role-themes";
+export { aggregateRoleThemes } from "@/lib/analysis/role-themes";
 
 export interface WeeklyJob {
   id: string;
@@ -60,13 +67,6 @@ interface HistoricalJobRow {
 export interface DigestCommentary {
   headline: string;
   body: string;
-}
-
-export interface RoleThemeSummary {
-  id: string;
-  label: string;
-  count: number;
-  sample_titles: string[];
 }
 
 export interface WeeklyDigestCompanyInput {
@@ -155,33 +155,6 @@ interface HistoricalPatternContext {
   yearToDateRoleThemes: RoleThemeSummary[];
 }
 
-const ROLE_THEME_RULES = [
-  { id: "ai_ml_risk", label: "AI and machine learning for risk", keywords: ["machine learning", "ml ", " ai ", "artificial intelligence", "decision science", "model risk", "risk model", "credit model", "fraud model"] },
-  { id: "quality_engineering", label: "Quality engineering", keywords: ["quality engineer", "qa engineer", "software development engineer in test", "sdet", "test automation", "qa automation"] },
-  { id: "risk_fraud", label: "Risk and fraud", keywords: ["risk", "fraud", "credit", "collections", "restructuring", "underwriting", "special loans"] },
-  { id: "lending_mortgage", label: "Lending and mortgage", keywords: ["mortgage", "lending", "underwriter", "loan", "servicing"] },
-  { id: "sales", label: "Sales", keywords: ["sales", "business development", "account executive", "account manager", "relationship manager", "regional manager"] },
-  { id: "in_person_sales", label: "In-person sales", keywords: ["mall", "kiosk", "retail", "field sales", "sales representative", "brand ambassador", "grocery", "outlet"] },
-  { id: "operations", label: "Operations", keywords: ["operations", "fulfillment", "coordinator", "specialist", "analyst", "servicing"] },
-  { id: "support", label: "Support and customer service", keywords: ["support", "customer service", "customer experience", "contact centre", "call centre", "service representative"] },
-  { id: "engineering", label: "Engineering", keywords: ["engineer", "developer", "software", "platform", "backend", "frontend", "full stack", "full-stack", "devops", "sre"] },
-  { id: "product_design", label: "Product and design", keywords: ["product manager", "product owner", "designer", "ux", "ui", "research"] },
-  { id: "finance", label: "Finance", keywords: ["finance", "accounting", "controller", "treasury", "fp&a", "financial analyst"] },
-  { id: "compliance_legal", label: "Compliance and legal", keywords: ["compliance", "legal", "aml", "kyc", "regulatory", "privacy"] },
-  { id: "leadership", label: "Leadership", keywords: ["vp", "vice president", "director", "head of", "chief", "principal"] },
-] as const;
-
-const DEPARTMENT_THEME_MAP: Record<string, string> = {
-  Engineering: "engineering",
-  Sales: "sales",
-  Product: "product_design",
-  Operations: "operations",
-  Finance: "finance",
-  Support: "support",
-  "Customer Success": "support",
-  Legal: "compliance_legal",
-};
-
 function getWeekBoundaries(): { weekStart: Date; weekEnd: Date } {
   const now = new Date();
   const dayOfWeek = now.getUTCDay();
@@ -234,67 +207,6 @@ function getTopTech(jobs: WeeklyJob[], topN: number = 3): string[] {
     .sort((a, b) => b[1] - a[1])
     .slice(0, topN)
     .map(([tech]) => tech);
-}
-
-function normalizeTitle(text: string): string {
-  return ` ${text.toLowerCase().replace(/[^\w\s]/g, " ")} `.replace(/\s+/g, " ");
-}
-
-function inferRoleThemeIds(title: string, department?: string | null): string[] {
-  const normalized = normalizeTitle(title);
-  const matches: string[] = ROLE_THEME_RULES
-    .map((rule) => ({
-      id: rule.id,
-      score: rule.keywords.reduce(
-        (total, keyword) => total + (normalized.includes(normalizeTitle(keyword)) ? 1 : 0),
-        0
-      ),
-    }))
-    .filter((entry) => entry.score > 0)
-    .sort((a, b) => b.score - a.score)
-    .map((entry) => entry.id);
-
-  const departmentTheme = department ? DEPARTMENT_THEME_MAP[department] : undefined;
-  if (departmentTheme && !matches.includes(departmentTheme)) {
-    matches.push(departmentTheme);
-  }
-
-  if (matches.length === 0 && departmentTheme) {
-    return [departmentTheme];
-  }
-
-  return matches.slice(0, 2);
-}
-
-export function aggregateRoleThemes(
-  jobs: Array<Pick<WeeklyJob, "title" | "standardized_department">>
-): RoleThemeSummary[] {
-  const themeMap = new Map<string, { count: number; titles: string[] }>();
-
-  for (const job of jobs) {
-    const themeIds = inferRoleThemeIds(job.title, job.standardized_department);
-    for (const themeId of themeIds) {
-      const rule = ROLE_THEME_RULES.find((candidate) => candidate.id === themeId);
-      if (!rule) continue;
-
-      const current = themeMap.get(themeId) ?? { count: 0, titles: [] };
-      current.count += 1;
-      if (!current.titles.includes(job.title) && current.titles.length < 3) {
-        current.titles.push(job.title);
-      }
-      themeMap.set(themeId, current);
-    }
-  }
-
-  return Array.from(themeMap.entries())
-    .map(([id, value]) => ({
-      id,
-      label: ROLE_THEME_RULES.find((rule) => rule.id === id)?.label ?? id,
-      count: value.count,
-      sample_titles: value.titles,
-    }))
-    .sort((a, b) => b.count - a.count)
-    .slice(0, 5);
 }
 
 function formatRoleThemesForPrompt(themes: RoleThemeSummary[]): string {

--- a/web/lib/analysis/role-themes.ts
+++ b/web/lib/analysis/role-themes.ts
@@ -1,0 +1,167 @@
+/**
+ * Role Themes — shared source of truth.
+ *
+ * Role themes are the coarse-grained "kinds of roles" we talk about in the
+ * weekly digest (e.g. "Engineering", "Risk and fraud", "AI and machine
+ * learning for risk"). They are derived at query time from a job's title and
+ * standardized department — we do NOT persist theme IDs on job rows, so the
+ * digest generator, the jobs list filter, and any other consumer must all
+ * import from this module to stay consistent.
+ *
+ * Usage:
+ *   import { classifyJob, getThemeLabel, ROLE_THEME_RULES } from "@/lib/analysis/role-themes";
+ *   const themeIds = classifyJob(job.title, job.standardized_department);
+ *   const label = getThemeLabel("ai_ml_risk"); // -> "AI and machine learning for risk"
+ */
+
+export const ROLE_THEME_RULES = [
+  { id: "ai_ml_risk", label: "AI and machine learning for risk", keywords: ["machine learning", "ml ", " ai ", "artificial intelligence", "decision science", "model risk", "risk model", "credit model", "fraud model"] },
+  { id: "quality_engineering", label: "Quality engineering", keywords: ["quality engineer", "qa engineer", "software development engineer in test", "sdet", "test automation", "qa automation"] },
+  { id: "risk_fraud", label: "Risk and fraud", keywords: ["risk", "fraud", "credit", "collections", "restructuring", "underwriting", "special loans"] },
+  { id: "lending_mortgage", label: "Lending and mortgage", keywords: ["mortgage", "lending", "underwriter", "loan", "servicing"] },
+  { id: "sales", label: "Sales", keywords: ["sales", "business development", "account executive", "account manager", "relationship manager", "regional manager"] },
+  { id: "in_person_sales", label: "In-person sales", keywords: ["mall", "kiosk", "retail", "field sales", "sales representative", "brand ambassador", "grocery", "outlet"] },
+  { id: "operations", label: "Operations", keywords: ["operations", "fulfillment", "coordinator", "specialist", "analyst", "servicing"] },
+  { id: "support", label: "Support and customer service", keywords: ["support", "customer service", "customer experience", "contact centre", "call centre", "service representative"] },
+  { id: "engineering", label: "Engineering", keywords: ["engineer", "developer", "software", "platform", "backend", "frontend", "full stack", "full-stack", "devops", "sre"] },
+  { id: "product_design", label: "Product and design", keywords: ["product manager", "product owner", "designer", "ux", "ui", "research"] },
+  { id: "finance", label: "Finance", keywords: ["finance", "accounting", "controller", "treasury", "fp&a", "financial analyst"] },
+  { id: "compliance_legal", label: "Compliance and legal", keywords: ["compliance", "legal", "aml", "kyc", "regulatory", "privacy"] },
+  { id: "leadership", label: "Leadership", keywords: ["vp", "vice president", "director", "head of", "chief", "principal"] },
+] as const;
+
+export type RoleThemeId = (typeof ROLE_THEME_RULES)[number]["id"];
+
+export interface RoleThemeSummary {
+  id: string;
+  label: string;
+  count: number;
+  sample_titles: string[];
+}
+
+const DEPARTMENT_THEME_MAP: Record<string, string> = {
+  Engineering: "engineering",
+  Sales: "sales",
+  Product: "product_design",
+  Operations: "operations",
+  Finance: "finance",
+  Support: "support",
+  "Customer Success": "support",
+  Legal: "compliance_legal",
+};
+
+const THEME_LABEL_INDEX: Record<string, string> = ROLE_THEME_RULES.reduce(
+  (acc, rule) => {
+    acc[rule.id] = rule.label;
+    return acc;
+  },
+  {} as Record<string, string>
+);
+
+/**
+ * Normalize a title string for keyword matching: lowercase, punctuation
+ * replaced with spaces, and padded with a leading/trailing space so that
+ * keyword tokens like " ai " match word boundaries without false positives.
+ */
+export function normalizeTitle(text: string): string {
+  return ` ${text.toLowerCase().replace(/[^\w\s]/g, " ")} `.replace(/\s+/g, " ");
+}
+
+/**
+ * Classify a job into up to 2 role themes based on title keyword scoring,
+ * with department as a secondary signal. Returns theme IDs sorted by score.
+ */
+export function classifyJob(
+  title: string,
+  department?: string | null
+): string[] {
+  const normalized = normalizeTitle(title);
+  const matches: string[] = ROLE_THEME_RULES.map((rule) => ({
+    id: rule.id,
+    score: rule.keywords.reduce(
+      (total, keyword) => total + (normalized.includes(normalizeTitle(keyword)) ? 1 : 0),
+      0
+    ),
+  }))
+    .filter((entry) => entry.score > 0)
+    .sort((a, b) => b.score - a.score)
+    .map((entry) => entry.id);
+
+  const departmentTheme = department ? DEPARTMENT_THEME_MAP[department] : undefined;
+  if (departmentTheme && !matches.includes(departmentTheme)) {
+    matches.push(departmentTheme);
+  }
+
+  if (matches.length === 0 && departmentTheme) {
+    return [departmentTheme];
+  }
+
+  return matches.slice(0, 2);
+}
+
+/**
+ * Does this job match the given theme? Uses the same classification logic.
+ */
+export function jobMatchesTheme(
+  themeId: string,
+  title: string,
+  department?: string | null
+): boolean {
+  return classifyJob(title, department).includes(themeId);
+}
+
+/**
+ * Look up a theme's human label by ID. Returns the ID itself if unknown so
+ * that callers never render a blank string.
+ */
+export function getThemeLabel(themeId: string): string {
+  return THEME_LABEL_INDEX[themeId] ?? themeId;
+}
+
+/**
+ * Reverse lookup: given a theme label (possibly as it appears in the digest
+ * UI), find the theme ID. Used when wiring legacy label strings from
+ * industry_trends back into filterable URLs.
+ */
+export function getThemeIdByLabel(label: string): string | null {
+  const normalized = label.trim().toLowerCase();
+  const match = ROLE_THEME_RULES.find(
+    (rule) => rule.label.toLowerCase() === normalized
+  );
+  return match?.id ?? null;
+}
+
+/**
+ * Aggregate theme counts over a collection of jobs. Returns the top 5 themes
+ * sorted by count, each with up to 3 sample titles.
+ */
+export function aggregateRoleThemes(
+  jobs: Array<{ title: string; standardized_department: string | null }>
+): RoleThemeSummary[] {
+  const themeMap = new Map<string, { count: number; titles: string[] }>();
+
+  for (const job of jobs) {
+    const themeIds = classifyJob(job.title, job.standardized_department);
+    for (const themeId of themeIds) {
+      const rule = ROLE_THEME_RULES.find((candidate) => candidate.id === themeId);
+      if (!rule) continue;
+
+      const current = themeMap.get(themeId) ?? { count: 0, titles: [] };
+      current.count += 1;
+      if (!current.titles.includes(job.title) && current.titles.length < 3) {
+        current.titles.push(job.title);
+      }
+      themeMap.set(themeId, current);
+    }
+  }
+
+  return Array.from(themeMap.entries())
+    .map(([id, value]) => ({
+      id,
+      label: getThemeLabel(id),
+      count: value.count,
+      sample_titles: value.titles,
+    }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 5);
+}

--- a/web/lib/email/links.ts
+++ b/web/lib/email/links.ts
@@ -1,0 +1,138 @@
+/**
+ * Digest Link Builder — single source of truth for URLs that appear in
+ * weekly digest emails and the in-app digest viewer.
+ *
+ * Every link the reader can click from a digest — in email or in app — is
+ * constructed here. The same targets exist in both surfaces so a reader
+ * sees the same affordances whether they're reading the email or browsing
+ * the archived digest at `/digests/{id}`.
+ *
+ * Email calls get UTM parameters appended automatically; in-app calls
+ * return clean relative paths. Both share the same path/query contract.
+ *
+ * Usage:
+ *   // Email (absolute URL with UTM):
+ *   buildDigestLink({ surface: "email", digestId, target: { kind: "company", slug: "wealthsimple" } })
+ *   // In-app (relative path, no UTM):
+ *   buildDigestLink({ surface: "app", digestId, target: { kind: "jobs", theme: "ai_ml_risk", company: "wealthsimple", inDigest: true } })
+ */
+
+export const DEFAULT_APP_URL = "https://fintech-talent-brief.vercel.app";
+
+/** A jobs-list deep link — filters the /jobs page by theme/company/digest slice. */
+export interface JobsLinkTarget {
+  kind: "jobs";
+  /** Role theme id from @/lib/analysis/role-themes (e.g. "ai_ml_risk"). */
+  theme?: string;
+  /** Company slug — matches companies.slug. */
+  company?: string;
+  /** When true, scope /jobs to the job ids captured in this digest's snapshot. */
+  inDigest?: boolean;
+  /** ISO date (inclusive) lower bound on first_seen_date. */
+  from?: string;
+  /** ISO date (inclusive) upper bound on first_seen_date. */
+  to?: string;
+}
+
+/** A single-company detail page link (`/companies/[slug]`). */
+export interface CompanyLinkTarget {
+  kind: "company";
+  slug: string;
+}
+
+/** The full digest detail page (`/digests/[id]`). */
+export interface DigestLinkTarget {
+  kind: "digest";
+}
+
+/** The all-companies list (`/companies`). */
+export interface CompaniesIndexLinkTarget {
+  kind: "companies";
+}
+
+/** The releases / changelog page. */
+export interface ReleasesLinkTarget {
+  kind: "releases";
+}
+
+export type DigestLinkKind =
+  | JobsLinkTarget
+  | CompanyLinkTarget
+  | DigestLinkTarget
+  | CompaniesIndexLinkTarget
+  | ReleasesLinkTarget;
+
+export interface BuildDigestLinkOptions {
+  /** "email" = absolute URL + UTM; "app" = relative path, no UTM. */
+  surface: "email" | "app";
+  /** Digest id this link belongs to — used for the `inDigest` filter and UTM content tag. */
+  digestId: string;
+  /** Override the base origin for "email" surface (defaults to env/public URL). */
+  appUrl?: string;
+  target: DigestLinkKind;
+}
+
+/**
+ * Resolve the base origin for absolute email links.
+ */
+export function getEmailBaseUrl(appUrl?: string): string {
+  if (appUrl) return appUrl.replace(/\/$/, "");
+  if (typeof process !== "undefined" && process.env?.NEXT_PUBLIC_APP_URL) {
+    return process.env.NEXT_PUBLIC_APP_URL.replace(/\/$/, "");
+  }
+  return DEFAULT_APP_URL;
+}
+
+function buildJobsPath(target: JobsLinkTarget, digestId: string): string {
+  const params = new URLSearchParams();
+  if (target.theme) params.set("theme", target.theme);
+  if (target.company) params.set("company", target.company);
+  if (target.inDigest) params.set("inDigest", digestId);
+  if (target.from) params.set("from", target.from);
+  if (target.to) params.set("to", target.to);
+  const query = params.toString();
+  return query ? `/jobs?${query}` : "/jobs";
+}
+
+function resolvePath(target: DigestLinkKind, digestId: string): string {
+  switch (target.kind) {
+    case "jobs":
+      return buildJobsPath(target, digestId);
+    case "company":
+      return `/companies/${target.slug}`;
+    case "companies":
+      return "/companies";
+    case "digest":
+      return `/digests/${digestId}`;
+    case "releases":
+      return "/releases";
+  }
+}
+
+function appendUtm(path: string, digestId: string): string {
+  const [pathname, search] = path.split("?", 2);
+  const params = new URLSearchParams(search ?? "");
+  params.set("utm_source", "digest");
+  params.set("utm_medium", "email");
+  params.set("utm_campaign", "weekly");
+  params.set("utm_content", digestId);
+  return `${pathname}?${params.toString()}`;
+}
+
+/**
+ * Build a URL to a digest-relevant destination.
+ *
+ * Email surface returns absolute URLs with UTM params; app surface returns
+ * clean relative paths for Next.js <Link> navigation.
+ */
+export function buildDigestLink(options: BuildDigestLinkOptions): string {
+  const { surface, digestId, target, appUrl } = options;
+  const path = resolvePath(target, digestId);
+
+  if (surface === "app") {
+    return path;
+  }
+
+  const base = getEmailBaseUrl(appUrl);
+  return `${base}${appendUtm(path, digestId)}`;
+}

--- a/web/lib/email/templates/weekly-digest.tsx
+++ b/web/lib/email/templates/weekly-digest.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   Html,
   Head,
@@ -11,12 +12,26 @@ import {
   Hr,
 } from "@react-email/components";
 import type { WeeklyDigest, CompanyWeeklySummary, GlobalSummary } from "@/lib/analysis/digest";
+import { buildDigestLink } from "@/lib/email/links";
+import { getThemeIdByLabel } from "@/lib/analysis/role-themes";
 
 interface WeeklyDigestEmailProps {
   digest: WeeklyDigest;
   digestId: string;  // NEW - for deep linking
   appUrl?: string;
   version?: string;
+}
+
+/**
+ * Look up a company slug by its display name. Used to resolve strategy signal
+ * / industry trend company references back into linkable slugs.
+ */
+function findCompanySlug(
+  companies: CompanyWeeklySummary[],
+  companyName: string
+): string | null {
+  const match = companies.find((entry) => entry.company_name === companyName);
+  return match?.company_slug ?? null;
 }
 
 /**
@@ -68,15 +83,51 @@ function GlobalSummarySection({ summary }: { summary: GlobalSummary }) {
 /**
  * Company section component
  */
-function CompanySection({ company, appUrl = "https://fintech-talent-brief.vercel.app" }: { company: CompanyWeeklySummary; appUrl?: string }) {
+function CompanySection({
+  company,
+  digestId,
+  yearStartIso,
+  appUrl = "https://fintech-talent-brief.vercel.app",
+}: {
+  company: CompanyWeeklySummary;
+  digestId: string;
+  yearStartIso: string;
+  appUrl?: string;
+}) {
   const primaryFocus = getLeadingTheme(company);
-  const companyUrl = `${appUrl}/companies/${company.company_slug}`;
-  const continuityLine =
-    company.hiring_pattern.continuity === "continuing"
-      ? `This continues an existing hiring pattern for ${company.company_name}.`
-      : company.hiring_pattern.new_themes.length > 0
-        ? `New this week: ${company.hiring_pattern.new_themes.join(", ")}.`
-        : "This week's mix is close to the company's recent hiring pattern.";
+  const primaryFocusThemeId = company.hiring_pattern.weekly_role_themes[0]?.id ?? null;
+  const slug = company.company_slug;
+  const companyUrl = buildDigestLink({
+    surface: "email",
+    digestId,
+    appUrl,
+    target: { kind: "company", slug },
+  });
+  const newJobsUrl = buildDigestLink({
+    surface: "email",
+    digestId,
+    appUrl,
+    target: { kind: "jobs", company: slug, inDigest: true },
+  });
+  const yearTotalUrl = buildDigestLink({
+    surface: "email",
+    digestId,
+    appUrl,
+    target: { kind: "jobs", company: slug, from: yearStartIso },
+  });
+  const focusUrl = primaryFocusThemeId
+    ? buildDigestLink({
+        surface: "email",
+        digestId,
+        appUrl,
+        target: { kind: "jobs", company: slug, theme: primaryFocusThemeId, inDigest: true },
+      })
+    : null;
+  const yearLabel = yearStartIso.slice(0, 4);
+
+  const newThemes = company.hiring_pattern.new_themes;
+  const isContinuing = company.hiring_pattern.continuity === "continuing";
+  const hasNewThemes = newThemes.length > 0;
 
   return (
     <Section style={companySection}>
@@ -84,27 +135,80 @@ function CompanySection({ company, appUrl = "https://fintech-talent-brief.vercel
       <Link href={companyUrl} style={{ ...companyName, color: "#000", textDecoration: "none" }}>
         {company.company_name}
       </Link>
-      
+
       {/* AI Headline */}
       <Heading as="h3" style={headline}>
         {company.ai_commentary.headline}
       </Heading>
-      
+
       {/* AI Body */}
       <Text style={bodyText}>
         {company.ai_commentary.body}
       </Text>
 
       <Text style={{ ...statsLine, marginBottom: "12px", color: "#4b5563" }}>
-        {continuityLine}
+        {isContinuing ? (
+          `This continues an existing hiring pattern for ${company.company_name}.`
+        ) : hasNewThemes ? (
+          <>
+            {"New this week: "}
+            {newThemes.map((themeLabel, idx) => {
+              const themeId = getThemeIdByLabel(themeLabel);
+              const separator = idx < newThemes.length - 1 ? ", " : ".";
+              if (!themeId) {
+                return (
+                  <React.Fragment key={`${themeLabel}-${idx}`}>
+                    {themeLabel}
+                    {separator}
+                  </React.Fragment>
+                );
+              }
+              const href = buildDigestLink({
+                surface: "email",
+                digestId,
+                appUrl,
+                target: { kind: "jobs", company: slug, theme: themeId, inDigest: true },
+              });
+              return (
+                <React.Fragment key={`${themeLabel}-${idx}`}>
+                  <Link href={href} style={inlineLink}>
+                    {themeLabel}
+                  </Link>
+                  {separator}
+                </React.Fragment>
+              );
+            })}
+          </>
+        ) : (
+          "This week's mix is close to the company's recent hiring pattern."
+        )}
       </Text>
-      
+
       {/* Stats Footer */}
       <Text style={statsLine}>
-        <span style={statLabel}>New Jobs:</span> {String(company.new_job_count)} | 
-        <span style={statLabel}> Open Now:</span> {String(company.current_open_job_count)} | 
-        <span style={statLabel}> 2026 Total:</span> {String(company.year_to_date_job_count)} | 
-        <span style={statLabel}> Focus:</span> {primaryFocus}
+        <span style={statLabel}>New Jobs:</span>{" "}
+        <Link href={newJobsUrl} style={inlineLink}>
+          {String(company.new_job_count)}
+        </Link>
+        {" | "}
+        <span style={statLabel}>Open Now:</span>{" "}
+        <Link href={companyUrl} style={inlineLink}>
+          {String(company.current_open_job_count)}
+        </Link>
+        {" | "}
+        <span style={statLabel}>{yearLabel} Total:</span>{" "}
+        <Link href={yearTotalUrl} style={inlineLink}>
+          {String(company.year_to_date_job_count)}
+        </Link>
+        {" | "}
+        <span style={statLabel}>Focus:</span>{" "}
+        {focusUrl ? (
+          <Link href={focusUrl} style={inlineLink}>
+            {primaryFocus}
+          </Link>
+        ) : (
+          primaryFocus
+        )}
       </Text>
     </Section>
   );
@@ -118,7 +222,25 @@ function CompanySection({ company, appUrl = "https://fintech-talent-brief.vercel
 export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-talent-brief.vercel.app", version }: WeeklyDigestEmailProps) {
   const dateRange = formatDateRange(digest.week_start, digest.week_end);
   const previewText = `The Fintech Talent Brief: ${digest.total_jobs} new jobs across ${digest.total_companies} companies this week`;
-  const digestUrl = `${appUrl}/digests/${digestId}`;
+  const digestUrl = buildDigestLink({
+    surface: "email",
+    digestId,
+    appUrl,
+    target: { kind: "digest" },
+  });
+  const jobsInDigestUrl = buildDigestLink({
+    surface: "email",
+    digestId,
+    appUrl,
+    target: { kind: "jobs", inDigest: true },
+  });
+  const releasesUrl = buildDigestLink({
+    surface: "email",
+    digestId,
+    appUrl,
+    target: { kind: "releases" },
+  });
+  const yearStartIso = `${new Date(digest.week_end).getUTCFullYear()}-01-01`;
 
   return (
     <Html>
@@ -156,12 +278,16 @@ export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-
               <tbody>
                 <tr>
                   <td style={statCell}>
-                    <Text style={statNumber}>{String(digest.total_jobs)}</Text>
-                    <Text style={statDescription}>New Jobs</Text>
+                    <Link href={jobsInDigestUrl} style={statCellLink}>
+                      <span style={statNumberSpan}>{String(digest.total_jobs)}</span>
+                      <span style={statDescriptionSpan}>New Jobs</span>
+                    </Link>
                   </td>
                   <td style={statCell}>
-                    <Text style={statNumber}>{String(digest.total_companies)}</Text>
-                    <Text style={statDescription}>Companies</Text>
+                    <Link href={digestUrl} style={statCellLink}>
+                      <span style={statNumberSpan}>{String(digest.total_companies)}</span>
+                      <span style={statDescriptionSpan}>Companies</span>
+                    </Link>
                   </td>
                 </tr>
               </tbody>
@@ -176,22 +302,55 @@ export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-
                 <Heading as="h2" style={{ fontSize: "18px", fontWeight: "600", marginBottom: "12px" }}>
                   New This Week
                 </Heading>
-                {digest.strategy_signals.slice(0, 3).map((signal, idx) => (
-                  <div key={idx} style={{ marginBottom: "16px", paddingBottom: "16px", borderBottom: idx < Math.min(digest.strategy_signals!.length - 1, 2) ? "1px solid #e5e7eb" : "none" }}>
-                    <Text style={{ fontWeight: "600", marginBottom: "4px" }}>
-                      {signal.company}
-                    </Text>
-                    <Text style={{ fontSize: "14px", color: "#6b7280", marginBottom: "8px" }}>
-                      {signal.signal}
-                    </Text>
-                    <Text style={{ fontSize: "13px", color: "#374151" }}>
-                      {signal.interpretation}
-                    </Text>
-                  </div>
-                ))}
+                {digest.strategy_signals.slice(0, 3).map((signal, idx) => {
+                  const signalSlug = findCompanySlug(digest.companies, signal.company);
+                  const companyHref = signalSlug
+                    ? buildDigestLink({
+                        surface: "email",
+                        digestId,
+                        appUrl,
+                        target: { kind: "company", slug: signalSlug },
+                      })
+                    : null;
+                  const signalHref = signalSlug
+                    ? buildDigestLink({
+                        surface: "email",
+                        digestId,
+                        appUrl,
+                        target: { kind: "jobs", company: signalSlug, inDigest: true },
+                      })
+                    : null;
+                  return (
+                    <div key={idx} style={{ marginBottom: "16px", paddingBottom: "16px", borderBottom: idx < Math.min(digest.strategy_signals!.length - 1, 2) ? "1px solid #e5e7eb" : "none" }}>
+                      <Text style={{ fontWeight: "600", marginBottom: "4px" }}>
+                        {companyHref ? (
+                          <Link href={companyHref} style={inlineLink}>
+                            {signal.company}
+                          </Link>
+                        ) : (
+                          signal.company
+                        )}
+                      </Text>
+                      <Text style={{ fontSize: "14px", color: "#6b7280", marginBottom: "8px" }}>
+                        {signalHref ? (
+                          <Link href={signalHref} style={inlineLink}>
+                            {signal.signal}
+                          </Link>
+                        ) : (
+                          signal.signal
+                        )}
+                      </Text>
+                      <Text style={{ fontSize: "13px", color: "#374151" }}>
+                        {signal.interpretation}
+                      </Text>
+                    </div>
+                  );
+                })}
                 {digest.strategy_signals.length > 3 && (
                   <Text style={{ fontSize: "12px", color: "#6b7280", marginTop: "8px" }}>
-                    +{digest.strategy_signals.length - 3} more signals in full digest
+                    <Link href={digestUrl} style={inlineLink}>
+                      +{digest.strategy_signals.length - 3} more signals in full digest
+                    </Link>
                   </Text>
                 )}
               </Section>
@@ -218,19 +377,66 @@ export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-
                     </tr>
                   </thead>
                   <tbody>
-                    {digest.industry_trends.slice(0, 5).map((trend, idx) => (
-                      <tr key={idx} style={{ borderBottom: idx < Math.min(digest.industry_trends!.length - 1, 4) ? "1px solid #f3f4f6" : "none" }}>
-                        <td style={{ padding: "8px 8px 8px 0", fontWeight: "500" }}>
-                          {trend.trend}
-                        </td>
-                        <td style={{ padding: "8px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
-                          {String(trend.jobCount)}
-                        </td>
-                        <td style={{ padding: "8px 0 8px 8px", color: "#6b7280" }}>
-                          {trend.companies.join(", ")}
-                        </td>
-                      </tr>
-                    ))}
+                    {digest.industry_trends.slice(0, 5).map((trend, idx) => {
+                      const themeId = getThemeIdByLabel(trend.trend);
+                      const trendHref = themeId
+                        ? buildDigestLink({
+                            surface: "email",
+                            digestId,
+                            appUrl,
+                            target: { kind: "jobs", theme: themeId, inDigest: true },
+                          })
+                        : null;
+                      return (
+                        <tr key={idx} style={{ borderBottom: idx < Math.min(digest.industry_trends!.length - 1, 4) ? "1px solid #f3f4f6" : "none" }}>
+                          <td style={{ padding: "8px 8px 8px 0", fontWeight: "500" }}>
+                            {trendHref ? (
+                              <Link href={trendHref} style={inlineLink}>
+                                {trend.trend}
+                              </Link>
+                            ) : (
+                              trend.trend
+                            )}
+                          </td>
+                          <td style={{ padding: "8px", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>
+                            {String(trend.jobCount)}
+                          </td>
+                          <td style={{ padding: "8px 0 8px 8px", color: "#6b7280" }}>
+                            {trend.companies.map((companyName, companyIdx) => {
+                              const slug = findCompanySlug(digest.companies, companyName);
+                              const separator = companyIdx < trend.companies.length - 1 ? ", " : "";
+                              if (!slug) {
+                                return (
+                                  <React.Fragment key={`${companyName}-${companyIdx}`}>
+                                    {companyName}
+                                    {separator}
+                                  </React.Fragment>
+                                );
+                              }
+                              const href = buildDigestLink({
+                                surface: "email",
+                                digestId,
+                                appUrl,
+                                target: {
+                                  kind: "jobs",
+                                  company: slug,
+                                  ...(themeId ? { theme: themeId } : {}),
+                                  inDigest: true,
+                                },
+                              });
+                              return (
+                                <React.Fragment key={`${companyName}-${companyIdx}`}>
+                                  <Link href={href} style={inlineLink}>
+                                    {companyName}
+                                  </Link>
+                                  {separator}
+                                </React.Fragment>
+                              );
+                            })}
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </Section>
@@ -241,7 +447,13 @@ export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-
 
           {/* Company Sections */}
           {digest.companies.map((company) => (
-            <CompanySection key={company.company_id} company={company} appUrl={appUrl} />
+            <CompanySection
+              key={company.company_id}
+              company={company}
+              digestId={digestId}
+              yearStartIso={yearStartIso}
+              appUrl={appUrl}
+            />
           ))}
 
           {/* No companies message */}
@@ -269,7 +481,7 @@ export function WeeklyDigestEmail({ digest, digestId, appUrl = "https://fintech-
               <Text style={footerVersion}>
                 v{version}
                 {" \u2013 "}
-                <Link href={`${appUrl}/releases`} style={footerVersionLink}>
+                <Link href={releasesUrl} style={footerVersionLink}>
                   See what&apos;s new
                 </Link>
               </Text>
@@ -363,12 +575,33 @@ const statNumber: React.CSSProperties = {
   lineHeight: "1",
 };
 
+/**
+ * Inline (span) variant of statNumber used when the stat sits inside a <Link>
+ * wrapper — react-email's <Text> renders a <p>, which is invalid inside <a>.
+ */
+const statNumberSpan: React.CSSProperties = {
+  color: "#4a69bd",
+  fontSize: "32px",
+  fontWeight: "700",
+  lineHeight: "1",
+  display: "block",
+};
+
 const statDescription: React.CSSProperties = {
   color: "#6b7280",
   fontSize: "12px",
   margin: "8px 0 0",
   textTransform: "uppercase" as const,
   letterSpacing: "0.5px",
+};
+
+const statDescriptionSpan: React.CSSProperties = {
+  color: "#6b7280",
+  fontSize: "12px",
+  marginTop: "8px",
+  textTransform: "uppercase" as const,
+  letterSpacing: "0.5px",
+  display: "block",
 };
 
 const divider: React.CSSProperties = {
@@ -459,6 +692,30 @@ const footerVersionLink: React.CSSProperties = {
   color: "#9ca3af",
   fontSize: "11px",
   textDecoration: "underline",
+};
+
+/**
+ * Subtle inline underline — keeps the text in the existing typographic scale
+ * (color inherits from the parent, gains a muted underline). Used for every
+ * structural deep link inside the email body.
+ */
+const inlineLink: React.CSSProperties = {
+  color: "inherit",
+  textDecoration: "underline",
+  textDecorationColor: "#c0c0c0",
+  textUnderlineOffset: "2px",
+};
+
+/**
+ * Big-number stat cells wrap their contents in a Link. We suppress the
+ * underline so the cell looks visually identical to a non-linked cell; the
+ * clickable affordance comes from the cursor/hover state in email clients
+ * that support it.
+ */
+const statCellLink: React.CSSProperties = {
+  color: "inherit",
+  textDecoration: "none",
+  display: "block",
 };
 
 export default WeeklyDigestEmail;

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.7.3",
+  "version": "1.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -37,11 +37,20 @@ export async function proxy(request: NextRequest) {
   } = await supabase.auth.getUser();
 
   if (!user && pathname !== "/login") {
-    return NextResponse.redirect(new URL("/login", request.url));
+    // Preserve the original destination so that links from emails (and
+    // any other deep link) land where the user intended after logging in.
+    const loginUrl = new URL("/login", request.url);
+    const destination = `${pathname}${request.nextUrl.search}`;
+    if (destination && destination !== "/") {
+      loginUrl.searchParams.set("next", destination);
+    }
+    return NextResponse.redirect(loginUrl);
   }
 
   if (user && pathname === "/login") {
-    return NextResponse.redirect(new URL("/", request.url));
+    const next = request.nextUrl.searchParams.get("next");
+    const safeNext = next && next.startsWith("/") && !next.startsWith("//") ? next : "/";
+    return NextResponse.redirect(new URL(safeNext, request.url));
   }
 
   return response;


### PR DESCRIPTION
Phase 1 of the interactive weekly digest work. Extracts role themes into
a shared module so the digest generator and the /jobs filter can use one
source of truth, adds a single link-builder used by both email and
in-app digest views, and fixes the auth proxy to preserve the
destination path so email deep links survive a login redirect.

- web/lib/analysis/role-themes.ts: new shared module exporting
  ROLE_THEME_RULES, classifyJob, aggregateRoleThemes, getThemeLabel,
  getThemeIdByLabel. digest.ts now re-exports from it.
- web/lib/email/links.ts: new buildDigestLink helper. Single call site
  for every URL that appears in a digest email or the in-app viewer;
  auto-applies UTM params on the email surface.
- web/proxy.ts, web/app/auth/callback/route.ts, web/hooks/use-google-auth.ts,
  web/app/(auth)/login/page.tsx: on an unauthenticated request, the
  proxy now attaches ?next={destination} to /login; the login page and
  Google auth hook forward it through OAuth; the callback validates it
  is a same-origin path before honoring the redirect.

https://claude.ai/code/session_01WSAG4hJyWYMieg3P18ega2