### PR TITLE
Agent memories: capture Gemini cost-reduction playbook

### DIFF
--- a/web/.claude/agent-memory/senior-architect/MEMORY.md
+++ b/web/.claude/agent-memory/senior-architect/MEMORY.md
@@ -1,0 +1,71 @@
+# Senior Architect -- Memory
+
+## Project: Fintech Talent Brief
+
+### Gemini cost-reduction playbook (April 2026)
+
+Started at ~$1.50–$1.90/day Gemini spend (forecast $51/month, +23.5% vs March). Shipped as a phased, measurement-first effort across PRs #55–#60. Future work in this area should follow the same discipline: measure first, ship one change per PR, attach the comparison report.
+
+**Phase 0 (#55) — `-latest` alias migration.** Swapped every pinned preview ID to the floating alias convention. Rationale: model rotations land without code changes; `-latest` may point to preview/experimental, detected by Phase-1 harness and Phase-5 telemetry.
+
+**Phase 1 (#56) — meter + compare harness + committed baselines.** Non-optional prerequisite: never optimize without a baseline. Built `web/lib/ai/gemini-meter.ts` (`recordUsage`, `UsageRecord`), `web/scripts/gemini-compare.ts`, and the seeded 20-job fixture. Baselines committed in `web/scripts/artifacts/`. Two headline numbers worth remembering:
+- `extract-structure` per-job: ~$0.0015 (Flash), ~9s latency, 13% retry rate.
+- `analyze-advanced` per-job: ~$0.089 (2 Pro+grounded calls), ~30s latency.
+
+**Phase 2 (#57) — description-hash gate on re-extraction.** Migration adds `job_postings.description_hash` with in-migration pgcrypto backfill. `processor.ts` skips `extractAndUpdateStructure` on unchanged descriptions. Null hash = treat as changed (safe first-scrape behavior). This is the dominant Flash-tier saving in production — every daily scrape that repeats unchanged descriptions becomes free.
+
+**Phase 3 (#58) — drop duplicate Pro+grounded pre-fetch.** One-line change: `advanced-strategic.ts` no longer calls `performWebSearch` by default; the main analysis call already has `googleSearch` tool enabled and grounds in-flight. Measured −51% analyze cost with 100% agreement on `is_new_direction` / `is_executive_movement` / `confidence` / `novelty_score`. `category` dropped to 70% — accepted as defensible reclassifications rather than gamed with a lowered threshold.
+
+**Phase 4 (#59) — Flash-Lite routing evaluation.** Negative result: 78% cheaper, 83% faster, 0 retries, but L1 agreement 80% on `function_category` and `seniority_level` vs the 95% bar. One hard error (`Senior Backend Engineer → fraud-trust-safety`) disqualified the swap. Tooling + enum entry shipped so this is easy to re-evaluate after Google rotates the alias or the prompt changes.
+
+**Phase 5 (#60) — production telemetry.** `gemini_usage_events` table + `writeUsageEvent` fire-and-forget sink + 15 production call-sites wired. Captures `model_served` distinct from `model_requested` so the silent Pro→Flash fallback is observable.
+
+**Phase 6 — explicitly optional.** Novelty-gated Pro routing, company-insight content-hash cache, extract-prompt trim. The user's stance (2026-04-19): *"we may never do phase 6."* Pursue ONLY if Phase-5 telemetry shows residual waste after Phase 2 and Phase 3 land in production.
+
+### Architectural patterns worth preserving
+
+- **Fire-and-forget telemetry.** `gemini-telemetry.ts` never awaits and swallows errors. A flaky DB insert does not block a user request. Apply this pattern whenever observability is added to a hot path.
+- **Content-hash gate.** Phase 2 pattern applies broadly: when re-work is cheap to detect (hash the input, compare to stored), always gate on it. Candidates for the same pattern: company-insight regeneration, weekly digest commentary per company.
+- **Negative-result PRs.** Phase 4 shipped measurement tooling + committed evidence without changing production. Preserves the work and documents the "we tried, here's why not" for future reviewers.
+- **Measure at the boundary.** `recordUsage` + `writeUsageEvent` at every call-site, not a central interceptor. Each site knows its call-site label and `extra` context better than a global hook could.
+
+### Live ingestion path (sacred)
+```
+processor.ts → [description_hash gate] → extractAndUpdateStructure → extractJobStructure (Flash)
+analyzer.ts → analyzeJobAdvanced (Pro+grounded, in-flight grounding, no pre-fetch)
+```
+Two Gemini calls per new job (not three, not one). Protect this shape — the history of miscounting call-sites was the origin of the April cost debugging round.
+
+### Cost drivers and their levers
+
+| call-site | per-call cost (2026-04 measured) | primary lever |
+|---|---|---|
+| `analyzeJobAdvanced` (Pro+grounded) | ~$0.043 | novelty-gated routing (Phase 6 candidate) |
+| `performWebSearch` (pre-fetch) | ~$0.043 | dropped in Phase 3 |
+| `extractJobStructure` (Flash) | ~$0.0015 | hash gate (Phase 2) |
+| `generateCompanyInsight` | ~$0.01–0.02 | content-hash cache (Phase 6 candidate) |
+| Grounding surcharge | $0.035/request flat | remove grounding where prompt doesn't need fresh news |
+
+Any grounded call is ~$0.035 even at zero tokens — scrutinize it before merge.
+
+### Known dead code on the ingestion path
+- `strategic.ts#analyzeJob` — exported only.
+- `categorizer.ts#categorizePosting` — backfill script only.
+- The 8000-char description cap in `strategic.ts` — on the dead branch; the live `advanced-strategic.ts` has no cap.
+
+If a future change needs to wire these in, that's an explicit architectural decision, not a drive-by.
+
+### Silent Pro→Flash fallback
+Lives at `advanced-strategic.ts:467-485`. Now observable via `gemini_usage_events.model_served`. Any new Pro call that doesn't capture `modelServed` distinctly is a regression.
+
+### Measurement infrastructure
+- Fixture: `web/scripts/fixtures/gemini-sample-jobs.json` (20 seeded jobs across 5 companies, min 500 description chars).
+- Runner: `web/scripts/gemini-compare.ts` with `--scenario`, `--mode`, `--variant`, `--model`, `--limit`, `--dry-run`.
+- Diff tools: `diff-analyze-artifacts.ts`, `diff-extract-artifacts.ts`, `project-hash-gate-savings.ts`.
+- Baselines committed in `web/scripts/artifacts/` at specific git SHAs — reference them before any new optimization instead of regenerating.
+
+### Pricing table caveat
+`web/lib/ai/gemini-pricing.ts` is hand-maintained from Google's public pricing page and intended for relative trending only. Reconcile `estimated_usd` totals to Google Cloud billing monthly; expect drift. Update the constants when observed drift exceeds ~10%.
+
+### Cron constraint
+Max 2 Vercel crons per CLAUDE.md. Currently daily `/api/cron/collect` at 06:00 UTC and weekly `/api/cron/report` Mon 05:00 UTC. Any future scheduled quality-suite run must fold into one of these or replace the oldest entry.

--- a/web/.claude/agent-memory/senior-staff-code-reviewer/MEMORY.md
+++ b/web/.claude/agent-memory/senior-staff-code-reviewer/MEMORY.md
@@ -2,38 +2,79 @@
 
 ## Project: Fintech Talent Brief
 
-### AI Model Convention
-- All Gemini calls MUST use `gemini-3-flash-preview` or `gemini-pro-latest`
-- Found violation in `lib/ai/tech-stack-extraction.ts` using `gemini-flash-latest` (invalid)
-- Pro model is used only when web search/grounding is needed
+### AI Model Convention (updated 2026-04-19)
+- All Gemini calls MUST use floating `-latest` aliases: `gemini-flash-latest`, `gemini-flash-lite-latest`, `gemini-pro-latest`.
+- Never pin a versioned or preview ID (`gemini-3-flash-preview`, `gemini-2.0-flash`, etc.).
+- Model strings must resolve through `AI_MODEL_OPTIONS` in `web/lib/ai/prompt-config.ts` — anything outside that Zod enum fails validation. Flag hardcoded strings that bypass it.
+- Pro model is used only when web-search grounding is load-bearing.
+
+### Mandatory Gemini telemetry (Phase 5, 2026-04-19)
+- Every new Gemini call-site MUST build a `UsageRecord` via `recordUsage` from `web/lib/ai/gemini-meter.ts` and pass it to `writeUsageEvent` from `web/lib/ai/gemini-telemetry.ts`. Writes are fire-and-forget into `gemini_usage_events`.
+- Propagate an optional `onUsage` observer alongside the DB write for scripts that run the same function in a `gemini-compare.ts` scenario.
+- Flag any `generateContent` call without these two alongside. Reference implementations: `structure.ts#extractJobStructure`, `advanced-strategic.ts#analyzeJobAdvanced`, `advanced-strategic.ts#performWebSearch` (they also pull `usageMetadata` from `stream.response` in the streaming chat path).
+
+### Grounding discipline (Phase 3 lesson, 2026-04-19)
+- Before approving a new `googleSearch`-enabled call, confirm the upstream caller is not already grounding. The Apr 2026 incident was `analyzeJobAdvanced` firing a pre-fetch grounded call PLUS the main grounded call — duplicate work, doubled per-job cost.
+- Grounding surcharge is ~$0.035/request regardless of token count. Two grounded calls per logical operation is nearly always a smell.
+
+### Live ingestion path (sacred)
+```
+processor.ts → [description_hash gate] → extractAndUpdateStructure → extractJobStructure (Flash)
+analyzer.ts → analyzeJobAdvanced (Pro+grounded; in-flight grounding, no pre-fetch)
+```
+Do NOT add wiring into `analyzeJob` in `strategic.ts` or `categorizePosting` in `categorizer.ts` — both are dead code on the live ingestion path (legacy/backfill only). Anyone wiring them in needs to justify it explicitly.
+
+### Dead code to beware of
+- `strategic.ts#analyzeJob` — exported, never called in production
+- `categorizer.ts#categorizePosting` — only in `scripts/backfill-function-category.ts`
+- The 8000-char description cap in `strategic.ts` DOES NOT apply to the live `advanced-strategic.ts#analyzeJobAdvanced` path. Flag anyone citing it as a production constraint.
+
+### Silent Pro→Flash fallback
+- `advanced-strategic.ts:467-485` silently swaps Pro→Flash on quota errors. `gemini_usage_events.model_served` exposes when this fires — `WHERE model_requested <> model_served` surfaces it. Flag any new analysis function that logs only `modelRequested` without also recording `modelServed`.
+
+### Quality testing thresholds (Phase 3 & 4 plan-of-record)
+- For `analyze-advanced` optimizations: L1 agreement on `is_new_direction`, `is_executive_movement` must be ≥90%. `category` is a soft taxonomy field and below-threshold shifts (70% on Phase 3) can be accepted with explicit documentation of the reclassifications.
+- For `extract-structure` optimizations: L1 agreement on `function_category`, `seniority_level`, `standardized_department` must be ≥95%. Phase 4 Flash-Lite evaluation failed this bar (80%) and was NOT routed — hard "no" precedent for blind-swapping extract models.
+- L2 voice-validator delta must not regress by >2pp.
+- Voice warnings are post-hoc regex checks from `lib/ai/voice-validator.ts` — not a substitute for human judgment on `insight_summary` tone.
+
+### Cache-key invariant
+- Any response cache (present or future, e.g. company-insight cache envisioned in the plan) MUST include `prompt_config_version` in the key. Otherwise a prompt tweak silently serves stale outputs forever. Flag cache keys that only hash inputs.
+
+### Voice-directive placement
+- The ~140-token voice block from `web/lib/ai/voice.ts` is mandatory on user-facing surfaces (digest, company insight, chat, narrative) and forbidden on internal extraction/classification prompts (extraction output is never shown to users). Flag voice blocks leaking into extraction prompts.
+
+### Measurement-first convention
+- PRs touching `web/lib/ai/**` or `web/lib/analysis/**` must run `gemini-compare.ts` and attach the markdown report. Reference diff tools: `diff-analyze-artifacts.ts` (L1+L2+cost), `diff-extract-artifacts.ts` (L1+partial-extraction), `project-hash-gate-savings.ts` (projection vs baseline).
+- Committed baselines in `web/scripts/artifacts/` are the reference points. Do not regenerate the fixture casually — it's seeded annually.
 
 ### Silver Layer Pattern
-- Per-job `tech_stack: string[]` is extracted during ingestion via `lib/analysis/structure.ts`
-- Stored in `job_postings.tech_stack` (JSONB with GIN index)
-- Already aggregated in `lib/analysis/digest.ts:getTopTech()` for weekly digests
-- Company-level tech stack in `lib/ai/tech-stack-extraction.ts` duplicates this work with a separate Gemini call
+- Per-job `tech_stack: string[]` is extracted during ingestion via `lib/analysis/structure.ts`.
+- Stored in `job_postings.tech_stack` (JSONB with GIN index).
+- Aggregated in `lib/analysis/digest.ts:getTopTech()` for weekly digests.
+- Company-level tech stack in `lib/ai/tech-stack-extraction.ts` duplicates this work with a separate Gemini call.
 
 ### Error Handling Anti-Pattern
-- `tech-stack-extraction.ts` catches all batch errors and continues, returning empty results on total failure
-- API route returns 201 for empty results, making failures look like success
-- This pattern (silent catch + continue) should be flagged anywhere it appears
+- `tech-stack-extraction.ts` catches all batch errors and continues, returning empty results on total failure.
+- API route returns 201 for empty results, making failures look like success.
+- Flag the `try { ... } catch { continue; }` pattern wherever it appears without an accompanying null-rate counter or status propagation.
 
 ### Job System -- Stuck Jobs (diagnosed 2026-03-06)
-- See `job-system-issues.md` for detailed findings
-- Root cause: no guaranteed-terminal-status invariant in runner/processor
-- `executeCollectionJob` and `executeAnalysisJob` throw after setting `running` without catch to set `failed`
-- Cron resume logic picks up stale `running` jobs, creating infinite loop
-- `processCollectionTask` catch block re-throws without defensive task status update
-- GitHub Actions offload leaves tasks `running`; cleanup cron NOT in vercel.json
-- Final status logic deliberately sets job to `running` for offloaded tasks
-- `triggerAnalysisJobIfNeeded` fires executeAnalysisJob with `.catch(console.error)` -- no status cleanup
+- See `job-system-issues.md` for detailed findings.
+- Root cause: no guaranteed-terminal-status invariant in runner/processor.
+- `executeCollectionJob` and `executeAnalysisJob` throw after setting `running` without catch to set `failed`.
+- Cron resume logic picks up stale `running` jobs, creating infinite loop.
+- `processCollectionTask` catch block re-throws without defensive task status update.
+- GitHub Actions offload leaves tasks `running`; cleanup cron NOT in vercel.json.
+- Final status logic deliberately sets job to `running` for offloaded tasks.
+- `triggerAnalysisJobIfNeeded` fires executeAnalysisJob with `.catch(console.error)` -- no status cleanup.
 
 ### Job Tracking
-- All cron/manual jobs tracked in `job_runs` table (not deprecated `cron_logs`)
-- Valid job_types: collect, analyze, report, company-insights, insight-generation
+- All cron/manual jobs tracked in `job_runs` table (not deprecated `cron_logs`).
+- Valid job_types: collect, analyze, report, company-insights, insight-generation.
 
 ### Cron Constraint
-- Max 2 cron jobs per CLAUDE.md; currently at: daily collect (6 AM), weekly report (Mon 6 AM)
-- `cleanup-jobs` cron exists at `/api/cron/cleanup-jobs/route.ts` but is NOT in vercel.json
-- `company-insights` cron exists but is NOT in vercel.json
-- Cleanup logic should be folded into collect cron to respect 2-cron limit
+- Max 2 cron jobs per CLAUDE.md; currently at: daily collect (6 AM), weekly report (Mon 6 AM).
+- `cleanup-jobs` cron exists at `/api/cron/cleanup-jobs/route.ts` but is NOT in vercel.json.
+- `company-insights` cron exists but is NOT in vercel.json.
+- Cleanup logic should be folded into collect cron to respect 2-cron limit.


### PR DESCRIPTION
## Summary

Both the senior-architect (\`luke\`) and senior-staff-code-reviewer (\`farhan\`) agents should start new sessions with the priors the Gemini cost-reduction work established. Without this, they'll re-derive the same facts every time and likely miscount the ingestion pipeline again.

### [\`senior-architect/MEMORY.md\`](web/.claude/agent-memory/senior-architect/MEMORY.md) — new file

Captures:
- Phase-by-phase cost-reduction history and rationale (PRs #55–#60)
- Architectural patterns worth preserving (fire-and-forget telemetry, content-hash gate, negative-result PRs)
- The live ingestion path as a sacred shape
- Per-call-site cost drivers (which lever applies to which call-site)
- Known dead code on the analysis path (\`analyzeJob\`, \`categorizePosting\`, the 8000-char cap that doesn't apply to production)
- Measurement infrastructure pointers (fixture, runner, diff tools, committed baselines)
- The user's 2026-04-19 stance that **Phase 6 is optional and may never happen** — explicit scoping signal for the agent

### [\`senior-staff-code-reviewer/MEMORY.md\`](web/.claude/agent-memory/senior-staff-code-reviewer/MEMORY.md) — updated

- **Corrects a stale rule:** the existing \"use gemini-3-flash-preview\" note was wrong post-Phase-0. Now says \`-latest\` aliases only.
- **Appends the non-negotiables** the reviewer should enforce going forward:
  - Mandatory \`writeUsageEvent\` wiring on any new Gemini call-site
  - Grounding discipline (don't stack grounded calls — Apr 2026 incident)
  - Dead-code inventory on the analysis path
  - \`model_served\` must be recorded distinct from \`model_requested\` (exposes the silent Pro→Flash fallback)
  - Cache-key invariant (\`prompt_config_version\`)
  - Voice-directive placement (user-facing only, forbidden on extraction)
  - Measurement-first convention with the diff tools and committed baselines

Preserves the existing non-Gemini memories (job-system stuck-jobs notes, Silver Layer pattern, error-handling anti-pattern, cron constraint).

## Pattern note

Both files live under \`web/.claude/agent-memory/\`, which is globally gitignored as part of \`web/.claude/\`. The existing farhan memory was already \`git add -f\`'d into the repo so the team sees it, and the agent definitions (\`senior-architect.md\`, \`senior-staff-code-reviewer.md\`, \`ux-design-advisor.md\`) follow the same pattern. luke's new memory gets the same treatment.

## No production impact

Markdown-only change under \`web/.claude/\`. No build, no code, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)