### PR TITLE
fix(jobs): closed-job detection broken since the Phase 2 hash gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,10 @@ jobs:
         env:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
         run: |
-          if [ -z "$SUPABASE_SERVICE_ROLE_KEY" ] || [ -z "$NEXT_PUBLIC_SUPABASE_URL" ]; then
-            echo "::warning::Skipping authed e2e — Supabase secrets not configured for this runner"
+          if [ -z "$SUPABASE_SERVICE_ROLE_KEY" ] || [ -z "$NEXT_PUBLIC_SUPABASE_URL" ] || [ -z "$NEXT_PUBLIC_SUPABASE_ANON_KEY" ]; then
+            echo "::warning::Skipping authed e2e — Supabase secrets not configured for this runner (need URL, anon key, and service-role key)"
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.0.2",
+    "date": "2026-05-18",
+    "changes": [
+      { "type": "fix", "description": "Closed-job detection: jobs that drop out of an ATS feed are once again marked closed. A regression in the Phase 2 description-hash gate left the closure loop passing an object where a job id was expected, so no posting had been marked closed since 2026-04-19 — the \"Closed\" series on the Net hiring flow chart and the \"closed\" half of 7-Day Net both flatlined at zero. Backfilled the 147 missed closures with closed_date set to each job's last_seen_date, so they land on the timeline when they actually happened rather than spiking on the fix date." }
+    ]
+  },
+  {
     "version": "2.0.1",
     "date": "2026-04-28",
     "changes": [

--- a/web/lib/jobs/processor.ts
+++ b/web/lib/jobs/processor.ts
@@ -348,7 +348,7 @@ export async function runIngestStage(
     // Mark jobs as closed if no longer in feed
     // Only update jobs that are currently active to avoid overwriting
     // closed_date on already-closed jobs every collection run
-    for (const [extId, jobId] of existingMap) {
+    for (const [extId, entry] of existingMap) {
       if (!fetchedIds.has(extId)) {
         const { count } = await supabase
           .from('job_postings')
@@ -356,7 +356,7 @@ export async function runIngestStage(
             is_active: false,
             closed_date: new Date().toISOString(),
           })
-          .eq('id', jobId)
+          .eq('id', entry.id)
           .eq('is_active', true);
         if (count && count > 0) {
           closedJobs++;

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/supabase/migrations/20260518120000_backfill_missed_closures.sql
+++ b/web/supabase/migrations/20260518120000_backfill_missed_closures.sql
@@ -1,0 +1,26 @@
+-- Backfill closures missed by the closed-job detection regression.
+--
+-- The Phase 2 description-hash gate (20260419150000) changed `existingMap` in
+-- processor.ts from Map<external_id, id> to Map<external_id, {id, hash}> but
+-- left the closure loop destructuring the value as if it were still the id
+-- string. `.eq('id', {object})` matched zero rows, so no job has been marked
+-- closed since 2026-04-19. processor.ts is fixed alongside this migration.
+--
+-- This backfills the missed closures. A job is treated as closed if it is
+-- still is_active but was not seen in its company's most recent collect run
+-- (last_seen_date predates the day of companies.last_collected_at). closed_date
+-- is set to last_seen_date — the last time the job was actually in the feed —
+-- so closures land on the timeline when they really happened rather than
+-- spiking on the backfill date.
+--
+-- Companies whose scraper has not run recently (no fresh last_collected_at)
+-- are naturally excluded: their jobs share last_seen_date with last_collected_at
+-- and so fail the predicate. Idempotent — re-running closes nothing new.
+
+UPDATE job_postings j
+SET is_active = false,
+    closed_date = j.last_seen_date
+FROM companies c
+WHERE j.company_id = c.id
+  AND j.is_active = true
+  AND j.last_seen_date < date_trunc('day', c.last_collected_at);


### PR DESCRIPTION
## Problem

Closed-job detection broke on **2026-04-19** with the Phase 2 description-hash gate. The closure loop in `processor.ts` destructured the `existingMap` value as a job-id string, but Phase 2 changed it to a `{ id, descriptionHash }` object. `.eq('id', { object })` matches zero rows, so no jobs were marked closed for ~4 weeks — flatlining the "Closed" series and the closed half of 7-Day Net.

## Changes

- **`processor.ts`** — closure loop now uses `entry.id` instead of the whole object.
- **Migration `20260518120000_backfill_missed_closures.sql`** — applied to the DB. Backfilled **147 missed closures** with `closed_date = last_seen_date` so they spread across the timeline (continuous through May 11, no artificial spike on today's date). Idempotent.
- **Changelog** entry + version bump `2.0.1 → 2.0.2`.

The forward fix uses `now()` for genuinely new closures, which is correct now that the backlog is cleared.

## Notes / follow-ups

- **Monzo** has 51 jobs still `is_active = true` with `last_collected_at` of 2026-01-18 — its scraper hasn't run in 4 months (likely dropped from `config/companies.yaml`). The backfill deliberately excluded it; closing those with a January date would be misleading. Worth a separate decision on retiring those jobs.

## Verification

- `cd web && npm run build` passes.
- Migration applied and verified (147 rows backfilled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)