### PR TITLE
Flash-Lite extract-structure evaluation (Phase 4, negative result — no prod swap)

### DIFF
--- a/web/lib/ai/prompt-config.ts
+++ b/web/lib/ai/prompt-config.ts
@@ -12,6 +12,12 @@ export const AI_MODEL_OPTIONS = [
     recommendedStages: ["job-structure", "tech-stack", "weekly-digest"],
   },
   {
+    value: "gemini-flash-lite-latest",
+    label: "Gemini Flash-Lite",
+    summary: "Cheapest tier (roughly a third of Flash's token price). Enabled here for comparison against Flash on structured-extraction surfaces; swap in only where the `gemini-compare.ts` report shows L1 field agreement >= 95%.",
+    recommendedStages: ["job-structure"],
+  },
+  {
     value: "gemini-pro-latest",
     label: "Gemini Pro",
     summary: "Best for deeper reasoning and narrative quality.",

--- a/web/scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-a689dae.json
+++ b/web/scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-a689dae.json
@@ -1,0 +1,1126 @@
+{
+  "scenario": "extract-structure",
+  "mode": "baseline",
+  "gitSha": "a689dae",
+  "generatedAt": "2026-04-19T15:37:01.837Z",
+  "fixtureFile": "/Users/tscheidt/fintech_insights/fintech_insights/web/scripts/fixtures/gemini-sample-jobs.json",
+  "fixtureCount": 20,
+  "processedCount": 20,
+  "totals": {
+    "calls": 20,
+    "inputTokens": 47055,
+    "outputTokens": 4764,
+    "cachedTokens": 0,
+    "totalTokens": 51819,
+    "estimatedUsd": 0.006611,
+    "avgLatencyMs": 1547
+  },
+  "byCallSite": {
+    "extractJobStructure": {
+      "calls": 20,
+      "inputTokens": 47055,
+      "outputTokens": 4764,
+      "totalTokens": 51819,
+      "estimatedUsd": 0.0066111,
+      "avgLatencyMs": 1547,
+      "modelsServed": [
+        "gemini-flash-lite-latest"
+      ]
+    }
+  },
+  "perJob": [
+    {
+      "jobId": "c7aea83d-c1ad-4198-9195-e7e8c8b2c377",
+      "title": "Associate, Commercial Credit, Commercial Finance Group (CFG)",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2362,
+          "outputTokens": 232,
+          "cachedTokens": 0,
+          "totalTokens": 2594,
+          "estimatedUsd": 0.000329,
+          "latencyMs": 1565,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Associate, Commercial Credit, Commercial Finance Group (CFG)",
+            "jobId": "c7aea83d-c1ad-4198-9195-e7e8c8b2c377"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Associate, Commercial Credit supports the underwriting team by managing document fulfillment, due diligence, and credit submission preparation for commercial mortgage transactions. This role acts as a key liaison between internal departments and external partners to ensure compliance and deal readiness.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Cyber Query",
+          "PPlus"
+        ],
+        "keywords": [
+          "Commercial Credit",
+          "Underwriting",
+          "Commercial Mortgages",
+          "Due Diligence",
+          "Document Fulfillment",
+          "FINTRAC",
+          "Credit Risk",
+          "Lending Guidelines",
+          "Portfolio Management"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "risk-management",
+        "location_structured": {
+          "city": "Montreal or Toronto",
+          "state": null,
+          "country": "Canada",
+          "formatted": "Montreal or Toronto, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "e4b91622-2162-4a87-a751-c287c9b0413b",
+      "title": "Senior Manager, Operational Risk Management",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2275,
+          "outputTokens": 252,
+          "cachedTokens": 0,
+          "totalTokens": 2527,
+          "estimatedUsd": 0.0003283,
+          "latencyMs": 1833,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Manager, Operational Risk Management",
+            "jobId": "e4b91622-2162-4a87-a751-c287c9b0413b"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Senior Manager, Operational Risk Management will lead the second line of defense for Equitable Bank, overseeing risk identification, control assessments, and GRC tool administration. This role focuses on operational resiliency, fraud risk, and third-party risk management within a challenger bank.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Resolver"
+        ],
+        "keywords": [
+          "Operational Risk Management",
+          "Risk and Control Self-Assessment",
+          "New Initiative Risk Assessment",
+          "Key Risk Indicators",
+          "Governance Risk and Compliance",
+          "Fraud Risk Management",
+          "Business Continuity",
+          "Third Party Risk",
+          "Operational Resiliency",
+          "Regulatory Compliance",
+          "Enterprise Risk Management",
+          "Risk Reporting"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "risk-management",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "85a09b75-1ff4-439d-b0d9-670a453cd468",
+      "title": "Senior Director, Asset and Liability Management (ALM)",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2320,
+          "outputTokens": 241,
+          "cachedTokens": 0,
+          "totalTokens": 2561,
+          "estimatedUsd": 0.0003284,
+          "latencyMs": 2049,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Director, Asset and Liability Management (ALM)",
+            "jobId": "85a09b75-1ff4-439d-b0d9-670a453cd468"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Senior Director, ALM will lead balance sheet strategy, interest rate risk management, and treasury investment practices at EQ Bank. This role involves developing sophisticated ALM models, performing stress testing, and ensuring regulatory compliance with OSFI guidelines.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Asset and Liability Management",
+          "Treasury",
+          "Interest Rate Risk",
+          "Balance Sheet Strategy",
+          "Financial Risk Management",
+          "Stress Testing",
+          "ICAAP",
+          "Hedge Accounting",
+          "Liquidity Risk",
+          "Capital Markets",
+          "Regulatory Compliance",
+          "Financial Modeling",
+          "Scenario Analysis"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "capital-markets-treasury",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "a1ab7ccd-68fe-49db-948f-e453716a8abe",
+      "title": "Senior Backend Engineer",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2236,
+          "outputTokens": 238,
+          "cachedTokens": 0,
+          "totalTokens": 2474,
+          "estimatedUsd": 0.00031880000000000005,
+          "latencyMs": 1424,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Backend Engineer",
+            "jobId": "a1ab7ccd-68fe-49db-948f-e453716a8abe"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Equitable Bank is seeking a Senior Backend Engineer to design and own end-to-end fraud decisioning systems. The role focuses on building scalable, event-driven architectures to protect customers across onboarding, transactions, and money movement within a high-growth digital banking environment.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Java"
+        ],
+        "keywords": [
+          "fraud engineering",
+          "event-driven systems",
+          "distributed systems",
+          "API design",
+          "observability",
+          "risk management",
+          "system architecture",
+          "production support",
+          "data contracts",
+          "service ownership"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "fraud-trust-safety",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "83177ac3-270d-41e9-9ad7-983ad3ed3fd4",
+      "title": "Senior Business Analyst, Fraud Strategy",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2436,
+          "outputTokens": 273,
+          "cachedTokens": 0,
+          "totalTokens": 2709,
+          "estimatedUsd": 0.0003528,
+          "latencyMs": 1538,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Business Analyst, Fraud Strategy",
+            "jobId": "83177ac3-270d-41e9-9ad7-983ad3ed3fd4"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Senior Business Analyst to lead fraud strategy and risk mitigation. You will design fraud detection models, analyze transactional data, and collaborate cross-functionally to protect users while maintaining a seamless customer experience.",
+        "seniority_level": "senior",
+        "salary_min": 95000,
+        "salary_max": 115000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "SQL",
+          "Python",
+          "Pandas",
+          "NumPy",
+          "dbt",
+          "Sigma"
+        ],
+        "keywords": [
+          "fraud strategy",
+          "AML",
+          "financial crime",
+          "risk mitigation",
+          "transaction monitoring",
+          "fraud detection",
+          "data analysis",
+          "payments",
+          "banking"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "fraud-trust-safety",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "3b4b39de-b7a3-4bec-8367-91bf4b95ac7e",
+      "title": "Product Manager / Sr Product Manager, Credit Building",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2472,
+          "outputTokens": 275,
+          "cachedTokens": 0,
+          "totalTokens": 2747,
+          "estimatedUsd": 0.0003572,
+          "latencyMs": 1432,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Product Manager / Sr Product Manager, Credit Building",
+            "jobId": "3b4b39de-b7a3-4bec-8367-91bf4b95ac7e"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Product Manager to lead the credit building product portfolio. This role focuses on driving the end-to-end product lifecycle, optimizing credit-related metrics, and collaborating with cross-functional teams to help Canadians build their credit scores.",
+        "seniority_level": "senior",
+        "salary_min": 130000,
+        "salary_max": 200000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "SQL",
+          "dbt",
+          "Redshift"
+        ],
+        "keywords": [
+          "credit building",
+          "consumer credit",
+          "lending",
+          "product management",
+          "credit risk",
+          "financial compliance",
+          "adjudication models",
+          "fintech",
+          "product lifecycle",
+          "data-informed"
+        ],
+        "standardized_department": "Product",
+        "function_category": "product-management",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "7c6f190a-7b87-4c04-8a0c-b44b9df2296f",
+      "title": "Director of Growth (Partnerships & Organic)",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2442,
+          "outputTokens": 283,
+          "cachedTokens": 0,
+          "totalTokens": 2725,
+          "estimatedUsd": 0.0003574,
+          "latencyMs": 1636,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Director of Growth (Partnerships & Organic)",
+            "jobId": "7c6f190a-7b87-4c04-8a0c-b44b9df2296f"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Director of Growth to lead partnership, affiliate, and organic growth strategies. The role focuses on scaling user acquisition through SEO, GEO, and CRO, while leveraging AI-driven search models and advanced attribution frameworks to drive sustainable, long-term growth.",
+        "seniority_level": "senior",
+        "salary_min": 170000,
+        "salary_max": 200000,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "Growth Marketing",
+          "Partnerships",
+          "Affiliate Marketing",
+          "SEO",
+          "GEO",
+          "ASO",
+          "CRO",
+          "Attribution Modeling",
+          "B2C",
+          "Fintech",
+          "User Acquisition",
+          "LTV",
+          "Generative AI",
+          "Performance Marketing"
+        ],
+        "standardized_department": "Marketing",
+        "function_category": "marketing-growth-performance",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "bac85455-34f8-46ae-8c42-84ecb796215c",
+      "title": "Product and Regulatory Counsel",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2404,
+          "outputTokens": 221,
+          "cachedTokens": 0,
+          "totalTokens": 2625,
+          "estimatedUsd": 0.00032879999999999997,
+          "latencyMs": 1604,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Product and Regulatory Counsel",
+            "jobId": "bac85455-34f8-46ae-8c42-84ecb796215c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Product and Regulatory Counsel to support its transition into a regulated bank. The role involves providing legal guidance on financial product development, regulatory strategy, and compliance with Canadian banking and consumer protection frameworks.",
+        "seniority_level": "senior",
+        "salary_min": 170000,
+        "salary_max": 200000,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "financial services regulation",
+          "banking law",
+          "consumer protection",
+          "regulatory strategy",
+          "compliance",
+          "AML",
+          "ATF",
+          "privacy law",
+          "RPAA",
+          "FCPF",
+          "product development",
+          "legal counsel"
+        ],
+        "standardized_department": "Legal",
+        "function_category": "legal",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "096d3a5d-e260-4204-9ae4-870d45250a9c",
+      "title": "Sales Representative - Toronto Premium Outlets",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2456,
+          "outputTokens": 248,
+          "cachedTokens": 0,
+          "totalTokens": 2704,
+          "estimatedUsd": 0.00034480000000000003,
+          "latencyMs": 1573,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Sales Representative - Toronto Premium Outlets",
+            "jobId": "096d3a5d-e260-4204-9ae4-870d45250a9c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is seeking a motivated Sales Representative to drive customer acquisition for credit and banking products through in-person activation events. This role involves representing the brand at retail locations and campuses, offering a base hourly rate plus uncapped commissions.",
+        "seniority_level": "junior",
+        "salary_min": 41600,
+        "salary_max": 74880,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "Neo App"
+        ],
+        "keywords": [
+          "Direct Sales",
+          "Customer Acquisition",
+          "Retail Sales",
+          "Financial Products",
+          "Field Sales",
+          "Lead Generation",
+          "Commission-based"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "c8fde90b-bb78-496a-aae4-a93480e391d3",
+      "title": "Product Manager, Fraud (PM / Senior / Lead)",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2564,
+          "outputTokens": 199,
+          "cachedTokens": 0,
+          "totalTokens": 2763,
+          "estimatedUsd": 0.00033600000000000004,
+          "latencyMs": 1363,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Product Manager, Fraud (PM / Senior / Lead)",
+            "jobId": "c8fde90b-bb78-496a-aae4-a93480e391d3"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is seeking a Product Manager to lead their fraud prevention squad. You will design and optimize intelligent fraud detection systems, manage experimentation frameworks, and balance risk mitigation with customer experience across credit, banking, and investment product surfaces.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "fraud prevention",
+          "risk management",
+          "product strategy",
+          "A/B testing",
+          "experimentation frameworks",
+          "data-driven decision making",
+          "statistical rigor",
+          "customer experience",
+          "transaction monitoring",
+          "fintech",
+          "rule engines",
+          "false positive reduction"
+        ],
+        "standardized_department": "Product",
+        "function_category": "fraud-trust-safety",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "1b5f56da-4240-4480-8abc-d5d02183d926",
+      "title": "Analyst, Treasury Operations",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2376,
+          "outputTokens": 233,
+          "cachedTokens": 0,
+          "totalTokens": 2609,
+          "estimatedUsd": 0.0003308,
+          "latencyMs": 1393,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Analyst, Treasury Operations",
+            "jobId": "1b5f56da-4240-4480-8abc-d5d02183d926"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is seeking a Treasury Operations Analyst to manage reconciliation, payment rails, and lending facility monitoring. The role requires 2-3 years of experience in treasury or cash management and proficiency in SQL to support operational efficiency and scaling.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Snowflake"
+        ],
+        "keywords": [
+          "Treasury Operations",
+          "Cash Management",
+          "Reconciliation",
+          "Payment Rails",
+          "Lending Facilities",
+          "Risk Management",
+          "Financial Reporting",
+          "Audit Support",
+          "Process Automation"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "capital-markets-treasury",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Calgary, Winnipeg, and Toronto, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "1e72a7e1-43e9-40b2-9a7e-22fab0ece689",
+      "title": "District Sales Manager - Calgary ",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2426,
+          "outputTokens": 230,
+          "cachedTokens": 0,
+          "totalTokens": 2656,
+          "estimatedUsd": 0.00033460000000000006,
+          "latencyMs": 1151,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "District Sales Manager - Calgary ",
+            "jobId": "1e72a7e1-43e9-40b2-9a7e-22fab0ece689"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is seeking a District Sales Manager in Calgary to lead field sales teams across multiple mall locations. The role focuses on driving profitability, optimizing customer acquisition costs, and managing the full lifecycle of store managers.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "field sales",
+          "sales management",
+          "customer acquisition cost",
+          "CAC",
+          "retail management",
+          "sales training",
+          "performance management",
+          "business development",
+          "financial services",
+          "credit cards",
+          "team leadership",
+          "data analysis"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": {
+          "city": "Calgary",
+          "state": "Alberta",
+          "country": "Canada",
+          "formatted": "Calgary, Alberta, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "fdc2e7bc-b36c-488b-8dde-a4c2c6b214f5",
+      "title": "Senior Analyst, Procurement & Vendor Management",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2273,
+          "outputTokens": 220,
+          "cachedTokens": 0,
+          "totalTokens": 2493,
+          "estimatedUsd": 0.0003153,
+          "latencyMs": 2420,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Analyst, Procurement & Vendor Management",
+            "jobId": "fdc2e7bc-b36c-488b-8dde-a4c2c6b214f5"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade Financial Group is seeking a Senior Analyst to manage the end-to-end procurement and vendor lifecycle. The role involves negotiating agreements, conducting due diligence, and ensuring compliance within a hybrid work environment.",
+        "seniority_level": "senior",
+        "salary_min": 80000,
+        "salary_max": 90000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "OneTrust"
+        ],
+        "keywords": [
+          "Procurement",
+          "Vendor Management",
+          "Contract Negotiation",
+          "Due Diligence",
+          "Vendor Lifecycle Management",
+          "Risk Management",
+          "Compliance",
+          "RFP",
+          "SLA Monitoring",
+          "Vendor Tiering"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "business-operations",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "2f6a19a7-acee-4224-8ca9-8d45a89a66d0",
+      "title": "Procurement Strategy & Innovation Lead",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2302,
+          "outputTokens": 202,
+          "cachedTokens": 0,
+          "totalTokens": 2504,
+          "estimatedUsd": 0.00031099999999999997,
+          "latencyMs": 1297,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Procurement Strategy & Innovation Lead",
+            "jobId": "2f6a19a7-acee-4224-8ca9-8d45a89a66d0"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade Financial Group is seeking a Procurement Strategy & Innovation Lead to overhaul its vendor management office. This role focuses on process modernization, AI-driven workflow automation, and managing the end-to-end procurement lifecycle within a hybrid work environment.",
+        "seniority_level": "lead",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Gemini",
+          "ClickUp"
+        ],
+        "keywords": [
+          "Procurement",
+          "Vendor Management",
+          "Process Mapping",
+          "Business Analysis",
+          "Workflow Automation",
+          "Contract Negotiation",
+          "Strategic Sourcing",
+          "Project Management",
+          "Systems Thinking",
+          "Compliance",
+          "Data Integrity"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "business-operations",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "bee6e083-e735-4702-9edf-d33f6611a81b",
+      "title": "Analyst, P&S & Buyins, Trade Operations",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2355,
+          "outputTokens": 302,
+          "cachedTokens": 0,
+          "totalTokens": 2657,
+          "estimatedUsd": 0.00035630000000000004,
+          "latencyMs": 1789,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Analyst, P&S & Buyins, Trade Operations",
+            "jobId": "bee6e083-e735-4702-9edf-d33f6611a81b"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade is seeking a Trade Operations Analyst to manage daily trade capture, reconciliation, and settlement processes. The role involves collaborating with internal teams and external counterparties to resolve disputes and mitigate risk within the Canadian and US securities markets.",
+        "seniority_level": "mid",
+        "salary_min": 55000,
+        "salary_max": 60000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "Broadridge",
+          "Power BI",
+          "SQL",
+          "Python",
+          "Google Apps Script",
+          "Arrow",
+          "CDS",
+          "DTC",
+          "Apex"
+        ],
+        "keywords": [
+          "trade operations",
+          "trade settlement",
+          "trade reconciliation",
+          "buy-ins",
+          "securities",
+          "broker-dealer",
+          "custodians",
+          "regulatory compliance",
+          "SLA management",
+          "risk management"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "customer-operations",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "ebb98abf-e790-4328-af02-27a665080f17",
+      "title": "Business Development Manager",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2254,
+          "outputTokens": 186,
+          "cachedTokens": 0,
+          "totalTokens": 2440,
+          "estimatedUsd": 0.0002998,
+          "latencyMs": 1226,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Business Development Manager",
+            "jobId": "ebb98abf-e790-4328-af02-27a665080f17"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade Financial Group is seeking a Business Development Manager to drive growth in their mortgage underwriting and fulfillment division. The role focuses on building broker partnerships, executing sales strategies, and ensuring compliance with AML and KYC regulatory requirements.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Business Development",
+          "Mortgage Underwriting",
+          "Alternative Lending",
+          "Sales Strategy",
+          "Broker Relations",
+          "AML",
+          "KYC",
+          "Regulatory Compliance",
+          "Portfolio Growth",
+          "Financial Services",
+          "Risk Management"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "business-development-partnerships",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "05723ea6-b50a-467a-a2d3-64d812d74d87",
+      "title": "Senior Product Analyst, Secured Lending",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2384,
+          "outputTokens": 250,
+          "cachedTokens": 0,
+          "totalTokens": 2634,
+          "estimatedUsd": 0.0003384,
+          "latencyMs": 1614,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Product Analyst, Secured Lending",
+            "jobId": "05723ea6-b50a-467a-a2d3-64d812d74d87"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is seeking a Senior Product Analyst to support its secured lending and mortgage strategy. The role focuses on data-driven insights, journey optimization, and cross-functional collaboration to drive acquisition and portfolio growth within the Canadian digital banking market.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Tableau",
+          "Power BI",
+          "SQL",
+          "Python"
+        ],
+        "keywords": [
+          "Secured Lending",
+          "Mortgage",
+          "Product Strategy",
+          "Data Analytics",
+          "Client Journey Mapping",
+          "Process Optimization",
+          "Business Case Development",
+          "Campaign Analytics",
+          "Financial Services",
+          "Portfolio Growth"
+        ],
+        "standardized_department": "Product",
+        "function_category": "data-analytics-bi",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "7f26c2e3-a760-43a1-89b6-9b6dac57a186",
+      "title": "Customer Experience Advisor",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2308,
+          "outputTokens": 249,
+          "cachedTokens": 0,
+          "totalTokens": 2557,
+          "estimatedUsd": 0.0003304,
+          "latencyMs": 1216,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Customer Experience Advisor",
+            "jobId": "7f26c2e3-a760-43a1-89b6-9b6dac57a186"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Customer Experience Advisor will provide professional service to Tangerine clients via inbound, outbound, and eService channels. The role involves managing complex financial transactions, educating clients on banking products, and ensuring compliance with regulatory and risk standards.",
+        "seniority_level": "junior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "customer service",
+          "contact center",
+          "financial services",
+          "banking products",
+          "TFSA",
+          "RSP",
+          "RIF",
+          "client relationship management",
+          "AML",
+          "compliance",
+          "risk management",
+          "inbound sales",
+          "outbound sales",
+          "eService"
+        ],
+        "standardized_department": "Support",
+        "function_category": "customer-support-cx",
+        "location_structured": {
+          "city": "Santo Domingo",
+          "state": "Distrito Nacional",
+          "country": "Dominican Republic",
+          "formatted": "Santo Domingo, Dominican Republic"
+        }
+      }
+    },
+    {
+      "jobId": "2eac4d10-ab20-45f0-96b7-867f344c4090",
+      "title": "Mortgage Solutions Manager - Tangerine",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2290,
+          "outputTokens": 182,
+          "cachedTokens": 0,
+          "totalTokens": 2472,
+          "estimatedUsd": 0.0003018,
+          "latencyMs": 1290,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Mortgage Solutions Manager - Tangerine",
+            "jobId": "2eac4d10-ab20-45f0-96b7-867f344c4090"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is seeking a Mortgage Solutions Manager to manage the end-to-end mortgage acquisition process. This role focuses on driving sales, providing consultative mortgage advice, and managing client pipelines from lead generation to funding.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Mortgage Origination",
+          "Secured Lending",
+          "Sales",
+          "HELOC",
+          "Underwriting",
+          "Client Acquisition",
+          "Relationship Management",
+          "Financial Advisory",
+          "Lead Conversion",
+          "Residential Mortgages"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "f3a3502b-9da2-4d26-b280-822eb5e40213",
+      "title": "Manager, Fraud Analytics",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2120,
+          "outputTokens": 248,
+          "cachedTokens": 0,
+          "totalTokens": 2368,
+          "estimatedUsd": 0.00031120000000000003,
+          "latencyMs": 1525,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Manager, Fraud Analytics",
+            "jobId": "f3a3502b-9da2-4d26-b280-822eb5e40213"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is seeking a Manager of Fraud Analytics to develop and monitor fraud mitigation strategies for retail banking products. The role involves leveraging data mining tools to analyze trends, minimize losses, and collaborate with IT and business partners to enhance fraud operations.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Python",
+          "R",
+          "PRM"
+        ],
+        "keywords": [
+          "Fraud Analytics",
+          "Risk Management",
+          "Retail Banking",
+          "Unsecured Lending",
+          "Secured Lending",
+          "Data Mining",
+          "Statistical Analysis",
+          "Payment Industry",
+          "Fraud Mitigation",
+          "Risk Appetite"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "fraud-trust-safety",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    }
+  ]
+}

