### PR TITLE
fix: raise Stage 1 output token cap to 8192

### DIFF
--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "1.12.1",
+    "date": "2026-04-21",
+    "changes": [
+      { "type": "fix", "description": "Job structure extraction no longer truncates responses mid-JSON on long descriptions — raised the output token cap to match the runtime config, eliminating the wasted first-call retries that were firing on ~3 EQ Bank jobs per collection run." }
+    ]
+  },
+  {
     "version": "1.12.0",
     "date": "2026-04-19",
     "changes": [

--- a/web/lib/analysis/structure.ts
+++ b/web/lib/analysis/structure.ts
@@ -54,7 +54,7 @@ const GEMINI_REQUEST_TIMEOUT_MS = 30000;
 const MAX_STAGE1_DESCRIPTION_CHARS = 6000;
 const MIN_STAGE1_DESCRIPTION_CHARS = 3000;
 const STAGE1_RETRY_DESCRIPTION_STEP = 1500;
-const MAX_STAGE1_OUTPUT_TOKENS = 4096;
+const MAX_STAGE1_OUTPUT_TOKENS = 8192;
 
 // Extended type for database insertion (flattened salary fields)
 export interface JobStructureForDB extends Omit<JobStructure, "salary" | "location"> {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Fixes mid-JSON truncation in `extractJobStructure` on long descriptions by raising `MAX_STAGE1_OUTPUT_TOKENS` from 4096 → 8192
- Matches the runtime config already stored in `system_settings.job_structure_ai` (8192)
- Eliminates the wasted first Gemini Flash call + ~1s retry latency for the ~3 jobs per collect run that currently truncate (observed on EQ Bank jobs in the 2026-04-21 run)

## Why now
The 2026-04-21 22:59 UTC collect run logged three truncation warnings on EQ Bank roles (Administrative Assistant, Corporate Services Paralegal, Senior Director ALM). In every case Flash got cut off mid-JSON, fell into the retry path, and re-ran with a 4500-char description — succeeding but doubling the Gemini bill for those rows and adding latency. The cap was the cause, not the fix.

## Cost impact
Flash output tokens are cheap (~$0.30/1M) and only consumed when actually needed, so raising the ceiling has minimal impact on steady-state cost. The wins come from not paying for a truncated-then-retried call pair on the long-description rows.

## Test plan
- [x] `npm run build` passes locally
- [ ] Next cron-triggered collect run shows no "Response appears truncated" warnings for previously-failing jobs
- [ ] `gemini_usage_events` shows no increase in avg output_tokens across call_site=`extractJobStructure` (only the affected rows lift; rest unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)