### PR TITLE
AI models: swap pinned previews for `-latest` aliases (v1.9.0)

### DIFF
--- a/.github/ISSUES/102-optimize-llm-calls.md
+++ b/.github/ISSUES/102-optimize-llm-calls.md
@@ -5,7 +5,7 @@ Gemini API calls are duplicated across 12+ modules (analysis libs, API routes, s
 
 ## Current state
 - **Where:** `web/lib/analysis/*` (structure, strategic, company-research, company-insights, categorizer, advanced-strategic, digest), `web/app/api/**/chat/route.ts`, backfill scripts.
-- **Pattern:** Every caller does `const key = process.env.GEMINI_API_KEY` → check → `new GoogleGenerativeAI(key)` → `getGenerativeModel({ model: "gemini-3-flash-preview" | "gemini-pro-latest" })` → `generateContent(...)`.
+- **Pattern:** Every caller does `const key = process.env.GEMINI_API_KEY` → check → `new GoogleGenerativeAI(key)` → `getGenerativeModel({ model: "gemini-flash-latest" | "gemini-pro-latest" })` → `generateContent(...)`.
 - **Inconsistencies:** Mixed error handling (throw vs warn vs skip), differing fallback behavior (Pro→Flash in some places, not others), no shared retries, logging, or cost/token tracking.
 - **Result:** Hard to change models, add rate limiting, mock for tests, or understand usage/cost.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ Vercel runs strict TypeScript checking during builds. Common issues:
 - **Backend**: Python with Click CLI, SQLAlchemy 2.0, BeautifulSoup4
 - **Database**: Supabase (PostgreSQL) with RLS
 - **Auth**: Supabase SSR with Google OAuth
-- **AI**: Gemini 3 Flash/Pro for strategic analysis
+- **AI**: Google Gemini via floating `-latest` aliases (`gemini-flash-latest`, `gemini-pro-latest`) for strategic analysis
 - **Email**: Resend API
 - **Scraping**: Puppeteer Core (serverless) + BeautifulSoup4
 
@@ -198,19 +198,20 @@ Each company needs: `name`, `slug`, `country`, `ats_type`, `ats_identifier`
 
 ## AI Model Requirements
 
-**IMPORTANT: Always use the latest Gemini 3 models. Never use Gemini 2.x or older.**
+**IMPORTANT: Always use the floating `-latest` model aliases. Never pin a versioned or preview model ID.**
+
+Using `-latest` aliases means new model generations roll through without code changes. The tradeoff is that Google may rotate the alias to a preview/experimental release; the Phase-1 comparison harness (`web/scripts/gemini-compare.ts`) and Phase-5 production telemetry are how we detect regressions.
 
 ### Approved Models
-- `gemini-pro-latest` - For advanced analysis with web search/grounding (always uses the latest Pro version)
-- `gemini-3-flash-preview` - For fast, cost-effective analysis
+- `gemini-pro-latest` — Advanced analysis with web search/grounding; deeper reasoning and narrative quality
+- `gemini-flash-latest` — Fast, cost-effective analysis; default for extraction, classification, digest, chat
+- `gemini-flash-lite-latest` — Cheapest tier for high-volume, low-stakes calls (use only where the comparison report confirms ≥95% L1 field agreement)
 
 ### Rules
-1. **Never use Gemini 2.x models** (gemini-2.0-flash, gemini-2.5-*, etc.)
-2. **Never use Gemini 1.x models** (gemini-1.5-pro, gemini-1.5-flash, etc.)
-3. All AI analysis code must use `gemini-3-flash-preview` or `gemini-pro-latest`
-4. Use Pro (`gemini-pro-latest`) for features requiring web search/grounding tools
-5. Use Flash for standard JSON generation and analysis
-
+1. **Never pin a versioned or preview model ID** (e.g. `gemini-3-flash-preview`, `gemini-2.0-flash`, `gemini-1.5-pro`). Always use the `-latest` alias.
+2. All AI code must resolve its model through the `AI_MODEL_OPTIONS` enum in `web/lib/ai/prompt-config.ts` — do not hardcode strings outside that module.
+3. Use Pro (`gemini-pro-latest`) only for features requiring web-search grounding or deep synthesis; Flash covers standard JSON generation and analysis.
+4. When adding a new call site, verify whether an upstream call already enables `googleSearch` grounding — two grounded Pro calls in series cost as much as one and produce duplicate work.
 
 ### Quota Errors
 If you see `limit: 0` quota errors, the API key may need:

--- a/config/settings.yaml
+++ b/config/settings.yaml
@@ -3,7 +3,7 @@ database:
 
 analysis:
   provider: gemini
-  model: gemini-3-flash-preview  # Always use Gemini 3 - never Gemini 2.x or older
+  model: gemini-flash-latest  # Always use the `-latest` alias; do not pin versioned or preview IDs
   temperature: 0.3
   max_tokens: 65536
 

--- a/docs/FUNCTION_CATEGORY_IMPLEMENTATION.md
+++ b/docs/FUNCTION_CATEGORY_IMPLEMENTATION.md
@@ -19,7 +19,7 @@
 2. **`categorizePosting()`** - AI-based, more accurate
    - **Location:** `web/lib/analysis/categorizer.ts`
    - **Input:** Job title + company name + full description
-   - **Method:** Gemini 3 Flash AI analysis
+   - **Method:** Gemini Flash AI analysis
    - **Pros:** More accurate, handles edge cases, consistent
    - **Cons:** API costs, slower, requires description
 
@@ -169,7 +169,7 @@ Respond ONLY with valid JSON.
 - ✅ **Better for ambiguous titles**
 
 **Cons:**
-- ❌ **API costs** (~$0.0001 per job with Gemini 3 Flash)
+- ❌ **API costs** (~$0.0001 per job with Gemini Flash)
 - ❌ **Slower** (API call per job)
 - ❌ **Requires description** (won't work for jobs without descriptions)
 
@@ -245,7 +245,7 @@ function categorizeWithContext(
 
 2. **Already extracting other fields:** We're already calling `extractJobStructure()` for every job (extracts `standardized_department`, `seniority_level`, etc.) - we can add function_category to that same AI call
 
-3. **Cost is minimal:** Gemini 3 Flash is very cheap (~$0.0001 per job). For 10,000 jobs = $1.00
+3. **Cost is minimal:** Gemini Flash is very cheap (~$0.0001 per job). For 10,000 jobs = $1.00
 
 4. **Better user experience:** Users see accurate, consistent function labels
 

--- a/docs/FUNCTION_VS_DEPARTMENT_ANALYSIS.md
+++ b/docs/FUNCTION_VS_DEPARTMENT_ANALYSIS.md
@@ -43,7 +43,7 @@ This analysis compares two different categorization approaches:
 
 **Location:** `web/lib/analysis/structure.ts`
 
-- **Method:** `extractJobStructure()` - Gemini 3 Flash AI extraction from job descriptions
+- **Method:** `extractJobStructure()` - Gemini Flash AI extraction from job descriptions
 - **AI-powered** - extracts from full job description context
 - **Granularity:** High-level organizational departments:
   - Common values: "Engineering", "Sales", "Marketing", "Product", "Operations", "Finance", "Legal", "HR", "Customer Success", "Support"

--- a/docs/JOB_PROCESSING_PIPELINE_EXPLORATION.md
+++ b/docs/JOB_PROCESSING_PIPELINE_EXPLORATION.md
@@ -86,7 +86,7 @@ async function extractAndUpdateStructure(
 **Location:** `web/lib/analysis/structure.ts:82-206`
 
 - AI extracts `standardized_department` from job title + description
-- Uses Gemini 3 Flash with structured JSON output
+- Uses Gemini Flash with structured JSON output
 - Normalizes to common values: "Engineering", "Sales", "Marketing", etc.
 - **BUT**: Does not use raw `department` field as input/hint
 

--- a/docs/PROMPT_FORGE_GUIDE.md
+++ b/docs/PROMPT_FORGE_GUIDE.md
@@ -39,7 +39,7 @@ This document is intentionally split into two parts:
 - It does not directly modify source code when you save a prompt
 - It does not expose prompt editing to non-admin users
 
-- It does not tune **per-job strategic insights** (the `analyzeJobAdvanced` pipeline used after collection to populate `strategic_insights`). To compare Gemini models for that path—for example `gemini-pro-latest` vs `gemini-3-flash-preview` or `gemini-flash-latest`—use the dev script `web/scripts/compare-job-analysis-models.ts` with shared historical and web context so both arms see identical inputs.
+- It does not tune **per-job strategic insights** (the `analyzeJobAdvanced` pipeline used after collection to populate `strategic_insights`). To compare Gemini models for that path—for example `gemini-pro-latest` vs `gemini-flash-latest`—use the dev script `web/scripts/compare-job-analysis-models.ts` with shared historical and web context so both arms see identical inputs.
 
 ### Core product idea
 
@@ -137,14 +137,14 @@ All Prompt Forge outputs that become user-visible prose should align with **[voi
 
 ## Supported Models
 
-Prompt Forge currently supports these approved Gemini 3 models:
+Prompt Forge currently supports these approved Gemini models (all floating `-latest` aliases — the concrete version rolls with Google's releases; see CLAUDE.md `AI Model Requirements`):
 
-- `gemini-3-flash-preview`
+- `gemini-flash-latest`
 - `gemini-pro-latest`
 
 Recommended usage:
 
-- Use `gemini-3-flash-preview` for fast extraction and quick iteration
+- Use `gemini-flash-latest` for fast extraction and quick iteration
 - Use `gemini-pro-latest` when deeper synthesis quality matters more than speed
 
 ---
@@ -709,7 +709,7 @@ Admin access is enforced by:
 
 Model values are restricted by schema validation in `web/lib/ai/prompt-config.ts`.
 
-Only approved Gemini 3 models should be accepted.
+Only approved Gemini `-latest` alias models should be accepted (see CLAUDE.md `AI Model Requirements`).
 
 ### Prompt validation
 

--- a/docs/SILVER_LAYER_AUDIT.md
+++ b/docs/SILVER_LAYER_AUDIT.md
@@ -208,13 +208,13 @@ CREATE INDEX idx_job_postings_tech_stack ON job_postings USING GIN(tech_stack);
 
 #### ✅ Strategic Analysis (`web/lib/analysis/strategic.ts`)
 - **Function:** `analyzeJob(companyName, job)`
-- **Model:** Gemini 3 Flash Preview
+- **Model:** Gemini Flash (via `gemini-flash-latest`)
 - **Output:** `AnalyzeResult` with category, insight_summary, strategic_signals, is_new_direction, confidence
 - **Status:** ✅ **PRODUCTION READY**
 
 #### ✅ Advanced Strategic Analysis (`web/lib/analysis/advanced-strategic.ts`)
 - **Function:** `analyzeJobAdvanced(options)`
-- **Model:** Gemini 3 Pro Preview (with fallback to Flash)
+- **Model:** Gemini Pro (via `gemini-pro-latest`) (with fallback to Flash)
 - **Features:**
   - Historical context comparison
   - Web search grounding (Google Search tool)
@@ -226,7 +226,7 @@ CREATE INDEX idx_job_postings_tech_stack ON job_postings USING GIN(tech_stack);
 
 #### ✅ Job Categorization (`web/lib/analysis/categorizer.ts`)
 - **Function:** `categorizePosting(jobTitle, companyName, description)`
-- **Model:** Gemini 3 Flash Preview
+- **Model:** Gemini Flash (via `gemini-flash-latest`)
 - **Output:** `JobCategoryResult` with:
   - `role_category` (from ROLE_CATEGORIES enum)
   - `extracted_sections` (summary, responsibilities, requirements, nice_to_have, benefits)
@@ -236,7 +236,7 @@ CREATE INDEX idx_job_postings_tech_stack ON job_postings USING GIN(tech_stack);
 
 #### ✅ Company-Level Insights (`web/lib/analysis/company-insights.ts`)
 - **Function:** `generateCompanyInsight(companyId, companyName, options)`
-- **Model:** Gemini 3 Flash Preview
+- **Model:** Gemini Flash (via `gemini-flash-latest`)
 - **Features:**
   - Extended historical context (90-day periods)
   - Deep research (public company detection, financial context, analyst reports)
@@ -375,7 +375,7 @@ CREATE INDEX idx_job_postings_tech_stack ON job_postings USING GIN(tech_stack);
 **Good News:** The foundation for analysis and insights is **strongly established**:
 - ✅ Strategic analysis tables exist with advanced fields
 - ✅ Company-level insights with deep research
-- ✅ Comprehensive AI analysis functions using Gemini 3
+- ✅ Comprehensive AI analysis functions using Gemini
 - ✅ Job categorization system (36 categories)
 - ✅ Historical context and trend analysis
 

--- a/docs/STRATEGIC_IMPLEMENTATION_REPORT.md
+++ b/docs/STRATEGIC_IMPLEMENTATION_REPORT.md
@@ -47,7 +47,7 @@ We have completed the porting of core logic from the legacy Python CLI to a clou
 
 ### AI Implementation
 We have integrated **Google Gemini 3.0**:
-- **Categorization:** Uses `gemini-3-flash-preview` for low-latency, high-accuracy role classification.
+- **Categorization:** Uses `gemini-flash-latest` (floating `-latest` alias — see CLAUDE.md `AI Model Requirements`) for low-latency, high-accuracy role classification.
 - **Strategic Analysis:** Uses `gemini-pro-latest` for complex reasoning tasks, specifically "Novelty Scoring" and "Executive Movement Detection."
 
 ---

--- a/web/app/api/companies/[id]/insights/[insightId]/chat/route.ts
+++ b/web/app/api/companies/[id]/insights/[insightId]/chat/route.ts
@@ -102,7 +102,7 @@ export async function POST(
   try {
     const genAI = new GoogleGenerativeAI(key);
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       generationConfig: {
         temperature: 0.7,
         maxOutputTokens: 16384,

--- a/web/app/api/insights/[id]/chat/route.ts
+++ b/web/app/api/insights/[id]/chat/route.ts
@@ -132,7 +132,7 @@ Your role is to answer follow-up questions about this insight, provide deeper an
     const genAI = new GoogleGenerativeAI(key);
 
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       // @ts-expect-error - googleSearch tool exists at runtime but types may be outdated
       tools: [{ googleSearch: {} }],
       systemInstruction: systemPrompt,

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "1.9.0",
+    "date": "2026-04-19",
+    "changes": [
+      { "type": "improvement", "description": "Switched all Gemini calls from the pinned `gemini-3-flash-preview` preview ID to the floating `gemini-flash-latest` alias, so model upgrades now roll through without code changes." },
+      { "type": "improvement", "description": "Refreshed CLAUDE.md `AI Model Requirements` to require `-latest` aliases across Flash, Flash-Lite, and Pro tiers, and updated Prompt Forge's approved-models list accordingly." }
+    ]
+  },
+  {
     "version": "1.8.0",
     "date": "2026-04-14",
     "changes": [

--- a/web/lib/ai/prompt-config.ts
+++ b/web/lib/ai/prompt-config.ts
@@ -6,9 +6,9 @@ export type PromptStage = (typeof PROMPT_STAGES)[number];
 
 export const AI_MODEL_OPTIONS = [
   {
-    value: "gemini-3-flash-preview",
-    label: "Gemini 3 Flash",
-    summary: "Fastest for extraction and iteration rounds.",
+    value: "gemini-flash-latest",
+    label: "Gemini Flash",
+    summary: "Fastest for extraction and iteration rounds. Uses the `-latest` alias, so the active version is whatever Google currently marks as Flash-latest.",
     recommendedStages: ["job-structure", "tech-stack", "weekly-digest"],
   },
   {
@@ -243,7 +243,7 @@ Respond with ONLY valid JSON.`;
 
 export const DEFAULT_JOB_STRUCTURE_AI_CONFIG: JobStructureAiConfig = {
   stage: "job-structure",
-  model: "gemini-3-flash-preview",
+  model: "gemini-flash-latest",
   promptTemplate: DEFAULT_JOB_STRUCTURE_PROMPT,
   temperature: 0.2,
   maxOutputTokens: 4096,
@@ -253,7 +253,7 @@ export const DEFAULT_JOB_STRUCTURE_AI_CONFIG: JobStructureAiConfig = {
 
 export const DEFAULT_TECH_STACK_AI_CONFIG: TechStackAiConfig = {
   stage: "tech-stack",
-  model: "gemini-3-flash-preview",
+  model: "gemini-flash-latest",
   promptTemplate: DEFAULT_TECH_STACK_PROMPT,
   temperature: 0.25,
   maxOutputTokens: 4096,
@@ -263,7 +263,7 @@ export const DEFAULT_TECH_STACK_AI_CONFIG: TechStackAiConfig = {
 
 export const DEFAULT_WEEKLY_DIGEST_AI_CONFIG: WeeklyDigestAiConfig = {
   stage: "weekly-digest",
-  model: "gemini-3-flash-preview",
+  model: "gemini-flash-latest",
   promptTemplate: DEFAULT_WEEKLY_DIGEST_PROMPT,
   temperature: 0.2,
   maxOutputTokens: 2048,

--- a/web/lib/ai/strategy-analysis.ts
+++ b/web/lib/ai/strategy-analysis.ts
@@ -167,7 +167,7 @@ export async function analyzeCompanyStrategy(
   try {
     const genAI = new GoogleGenerativeAI(key);
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       generationConfig: {
         temperature: 0.3,
         maxOutputTokens: 8192,

--- a/web/lib/ai/tech-stack-extraction.ts
+++ b/web/lib/ai/tech-stack-extraction.ts
@@ -262,7 +262,7 @@ export async function extractCompanyTechStack(
 
   const genAI = new GoogleGenerativeAI(key);
   const model = genAI.getGenerativeModel({
-    model: "gemini-3-flash-preview",
+    model: "gemini-flash-latest",
     generationConfig: {
       temperature: 0.1,
       maxOutputTokens: 8192,

--- a/web/lib/analysis/advanced-strategic.ts
+++ b/web/lib/analysis/advanced-strategic.ts
@@ -17,7 +17,7 @@ import { buildHistoricalContext, formatHistoricalContextForPrompt, type Historic
 // ---------------------------------------------------------------------------
 
 const PRO_MODEL = "gemini-pro-latest";
-const FLASH_MODEL = "gemini-3-flash-preview";
+const FLASH_MODEL = "gemini-flash-latest";
 
 /** How many days of hiring history to include as context for each job analysis. */
 const HISTORICAL_CONTEXT_DAYS = 180;

--- a/web/lib/analysis/categorizer.ts
+++ b/web/lib/analysis/categorizer.ts
@@ -4,7 +4,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
  * Job Categorizer for Template Library
  * 
  * Logic ported from src/analysis/categorizer.py to TypeScript for Vercel deployment.
- * Uses Gemini 3 Flash for AI-based categorization and template extraction.
+ * Uses Gemini Flash for AI-based categorization and template extraction.
  */
 
 // Fintech-specific role categories (must match function-categories.ts)
@@ -174,7 +174,7 @@ Respond ONLY with valid JSON.`;
 
 
 /**
- * Categorize a job posting and extract template sections using Gemini 3.
+ * Categorize a job posting and extract template sections using Gemini.
  */
 export async function categorizePosting(
   jobTitle: string,
@@ -196,9 +196,9 @@ export async function categorizePosting(
   try {
     const genAI = new GoogleGenerativeAI(key);
     
-    // Using Gemini 3 Flash Preview as requested
+    // Using Gemini Flash (via `gemini-flash-latest`) as requested
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       generationConfig: {
         temperature: 0.2,
         maxOutputTokens: 64000,

--- a/web/lib/analysis/company-insights.ts
+++ b/web/lib/analysis/company-insights.ts
@@ -541,7 +541,7 @@ async function generateInsightWithLLM(
 
   const genAI = new GoogleGenerativeAI(key);
   const model = genAI.getGenerativeModel({
-    model: "gemini-3-flash-preview",
+    model: "gemini-flash-latest",
     generationConfig: {
       temperature: 0.25,
       maxOutputTokens: 4096,

--- a/web/lib/analysis/company-news.ts
+++ b/web/lib/analysis/company-news.ts
@@ -220,7 +220,7 @@ async function fetchFreshNewsContext(companyName: string): Promise<CompanyNewsCo
     // Use Gemini Flash with grounding for web search (Flash supports Google Search
     // and is significantly cheaper than Pro — company-research.ts already uses this pattern)
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       // @ts-expect-error - googleSearch tool exists at runtime but types may be outdated
       tools: [{ googleSearch: {} }],
       generationConfig: {

--- a/web/lib/analysis/company-research.ts
+++ b/web/lib/analysis/company-research.ts
@@ -172,7 +172,7 @@ export async function detectCompanyType(
   try {
     const genAI = new GoogleGenerativeAI(key);
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       generationConfig: {
         temperature: 0.1,
         maxOutputTokens: 256,
@@ -407,7 +407,7 @@ export async function performDeepResearch(
 
     try {
       const model = genAI.getGenerativeModel({
-        model: "gemini-3-flash-preview",
+        model: "gemini-flash-latest",
         // @ts-expect-error - googleSearch tool exists at runtime but types may be outdated
         tools: [{ googleSearch: {} }],
       });
@@ -723,7 +723,7 @@ async function extractStatedStrategy(
 
   try {
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       generationConfig: {
         temperature: 0.3,
         maxOutputTokens: 2048,
@@ -775,7 +775,7 @@ async function extractFinancialContext(
 
   try {
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       generationConfig: {
         temperature: 0.2,
         maxOutputTokens: 2048,

--- a/web/lib/analysis/strategic.ts
+++ b/web/lib/analysis/strategic.ts
@@ -1,10 +1,10 @@
 import { GoogleGenerativeAI } from "@google/generative-ai";
 
 /**
- * Strategic Analysis using Gemini 3 Flash
+ * Strategic Analysis using Gemini Flash
  * 
  * Uses JSON mode for guaranteed structured output.
- * Leverages Gemini 3's enhanced reasoning capabilities.
+ * Leverages Gemini 's enhanced reasoning capabilities.
  */
 
 const PROMPT = `You are a competitive intelligence analyst specializing in the fintech industry.
@@ -67,9 +67,9 @@ export async function analyzeJob(
   try {
     const genAI = new GoogleGenerativeAI(key);
     
-    // Use Gemini 3 Flash with JSON mode for guaranteed structured output
+    // Use Gemini Flash with JSON mode for guaranteed structured output
     const model = genAI.getGenerativeModel({
-      model: "gemini-3-flash-preview",
+      model: "gemini-flash-latest",
       generationConfig: {
         temperature: 0.3,
         maxOutputTokens: 64000,

--- a/web/lib/analysis/structure.ts
+++ b/web/lib/analysis/structure.ts
@@ -9,7 +9,7 @@ import {
 /**
  * Job Structure Extractor
  * 
- * Extracts structured data ("Silver Layer") from job descriptions using Gemini 3 Flash.
+ * Extracts structured data ("Silver Layer") from job descriptions using Gemini Flash.
  * Provides standardized fields for job_postings table.
  */
 
@@ -144,7 +144,7 @@ export async function extractJobStructure(
   try {
     const genAI = new GoogleGenerativeAI(key);
 
-    // Use Gemini 3 Flash with JSON mode for guaranteed structured output
+    // Use Gemini Flash with JSON mode for guaranteed structured output
     const model = genAI.getGenerativeModel({
       model: config.model,
       generationConfig: {

--- a/web/lib/labs/prompt-forge.ts
+++ b/web/lib/labs/prompt-forge.ts
@@ -1269,7 +1269,7 @@ export function buildPromptPromotionIssue(options: {
 1. Update \`${settingsFile}\` so the default config for \`${options.stage}\` matches the approved model and prompt below.
 2. Ensure the stage implementation in \`${targetFile}\` still consumes the default config correctly.
 3. Do not remove runtime loading from \`system_settings\`; the app must continue honoring saved admin settings.
-4. Keep all model options restricted to approved Gemini 3 models only.
+4. Keep all model options restricted to approved Gemini \`-latest\` alias models only (see \`AI_MODEL_OPTIONS\` in \`web/lib/ai/prompt-config.ts\`).
 5. Do not change unrelated UI or business logic.
 
 ## Approved prompt text

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/scripts/backfill-insight-display-fields.ts
+++ b/web/scripts/backfill-insight-display-fields.ts
@@ -3,7 +3,7 @@
  * Backfill Insight Display Fields
  * 
  * Generates headline, significance_score, and key_signal for existing
- * company_insights that don't have them yet. Uses Gemini 3 Flash for generation.
+ * company_insights that don't have them yet. Uses Gemini Flash for generation.
  * 
  * Usage:
  *   npx tsx --env-file=.env.local web/scripts/backfill-insight-display-fields.ts
@@ -85,7 +85,7 @@ async function generateDisplayFields(
 
   const genAI = new GoogleGenerativeAI(key);
   const model = genAI.getGenerativeModel({
-    model: "gemini-3-flash-preview",
+    model: "gemini-flash-latest",
     generationConfig: {
       temperature: 0.5,
       maxOutputTokens: 64000,

--- a/web/scripts/compare-job-analysis-models.ts
+++ b/web/scripts/compare-job-analysis-models.ts
@@ -12,7 +12,7 @@
  *   --company=<slug-or-name>   Alternative to positional company arg
  *   --limit=N                  Jobs to sample (default 3)
  *   --arm-a=<model_id>         Default: gemini-pro-latest
- *   --arm-b=<model_id>         Default: gemini-3-flash-preview
+ *   --arm-b=<model_id>         Default: gemini-flash-latest
  *   --no-analysis-search       Omit Google Search tool on the analysis call (context-only)
  *   --skip-prefetch-web        Empty web context (fast/cheap; not representative of production)
  *   --json                     Print one JSON object per job to stdout
@@ -33,7 +33,7 @@ function parseArgs(argv: string[]) {
   let positional: string | undefined;
   let limit = 3;
   let armA = "gemini-pro-latest";
-  let armB = "gemini-3-flash-preview";
+  let armB = "gemini-flash-latest";
   let companyArg: string | undefined;
   let noAnalysisSearch = false;
   let skipPrefetchWeb = false;

--- a/web/scripts/test-gemini-models.ts
+++ b/web/scripts/test-gemini-models.ts
@@ -9,7 +9,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 const MODELS_TO_TEST = [
   // Gemini Pro latest (REQUIRED - always use this)
   "gemini-pro-latest",
-  "gemini-3-flash-preview",
+  "gemini-flash-latest",
   // Older models (DO NOT USE - listed only for verification)
   "gemini-2.5-pro-preview-06-05",
   "gemini-2.5-flash-preview-05-20",

--- a/web/supabase/migrations/20260419120000_gemini_alias_migration.sql
+++ b/web/supabase/migrations/20260419120000_gemini_alias_migration.sql
@@ -1,0 +1,17 @@
+-- Swap pinned `gemini-3-flash-preview` references in runtime settings to the
+-- floating `gemini-flash-latest` alias. Historical rows in `prompt_lab_runs`
+-- and the original seed migrations are intentionally left untouched — those
+-- are snapshots of what ran at the time.
+--
+-- The `AI_MODEL_OPTIONS` enum in `web/lib/ai/prompt-config.ts` now validates
+-- runtime configs against `gemini-flash-latest`; any `system_settings` row
+-- still carrying the old value would fail validation until this runs.
+
+UPDATE system_settings
+SET setting_value = jsonb_set(
+  setting_value,
+  '{model}',
+  '"gemini-flash-latest"'::jsonb,
+  false
+)
+WHERE setting_value->>'model' = 'gemini-3-flash-preview';


### PR DESCRIPTION
## Summary

Phase 0 of the Gemini cost-reduction plan. Every Gemini call now resolves through a floating `-latest` alias (`gemini-flash-latest`, `gemini-pro-latest`) instead of the pinned `gemini-3-flash-preview` preview ID, so future Google model rotations land without code changes. No behavior change beyond the alias rotation itself.

- **Code:** 15 files swapped from `gemini-3-flash-preview` → `gemini-flash-latest`; `AI_MODEL_OPTIONS` in [web/lib/ai/prompt-config.ts](web/lib/ai/prompt-config.ts) now validates against the new alias.
- **Policy:** [CLAUDE.md](CLAUDE.md) `AI Model Requirements` rewritten to require `-latest` aliases across Flash, Flash-Lite, and Pro tiers; the hard "Never use Gemini 2.x / 1.x" bans are superseded by the alias policy.
- **Database:** Forward-only migration [20260419120000_gemini_alias_migration.sql](web/supabase/migrations/20260419120000_gemini_alias_migration.sql) updates `system_settings` rows still carrying the old pinned model string. Historical `prompt_lab_runs` snapshots are intentionally left untouched.
- **Docs:** PROMPT_FORGE_GUIDE, STRATEGIC_IMPLEMENTATION_REPORT, SILVER_LAYER_AUDIT, JOB_PROCESSING_PIPELINE_EXPLORATION, FUNCTION_CATEGORY_IMPLEMENTATION, FUNCTION_VS_DEPARTMENT_ANALYSIS, and issue #102 — all normalized to the new alias convention.
- **Release:** Bumped to `v1.9.0` with two `improvement` entries in [web/data/releases.json](web/data/releases.json).

## Tradeoff accepted

Per Google's own guidance, `-latest` aliases may rotate to preview/experimental releases. The project already accepted this for `gemini-pro-latest`; we now extend it to Flash. The Phase-1 comparison harness (next PR) and Phase-5 production telemetry are the detectors for any alias-rotation regression.

## Test plan

- [x] `cd web && npm run build` passes (Turbopack)
- [x] `npm run lint` introduces no new errors (pre-existing errors in `scripts/*` unchanged)
- [ ] Apply migration to Supabase preview; confirm `system_settings` rows where `setting_value->>'model' = 'gemini-3-flash-preview'` are updated to `gemini-flash-latest`
- [ ] Trigger a preview `/api/cron/collect` against one company; confirm the call chain succeeds end-to-end against the `-latest` aliases
- [ ] Confirm Prompt Forge admin page loads and the saved runtime model shows as `gemini-flash-latest`

## What ships next

Phase 1 (separate PR): `gemini-meter.ts` + `gemini-compare.ts` measurement harness with a seeded 20-job fixture, so we can see token/cost/L1-agreement side-by-side across `-latest` Flash, Flash-Lite, and Pro variants — plus a committed baseline artifact. From there Phases 2–3 ship the two obvious cost wins (description-hash gate on re-extraction, dropping the duplicate Pro+grounded pre-fetch call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)