--- a/web/scripts/artifacts/diff-extract-a689dae.json
+++ b/web/scripts/artifacts/diff-extract-a689dae.json
@@ -1,0 +1,512 @@
+{
+  "baseline": {
+    "path": "scripts/artifacts/baseline-extract-structure-ce4ff9a.json",
+    "model": "gemini-flash-latest",
+    "totals": {
+      "calls": 23,
+      "inputTokens": 53403,
+      "outputTokens": 5751,
+      "cachedTokens": 0,
+      "totalTokens": 93706,
+      "estimatedUsd": 0.030398,
+      "avgLatencyMs": 9146
+    },
+    "processedCount": 20
+  },
+  "candidate": {
+    "path": "scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-a689dae.json",
+    "model": "gemini-flash-lite-latest",
+    "totals": {
+      "calls": 20,
+      "inputTokens": 47055,
+      "outputTokens": 4764,
+      "cachedTokens": 0,
+      "totalTokens": 51819,
+      "estimatedUsd": 0.006611,
+      "avgLatencyMs": 1547
+    },
+    "processedCount": 20
+  },
+  "commonJobs": 20,
+  "stats": {
+    "function_category": {
+      "match": 16,
+      "total": 20
+    },
+    "seniority_level": {
+      "match": 16,
+      "total": 20
+    },
+    "standardized_department": {
+      "match": 19,
+      "total": 20
+    },
+    "tech_stack_jaccard_sum": 17.55,
+    "tech_stack_pairs": 20,
+    "keywords_jaccard_sum": 8.310528437850419,
+    "keywords_pairs": 20
+  },
+  "partial": {
+    "baselineNullOutputs": 0,
+    "candidateNullOutputs": 0,
+    "baselineRetries": 3,
+    "candidateRetries": 0,
+    "baselineMissingCategory": 0,
+    "candidateMissingCategory": 0
+  },
+  "cost": {
+    "deltaUsd": -0.023787,
+    "percentChange": -78.25
+  },
+  "latency": {
+    "deltaMs": -7599,
+    "percentChange": -83.1
+  },
+  "acceptance": {
+    "l1AgreementGte95": false,
+    "partialExtractionNotWorse": true,
+    "overall": false
+  },
+  "perJobDiffs": [
+    {
+      "jobId": "c7aea83d-c1ad-4198-9195-e7e8c8b2c377",
+      "title": "Associate, Commercial Credit, Commercial Finance Group (CFG)",
+      "companySlug": "eq-bank",
+      "function_category": {
+        "baseline": "risk-management",
+        "candidate": "risk-management",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "senior",
+        "match": false
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Finance",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.31
+    },
+    {
+      "jobId": "e4b91622-2162-4a87-a751-c287c9b0413b",
+      "title": "Senior Manager, Operational Risk Management",
+      "companySlug": "eq-bank",
+      "function_category": {
+        "baseline": "risk-management",
+        "candidate": "risk-management",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Operations",
+        "match": false
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.25
+    },
+    {
+      "jobId": "85a09b75-1ff4-439d-b0d9-670a453cd468",
+      "title": "Senior Director, Asset and Liability Management (ALM)",
+      "companySlug": "eq-bank",
+      "function_category": {
+        "baseline": "capital-markets-treasury",
+        "candidate": "capital-markets-treasury",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "executive",
+        "candidate": "senior",
+        "match": false
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Finance",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.63
+    },
+    {
+      "jobId": "a1ab7ccd-68fe-49db-948f-e453716a8abe",
+      "title": "Senior Backend Engineer",
+      "companySlug": "eq-bank",
+      "function_category": {
+        "baseline": "engineering-backend",
+        "candidate": "fraud-trust-safety",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Engineering",
+        "candidate": "Engineering",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.53
+    },
+    {
+      "jobId": "83177ac3-270d-41e9-9ad7-983ad3ed3fd4",
+      "title": "Senior Business Analyst, Fraud Strategy",
+      "companySlug": "koho",
+      "function_category": {
+        "baseline": "fraud-trust-safety",
+        "candidate": "fraud-trust-safety",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.5
+    },
+    {
+      "jobId": "3b4b39de-b7a3-4bec-8367-91bf4b95ac7e",
+      "title": "Product Manager / Sr Product Manager, Credit Building",
+      "companySlug": "koho",
+      "function_category": {
+        "baseline": "product-management",
+        "candidate": "product-management",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Product",
+        "candidate": "Product",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.75,
+      "keywords_jaccard": 0.35
+    },
+    {
+      "jobId": "7c6f190a-7b87-4c04-8a0c-b44b9df2296f",
+      "title": "Director of Growth (Partnerships & Organic)",
+      "companySlug": "koho",
+      "function_category": {
+        "baseline": "marketing-growth-performance",
+        "candidate": "marketing-growth-performance",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "executive",
+        "candidate": "senior",
+        "match": false
+      },
+      "standardized_department": {
+        "baseline": "Marketing",
+        "candidate": "Marketing",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.58
+    },
+    {
+      "jobId": "bac85455-34f8-46ae-8c42-84ecb796215c",
+      "title": "Product and Regulatory Counsel",
+      "companySlug": "koho",
+      "function_category": {
+        "baseline": "regulatory-affairs",
+        "candidate": "legal",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Legal",
+        "candidate": "Legal",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.5
+    },
+    {
+      "jobId": "096d3a5d-e260-4204-9ae4-870d45250a9c",
+      "title": "Sales Representative - Toronto Premium Outlets",
+      "companySlug": "neo-financial",
+      "function_category": {
+        "baseline": "sales-account-executives",
+        "candidate": "sales-account-executives",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "junior",
+        "candidate": "junior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 0,
+      "keywords_jaccard": 0.21
+    },
+    {
+      "jobId": "c8fde90b-bb78-496a-aae4-a93480e391d3",
+      "title": "Product Manager, Fraud (PM / Senior / Lead)",
+      "companySlug": "neo-financial",
+      "function_category": {
+        "baseline": "fraud-trust-safety",
+        "candidate": "fraud-trust-safety",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Product",
+        "candidate": "Product",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.44
+    },
+    {
+      "jobId": "1b5f56da-4240-4480-8abc-d5d02183d926",
+      "title": "Analyst, Treasury Operations",
+      "companySlug": "neo-financial",
+      "function_category": {
+        "baseline": "capital-markets-treasury",
+        "candidate": "capital-markets-treasury",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Finance",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.33
+    },
+    {
+      "jobId": "1e72a7e1-43e9-40b2-9a7e-22fab0ece689",
+      "title": "District Sales Manager - Calgary ",
+      "companySlug": "neo-financial",
+      "function_category": {
+        "baseline": "sales-account-executives",
+        "candidate": "sales-account-executives",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.18
+    },
+    {
+      "jobId": "fdc2e7bc-b36c-488b-8dde-a4c2c6b214f5",
+      "title": "Senior Analyst, Procurement & Vendor Management",
+      "companySlug": "questrade",
+      "function_category": {
+        "baseline": "business-operations",
+        "candidate": "business-operations",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Finance",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.56
+    },
+    {
+      "jobId": "2f6a19a7-acee-4224-8ca9-8d45a89a66d0",
+      "title": "Procurement Strategy & Innovation Lead",
+      "companySlug": "questrade",
+      "function_category": {
+        "baseline": "business-operations",
+        "candidate": "business-operations",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "lead",
+        "candidate": "lead",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.5
+    },
+    {
+      "jobId": "bee6e083-e735-4702-9edf-d33f6611a81b",
+      "title": "Analyst, P&S & Buyins, Trade Operations",
+      "companySlug": "questrade",
+      "function_category": {
+        "baseline": "business-operations",
+        "candidate": "customer-operations",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.8,
+      "keywords_jaccard": 0.43
+    },
+    {
+      "jobId": "ebb98abf-e790-4328-af02-27a665080f17",
+      "title": "Business Development Manager",
+      "companySlug": "questrade",
+      "function_category": {
+        "baseline": "business-development-partnerships",
+        "candidate": "business-development-partnerships",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "senior",
+        "match": false
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.3
+    },
+    {
+      "jobId": "05723ea6-b50a-467a-a2d3-64d812d74d87",
+      "title": "Senior Product Analyst, Secured Lending",
+      "companySlug": "tangerine",
+      "function_category": {
+        "baseline": "product-management",
+        "candidate": "data-analytics-bi",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Product",
+        "candidate": "Product",
+        "match": true
+      },
+      "tech_stack_jaccard": 0,
+      "keywords_jaccard": 0.35
+    },
+    {
+      "jobId": "7f26c2e3-a760-43a1-89b6-9b6dac57a186",
+      "title": "Customer Experience Advisor",
+      "companySlug": "tangerine",
+      "function_category": {
+        "baseline": "customer-support-cx",
+        "candidate": "customer-support-cx",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "junior",
+        "candidate": "junior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Support",
+        "candidate": "Support",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.5
+    },
+    {
+      "jobId": "2eac4d10-ab20-45f0-96b7-867f344c4090",
+      "title": "Mortgage Solutions Manager - Tangerine",
+      "companySlug": "tangerine",
+      "function_category": {
+        "baseline": "sales-account-executives",
+        "candidate": "sales-account-executives",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.33
+    },
+    {
+      "jobId": "f3a3502b-9da2-4d26-b280-822eb5e40213",
+      "title": "Manager, Fraud Analytics",
+      "companySlug": "tangerine",
+      "function_category": {
+        "baseline": "fraud-trust-safety",
+        "candidate": "fraud-trust-safety",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.5
+    }
+  ]
+}

--- a/web/scripts/diff-extract-artifacts.ts
+++ b/web/scripts/diff-extract-artifacts.ts
@@ -1,0 +1,337 @@
+/**
+ * Phase 4 quality check: diff two `extract-structure` artifacts (baseline
+ * vs candidate) on the critical structured fields and on partial-extraction
+ * rate. Writes a markdown summary and a JSON artifact.
+ *
+ * Does NOT call Gemini. Runs offline against two committed artifacts.
+ *
+ * Usage:
+ *   cd web
+ *   npx tsx scripts/diff-extract-artifacts.ts \
+ *     --baseline=scripts/artifacts/baseline-extract-structure-ce4ff9a.json \
+ *     --candidate=scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-a689dae.json
+ *
+ * Acceptance (Phase 4 plan):
+ *   - L1 agreement on function_category, seniority_level,
+ *     standardized_department >=95%
+ *   - partial-extraction rate not worse than baseline
+ */
+
+import { readFile, writeFile, mkdir } from "fs/promises";
+import { resolve } from "path";
+import { execSync } from "child_process";
+
+interface Output {
+  summary?: string;
+  seniority_level?: string;
+  salary?: unknown;
+  tech_stack?: string[];
+  keywords?: string[];
+  standardized_department?: string;
+  function_category?: string;
+  location_structured?: unknown;
+}
+
+interface PerJob {
+  jobId: string;
+  title: string;
+  companySlug: string;
+  calls: Array<{ inputTokens: number; outputTokens: number; estimatedUsd: number; extra?: Record<string, unknown> }>;
+  output: Output | null;
+  errorMessage?: string;
+}
+
+interface Artifact {
+  scenario: string;
+  totals: { calls: number; estimatedUsd: number; inputTokens: number; outputTokens: number; avgLatencyMs: number };
+  processedCount: number;
+  perJob: PerJob[];
+  byCallSite: Record<string, { calls: number; modelsServed: string[] }>;
+}
+
+function gitSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+function pct(n: number, d: number): number {
+  return d === 0 ? 0 : Number(((n / d) * 100).toFixed(1));
+}
+
+function normalizeDept(s: string | undefined): string {
+  return (s ?? "").toLowerCase().trim();
+}
+
+function jaccard(a: string[] = [], b: string[] = []): number {
+  const sa = new Set(a.map((x) => x.toLowerCase().trim()).filter(Boolean));
+  const sb = new Set(b.map((x) => x.toLowerCase().trim()).filter(Boolean));
+  if (sa.size === 0 && sb.size === 0) return 1;
+  let inter = 0;
+  for (const x of sa) if (sb.has(x)) inter++;
+  const union = sa.size + sb.size - inter;
+  return union === 0 ? 0 : inter / union;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const baselineFlag = args.find((a) => a.startsWith("--baseline="));
+  const candidateFlag = args.find((a) => a.startsWith("--candidate="));
+  if (!baselineFlag || !candidateFlag) {
+    console.error("Missing --baseline=<path> and/or --candidate=<path>.");
+    process.exit(1);
+  }
+  const baselinePath = baselineFlag.slice("--baseline=".length);
+  const candidatePath = candidateFlag.slice("--candidate=".length);
+
+  const baseline = JSON.parse(await readFile(baselinePath, "utf8")) as Artifact;
+  const candidate = JSON.parse(await readFile(candidatePath, "utf8")) as Artifact;
+
+  const baselineModel = Object.values(baseline.byCallSite)[0]?.modelsServed.join(",") ?? "unknown";
+  const candidateModel = Object.values(candidate.byCallSite)[0]?.modelsServed.join(",") ?? "unknown";
+
+  const baseByJob = new Map<string, PerJob>(baseline.perJob.map((p) => [p.jobId, p]));
+  const candByJob = new Map<string, PerJob>(candidate.perJob.map((p) => [p.jobId, p]));
+  const commonJobIds = [...baseByJob.keys()].filter((id) => candByJob.has(id));
+
+  const stats = {
+    function_category: { match: 0, total: 0 },
+    seniority_level: { match: 0, total: 0 },
+    standardized_department: { match: 0, total: 0 },
+    tech_stack_jaccard_sum: 0,
+    tech_stack_pairs: 0,
+    keywords_jaccard_sum: 0,
+    keywords_pairs: 0,
+  };
+  const partial = {
+    baselineNullOutputs: 0,
+    candidateNullOutputs: 0,
+    baselineRetries: 0,
+    candidateRetries: 0,
+    baselineMissingCategory: 0,
+    candidateMissingCategory: 0,
+  };
+  const perJobDiffs: Array<{
+    jobId: string;
+    title: string;
+    companySlug: string;
+    function_category: { baseline?: string; candidate?: string; match: boolean };
+    seniority_level: { baseline?: string; candidate?: string; match: boolean };
+    standardized_department: { baseline?: string; candidate?: string; match: boolean };
+    tech_stack_jaccard: number;
+    keywords_jaccard: number;
+  }> = [];
+
+  for (const jobId of commonJobIds) {
+    const b = baseByJob.get(jobId)!;
+    const c = candByJob.get(jobId)!;
+
+    if (b.output === null) partial.baselineNullOutputs++;
+    if (c.output === null) partial.candidateNullOutputs++;
+    // Retries: any call after the first on the same job
+    if (b.calls.length > 1) partial.baselineRetries += b.calls.length - 1;
+    if (c.calls.length > 1) partial.candidateRetries += c.calls.length - 1;
+
+    const bo = b.output ?? {};
+    const co = c.output ?? {};
+
+    if (!bo.function_category) partial.baselineMissingCategory++;
+    if (!co.function_category) partial.candidateMissingCategory++;
+
+    // Categories
+    if (bo.function_category || co.function_category) {
+      stats.function_category.total++;
+      if (bo.function_category === co.function_category) stats.function_category.match++;
+    }
+    if (bo.seniority_level || co.seniority_level) {
+      stats.seniority_level.total++;
+      if (bo.seniority_level === co.seniority_level) stats.seniority_level.match++;
+    }
+    if (bo.standardized_department || co.standardized_department) {
+      stats.standardized_department.total++;
+      if (normalizeDept(bo.standardized_department) === normalizeDept(co.standardized_department))
+        stats.standardized_department.match++;
+    }
+
+    const tj = jaccard(bo.tech_stack, co.tech_stack);
+    const kj = jaccard(bo.keywords, co.keywords);
+    if (bo.tech_stack || co.tech_stack) {
+      stats.tech_stack_jaccard_sum += tj;
+      stats.tech_stack_pairs++;
+    }
+    if (bo.keywords || co.keywords) {
+      stats.keywords_jaccard_sum += kj;
+      stats.keywords_pairs++;
+    }
+
+    perJobDiffs.push({
+      jobId,
+      title: b.title,
+      companySlug: b.companySlug,
+      function_category: {
+        baseline: bo.function_category,
+        candidate: co.function_category,
+        match: bo.function_category === co.function_category,
+      },
+      seniority_level: {
+        baseline: bo.seniority_level,
+        candidate: co.seniority_level,
+        match: bo.seniority_level === co.seniority_level,
+      },
+      standardized_department: {
+        baseline: bo.standardized_department,
+        candidate: co.standardized_department,
+        match:
+          normalizeDept(bo.standardized_department) === normalizeDept(co.standardized_department),
+      },
+      tech_stack_jaccard: Number(tj.toFixed(2)),
+      keywords_jaccard: Number(kj.toFixed(2)),
+    });
+  }
+
+  const costDeltaUsd = candidate.totals.estimatedUsd - baseline.totals.estimatedUsd;
+  const costPercentChange =
+    baseline.totals.estimatedUsd > 0
+      ? (costDeltaUsd / baseline.totals.estimatedUsd) * 100
+      : 0;
+  const latencyPercentChange =
+    baseline.totals.avgLatencyMs > 0
+      ? ((candidate.totals.avgLatencyMs - baseline.totals.avgLatencyMs) /
+          baseline.totals.avgLatencyMs) *
+        100
+      : 0;
+
+  const l1Pass =
+    pct(stats.function_category.match, stats.function_category.total) >= 95 &&
+    pct(stats.seniority_level.match, stats.seniority_level.total) >= 95 &&
+    pct(stats.standardized_department.match, stats.standardized_department.total) >= 95;
+  const partialPass =
+    partial.candidateNullOutputs <= partial.baselineNullOutputs &&
+    partial.candidateMissingCategory <= partial.baselineMissingCategory;
+
+  const report = {
+    baseline: {
+      path: baselinePath,
+      model: baselineModel,
+      totals: baseline.totals,
+      processedCount: baseline.processedCount,
+    },
+    candidate: {
+      path: candidatePath,
+      model: candidateModel,
+      totals: candidate.totals,
+      processedCount: candidate.processedCount,
+    },
+    commonJobs: commonJobIds.length,
+    stats,
+    partial,
+    cost: {
+      deltaUsd: Number(costDeltaUsd.toFixed(6)),
+      percentChange: Number(costPercentChange.toFixed(2)),
+    },
+    latency: {
+      deltaMs: candidate.totals.avgLatencyMs - baseline.totals.avgLatencyMs,
+      percentChange: Number(latencyPercentChange.toFixed(1)),
+    },
+    acceptance: {
+      l1AgreementGte95: l1Pass,
+      partialExtractionNotWorse: partialPass,
+      overall: l1Pass && partialPass,
+    },
+    perJobDiffs,
+  };
+
+  const outDir = resolve(process.cwd(), "scripts/artifacts");
+  await mkdir(outDir, { recursive: true });
+  const outPath = resolve(outDir, `diff-extract-${gitSha()}.json`);
+  await writeFile(outPath, JSON.stringify(report, null, 2));
+
+  // Markdown
+  const lines: string[] = [];
+  lines.push(`# extract-structure diff: baseline vs candidate`);
+  lines.push("");
+  lines.push(
+    `- baseline: \`${baselinePath.split("/").slice(-2).join("/")}\` (model: ${baselineModel})`
+  );
+  lines.push(
+    `- candidate: \`${candidatePath.split("/").slice(-2).join("/")}\` (model: ${candidateModel})`
+  );
+  lines.push(`- common jobs: ${commonJobIds.length}`);
+  lines.push("");
+  lines.push(`## Cost + latency`);
+  lines.push(
+    `- baseline: ${baseline.totals.calls} calls, $${baseline.totals.estimatedUsd.toFixed(6)}, ${baseline.totals.avgLatencyMs} ms avg`
+  );
+  lines.push(
+    `- candidate: ${candidate.totals.calls} calls, $${candidate.totals.estimatedUsd.toFixed(6)}, ${candidate.totals.avgLatencyMs} ms avg`
+  );
+  lines.push(
+    `- cost delta: $${costDeltaUsd.toFixed(6)} (**${costPercentChange.toFixed(1)}%**)`
+  );
+  lines.push(
+    `- latency delta: ${candidate.totals.avgLatencyMs - baseline.totals.avgLatencyMs} ms (${latencyPercentChange.toFixed(1)}%)`
+  );
+  lines.push("");
+  lines.push(`## L1 — structured-field agreement`);
+  lines.push("");
+  lines.push("| field | match / total | agreement | threshold |");
+  lines.push("|---|---|---|---|");
+  lines.push(
+    `| function_category | ${stats.function_category.match} / ${stats.function_category.total} | **${pct(stats.function_category.match, stats.function_category.total)}%** | ≥95% |`
+  );
+  lines.push(
+    `| seniority_level | ${stats.seniority_level.match} / ${stats.seniority_level.total} | **${pct(stats.seniority_level.match, stats.seniority_level.total)}%** | ≥95% |`
+  );
+  lines.push(
+    `| standardized_department (case-insensitive) | ${stats.standardized_department.match} / ${stats.standardized_department.total} | **${pct(stats.standardized_department.match, stats.standardized_department.total)}%** | ≥95% |`
+  );
+  lines.push(
+    `| tech_stack jaccard | ${stats.tech_stack_pairs} pairs | avg ${(stats.tech_stack_jaccard_sum / Math.max(1, stats.tech_stack_pairs)).toFixed(2)} | — |`
+  );
+  lines.push(
+    `| keywords jaccard | ${stats.keywords_pairs} pairs | avg ${(stats.keywords_jaccard_sum / Math.max(1, stats.keywords_pairs)).toFixed(2)} | — |`
+  );
+  lines.push(`- L1 acceptance (critical fields ≥95%): ${l1Pass ? "**PASS**" : "**FAIL**"}`);
+  lines.push("");
+  lines.push(`## Partial-extraction rate`);
+  lines.push("");
+  lines.push("| metric | baseline | candidate |");
+  lines.push("|---|---|---|");
+  lines.push(`| null outputs | ${partial.baselineNullOutputs} | ${partial.candidateNullOutputs} |`);
+  lines.push(`| retries (calls beyond first per job) | ${partial.baselineRetries} | ${partial.candidateRetries} |`);
+  lines.push(`| missing function_category | ${partial.baselineMissingCategory} | ${partial.candidateMissingCategory} |`);
+  lines.push(`- acceptance (not worse than baseline): ${partialPass ? "**PASS**" : "**FAIL**"}`);
+  lines.push("");
+  lines.push(`## Per-job field diffs`);
+  lines.push("");
+  lines.push("| company / title | function_category | seniority | department | tech jaccard | kw jaccard |");
+  lines.push("|---|---|---|---|---|---|");
+  for (const d of perJobDiffs) {
+    const catCell = d.function_category.match
+      ? "✓"
+      : `${d.function_category.baseline ?? "—"} → ${d.function_category.candidate ?? "—"}`;
+    const senCell = d.seniority_level.match
+      ? "✓"
+      : `${d.seniority_level.baseline ?? "—"} → ${d.seniority_level.candidate ?? "—"}`;
+    const deptCell = d.standardized_department.match
+      ? "✓"
+      : `${d.standardized_department.baseline ?? "—"} → ${d.standardized_department.candidate ?? "—"}`;
+    const title = `${d.companySlug} / ${d.title}`.slice(0, 70);
+    lines.push(
+      `| ${title} | ${catCell} | ${senCell} | ${deptCell} | ${d.tech_stack_jaccard} | ${d.keywords_jaccard} |`
+    );
+  }
+  lines.push("");
+  lines.push(`**Overall acceptance: ${report.acceptance.overall ? "**PASS**" : "**FAIL**"}**`);
+  lines.push("");
+  lines.push(`artifact: ${outPath}`);
+
+  console.log(lines.join("\n"));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/scripts/gemini-compare.ts
+++ b/web/scripts/gemini-compare.ts
@@ -18,6 +18,11 @@
  * Flags:
  *   --scenario=extract-structure | analyze-advanced
  *   --mode=baseline                  (compare mode ships with Phase 2)
+ *   --model=<alias>                  For extract-structure: override the default
+ *                                    model (`gemini-flash-latest`) with a Phase 4
+ *                                    candidate (e.g. `gemini-flash-lite-latest`).
+ *                                    The model appears in the artifact filename
+ *                                    so Flash vs Flash-Lite runs don't stomp.
  *   --limit=N                        Cap jobs processed (defaults: 20 for extract, 10 for analyze)
  *   --dry-run                        Skip Gemini calls; still emits the artifact skeleton
  */
@@ -28,6 +33,10 @@ import { execSync } from "child_process";
 
 import { extractJobStructure, type JobStructureForDB } from "@/lib/analysis/structure";
 import { analyzeJobAdvanced, type AdvancedAnalyzeResult } from "@/lib/analysis/advanced-strategic";
+import {
+  DEFAULT_JOB_STRUCTURE_AI_CONFIG,
+  type AllowedAiModel,
+} from "@/lib/ai/prompt-config";
 import type { UsageRecord } from "@/lib/ai/gemini-meter";
 
 type Scenario = "extract-structure" | "analyze-advanced";
@@ -38,6 +47,7 @@ interface Flags {
   mode: Mode;
   limit: number | null;
   dryRun: boolean;
+  model: string | null;
 }
 
 interface FixtureJob {
@@ -97,6 +107,7 @@ function parseFlags(argv: string[]): Flags {
   let mode: Mode = "baseline";
   let limit: number | null = null;
   let dryRun = false;
+  let model: string | null = null;
 
   for (const a of argv) {
     if (a.startsWith("--scenario=")) {
@@ -113,6 +124,8 @@ function parseFlags(argv: string[]): Flags {
       mode = v;
     } else if (a.startsWith("--limit=")) {
       limit = Math.max(1, parseInt(a.slice("--limit=".length), 10) || 0);
+    } else if (a.startsWith("--model=")) {
+      model = a.slice("--model=".length);
     } else if (a === "--dry-run") {
       dryRun = true;
     }
@@ -124,7 +137,11 @@ function parseFlags(argv: string[]): Flags {
     );
   }
 
-  return { scenario, mode, limit, dryRun };
+  if (model && scenario !== "extract-structure") {
+    throw new Error(`--model override only applies to --scenario=extract-structure`);
+  }
+
+  return { scenario, mode, limit, dryRun, model };
 }
 
 function gitSha(): string {
@@ -268,7 +285,17 @@ async function runExtractStructure(
       continue;
     }
     try {
+      // Phase 4: allow --model= override to route extraction through a
+      // different model (e.g. gemini-flash-lite-latest) without editing the
+      // default config.
+      const configOverride = flags.model
+        ? {
+            ...DEFAULT_JOB_STRUCTURE_AI_CONFIG,
+            model: flags.model as AllowedAiModel,
+          }
+        : undefined;
       const out = await extractJobStructure(job.title, job.description_text, job.department, {
+        ...(configOverride ? { config: configOverride } : {}),
         onUsage: (u) => callsForJob.push({ ...u, extra: { ...u.extra, jobId: job.id } }),
       });
       results.push({
@@ -383,9 +410,10 @@ async function main() {
 
   const artifactDir = resolve(process.cwd(), "scripts/artifacts");
   await mkdir(artifactDir, { recursive: true });
+  const modelSuffix = flags.model ? `-${flags.model.replace(/[^a-z0-9-]/gi, "_")}` : "";
   const artifactPath = resolve(
     artifactDir,
-    `${flags.mode}-${flags.scenario}-${artifact.gitSha}.json`
+    `${flags.mode}-${flags.scenario}${modelSuffix}-${artifact.gitSha}.json`
   );
   await writeFile(artifactPath, JSON.stringify(artifact, null, 2));
   console.error(`\nartifact: ${artifactPath}`);


### PR DESCRIPTION
## Summary

Phase 4 of the Gemini cost-reduction plan: evaluate routing \`extractJobStructure\` through \`gemini-flash-lite-latest\` instead of \`gemini-flash-latest\`. **Result: don't swap.** Flash-Lite is 78% cheaper and 83% faster, but L1 agreement on the critical \`function_category\` and \`seniority_level\` fields is 80% — well below the Phase 4 ≥95% bar.

**Posting this as a negative-result PR** so the measurement tooling, the Flash-Lite enum entry, and the committed evidence are in-tree for future re-evaluation (Google rotates the alias, prompt changes, etc.). Production code is unchanged.

## Evidence

Ran \`gemini-compare.ts --scenario=extract-structure --model=gemini-flash-lite-latest\` against the same 20-job fixture as the Phase 1 Flash baseline, then diffed with the new [\`diff-extract-artifacts.ts\`](web/scripts/diff-extract-artifacts.ts).

### Cost and latency

| | calls | total USD | per-job USD | avg latency | retries |
|---|---|---|---|---|---|
| Flash (baseline) | 23 | \$0.030 | \$0.0015 | 9,146 ms | 3 |
| Flash-Lite (candidate) | 20 | **\$0.007** | **\$0.00033** | **1,547 ms** | **0** |
| delta | −3 | **−78.3%** | **−78.3%** | **−83.1%** | −3 |

### L1 — structured-field agreement

| field | match / total | agreement | ≥95% bar |
|---|---|---|---|
| \`function_category\` | 16 / 20 | **80%** | ❌ |
| \`seniority_level\` | 16 / 20 | **80%** | ❌ |
| \`standardized_department\` (case-insensitive) | 19 / 20 | **95%** | ✅ |
| \`tech_stack\` (jaccard avg) | — | 0.88 | — |
| \`keywords\` (jaccard avg) | — | 0.42 | — |

### Partial-extraction rate (PASS)

| metric | baseline | candidate |
|---|---|---|
| null outputs | 0 | 0 |
| retries (calls beyond first per job) | 3 | **0** |
| missing \`function_category\` | 0 | 0 |

Flash-Lite hit zero truncation or JSON-fix retry paths — strictly better on reliability.

## The L1 misses

Full diff table in [\`diff-extract-a689dae.json\`](web/scripts/artifacts/diff-extract-a689dae.json). Key failures:

- **\`function_category\`** — one real error, three defensible reclassifications:
  - \`Senior Backend Engineer\` → \`engineering-backend\` (Flash) → \`fraud-trust-safety\` (Flash-Lite) — **outright wrong for the candidate.** This is the blocker.
  - \`Product and Regulatory Counsel\` → \`regulatory-affairs → legal\` (parent/child taxonomy dispute)
  - \`Analyst, P&S & Buyins, Trade Operations\` → \`business-operations → customer-operations\`
  - \`Senior Product Analyst, Secured Lending\` → \`product-management → data-analytics-bi\` (defensible — job IS data-heavy)

- **\`seniority_level\`** — all four mismatches are fuzzy-boundary calls:
  - \`Associate, Commercial Credit\` → \`mid → senior\` (Flash-Lite up-leveled)
  - \`Senior Director, ALM\` → \`executive → senior\` (Flash-Lite down-leveled)
  - \`Director of Growth\` → \`executive → senior\` (Director ≠ executive is defensible)
  - \`Business Development Manager\` → \`mid → senior\` (Flash-Lite up-leveled)

The one hard error (Backend Engineer → fraud) alone is disqualifying. Combined with the seniority ambiguity, blind-swapping would introduce visible regressions on filtering and dashboards.

## What ships in this PR

- [\`prompt-config.ts\`](web/lib/ai/prompt-config.ts): adds \`gemini-flash-lite-latest\` to \`AI_MODEL_OPTIONS\` so future evals can route through it without hitting the Zod enum guard. No default changes.
- [\`gemini-compare.ts\`](web/scripts/gemini-compare.ts): new \`--model=<alias>\` flag for the extract-structure scenario. Artifact filename gets a model suffix so Flash and Flash-Lite runs don't stomp each other.
- [\`diff-extract-artifacts.ts\`](web/scripts/diff-extract-artifacts.ts): offline diff tool — L1 agreement on \`function_category\` / \`seniority_level\` / \`standardized_department\`, jaccard on \`tech_stack\` / \`keywords\`, partial-extraction rate delta, and a pass/fail verdict against the Phase 4 criteria.
- Committed artifacts: the Flash-Lite baseline run and the diff.

**No production model swap.** The default for extract-structure stays \`gemini-flash-latest\`.

## Production impact

None. \`extractJobStructure\` and all callers continue to use the Flash default. This PR is evidence + tooling + enum whitelist only.

## When to revisit

Re-run the evaluation when any of these change:
- Google rotates \`gemini-flash-lite-latest\` to a newer generation
- The extract prompt in \`prompt-config.ts\` changes materially
- \`ROLE_CATEGORIES\` taxonomy is revised (Phase-1 agreement bar is fragile across taxonomy edits)

\`\`\`
npx tsx --env-file=.env.local scripts/gemini-compare.ts \\
  --scenario=extract-structure --model=gemini-flash-lite-latest
npx tsx scripts/diff-extract-artifacts.ts \\
  --baseline=scripts/artifacts/baseline-extract-structure-<old-sha>.json \\
  --candidate=scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-<new-sha>.json
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)