### PR TITLE
feat(schema): company tier column + fintech-default aggregator filter (big-6 banks, Phase 0)

### DIFF
--- a/web/lib/analysis/cross-company-themes.ts
+++ b/web/lib/analysis/cross-company-themes.ts
@@ -23,6 +23,7 @@ import { recordUsage } from "@/lib/ai/gemini-meter";
 import { writeUsageEvent } from "@/lib/ai/gemini-telemetry";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getCategoryGroup, type RoleCategory } from "./function-categories";
+import { DEFAULT_TIERS, type CompanyTier } from "@/lib/dashboard-queries";
 import { log } from "@/lib/log";
 
 export const THEME_LABELER_PROMPT_VERSION = "cross-company-themes-v1";
@@ -323,13 +324,20 @@ export async function persistThemeLabels(
  * call the labeler for any that are missing or stale, and persist results.
  * Returns the cached + fresh labels for downstream UI use.
  */
-export async function refreshAllThemeLabels(): Promise<ThemeLabelOutput[]> {
+export async function refreshAllThemeLabels(
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS,
+): Promise<ThemeLabelOutput[]> {
   const supabase = createAdminClient();
 
+  // Tier filter (default fintech-only) keeps incumbent keyword bags out of
+  // the cross-company labeler — otherwise bank hiring dwarfs every theme.
   const { data: jobs } = await supabase
     .from("job_postings")
-    .select("function_category, keywords, title, company_id, is_active")
+    .select(
+      "function_category, keywords, title, company_id, is_active, companies!inner(tier)"
+    )
     .eq("is_active", true)
+    .in("companies.tier", [...tiers])
     .not("function_category", "is", null);
 
   if (!jobs?.length) return [];

--- a/web/lib/analysis/digest.ts
+++ b/web/lib/analysis/digest.ts
@@ -19,6 +19,10 @@ import {
   aggregateRoleThemes,
   type RoleThemeSummary,
 } from "@/lib/analysis/role-themes";
+import {
+  DEFAULT_TIERS,
+  type CompanyTier,
+} from "@/lib/dashboard-queries";
 
 export type { RoleThemeSummary } from "@/lib/analysis/role-themes";
 export { aggregateRoleThemes } from "@/lib/analysis/role-themes";
@@ -486,12 +490,17 @@ export function buildWeeklyDigestCompanyInput(
   };
 }
 
-export async function getWeeklyData(daysBack: number = 7): Promise<Map<string, CompanyJobData>> {
+export async function getWeeklyData(
+  daysBack: number = 7,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS,
+): Promise<Map<string, CompanyJobData>> {
   const supabase = createAdminClient();
   const { weekStart, weekEnd } = getWeekBoundaries();
   const cutoffDate = new Date();
   cutoffDate.setUTCDate(cutoffDate.getUTCDate() - daysBack);
 
+  // Tier filter (default fintech-only) keeps the digest's cross-company
+  // themes from being skewed by big-bank volume.
   const query = supabase
     .from("job_postings")
     .select(`
@@ -511,10 +520,12 @@ export async function getWeeklyData(daysBack: number = 7): Promise<Map<string, C
         id,
         name,
         slug,
-        is_active
+        is_active,
+        tier
       )
     `)
     .eq("companies.is_active", true)
+    .in("companies.tier", [...tiers])
     .order("first_seen_date", { ascending: false });
 
   const { data: jobs, error } = daysBack === 7
@@ -673,9 +684,12 @@ export async function generateWeeklyReport(
   };
 }
 
-export async function createWeeklyDigest(daysBack: number = 7): Promise<WeeklyDigest> {
+export async function createWeeklyDigest(
+  daysBack: number = 7,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS,
+): Promise<WeeklyDigest> {
   console.log(`Generating weekly digest for the last ${daysBack} days...`);
-  const weeklyData = await getWeeklyData(daysBack);
+  const weeklyData = await getWeeklyData(daysBack, tiers);
   console.log(`Found ${weeklyData.size} companies with new job postings`);
   const digest = await generateWeeklyReport(weeklyData);
   console.log(`Generated digest with ${digest.total_jobs} total jobs`);

--- a/web/lib/dashboard-queries.test.ts
+++ b/web/lib/dashboard-queries.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Regression tests for the company-tier filter introduced in the big-6 bank
+ * integration plan (Phase 0). Big-bank "incumbent" rows must never leak into
+ * the cross-company volume aggregators by default — every aggregator filters
+ * via `.in("companies.tier", tiers)` with a fintech-only default. These
+ * tests fail if the filter is dropped from any aggregator we know skews
+ * volume views.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ----------------------------------------------------------------------------
+// Chain-recording Supabase mock.
+// ----------------------------------------------------------------------------
+// Every supabase-js query builder method returns the chainable object, so we
+// can substitute the whole client with a Proxy that records each call and
+// returns itself. Awaiting the chain resolves to `{ data: [], error: null }`
+// (the empty-result shape the aggregators tolerate).
+
+type CallLog = Array<{ method: string; args: unknown[] }>;
+
+function makeChain(callLog: CallLog) {
+  const handler: ProxyHandler<object> = {
+    get(_target, prop) {
+      if (prop === "then") {
+        return (resolve: (value: { data: unknown[]; error: null }) => unknown) =>
+          resolve({ data: [], error: null });
+      }
+      if (typeof prop !== "string") return undefined;
+      return (...args: unknown[]) => {
+        callLog.push({ method: prop, args });
+        return chainProxy;
+      };
+    },
+  };
+  const chainProxy: object = new Proxy({}, handler);
+  return chainProxy;
+}
+
+const callLogs: Record<string, CallLog> = {};
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: async () => ({
+    from: (table: string) => {
+      const log = callLogs[table] ?? [];
+      callLogs[table] = log;
+      return makeChain(log);
+    },
+  }),
+}));
+
+// Imports must come AFTER the mock to ensure they pick up the mocked client.
+import {
+  DEFAULT_TIERS,
+  getCompetitiveMatrixData,
+  getCrossCompanyThemes,
+  getFunctionHeatData,
+  getHotRoles,
+  getNetHiringFlow,
+  getNetThisWeek,
+  getPostingTrends,
+  getRawFunctionData,
+  type CompanyTier,
+} from "./dashboard-queries";
+
+function tierFilterArgs(table: string): unknown[][] {
+  const log = callLogs[table] ?? [];
+  return log
+    .filter((c) => c.method === "in" && c.args[0] === "companies.tier")
+    .map((c) => c.args as unknown[]);
+}
+
+beforeEach(() => {
+  for (const key of Object.keys(callLogs)) delete callLogs[key];
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ----------------------------------------------------------------------------
+
+describe("DEFAULT_TIERS", () => {
+  it("is fintech-only", () => {
+    expect([...DEFAULT_TIERS]).toEqual(["fintech"]);
+  });
+
+  it("does not include 'incumbent' — that's the whole point of Phase 0", () => {
+    expect([...DEFAULT_TIERS]).not.toContain("incumbent");
+  });
+});
+
+describe("volume aggregators apply the default fintech-only tier filter", () => {
+  const cutoffs = new Map<string, Date>();
+
+  it("getCompetitiveMatrixData filters the companies seed AND both job_postings pulls (main + this-week closures) on tier=fintech", async () => {
+    await getCompetitiveMatrixData(cutoffs);
+    // The function fires three queries: companies seed, main jobs join,
+    // and a closed-this-week pull. All three must be tier-filtered.
+    expect(tierFilterArgs("job_postings")).toEqual([
+      ["companies.tier", ["fintech"]],
+      ["companies.tier", ["fintech"]],
+    ]);
+    expect(
+      (callLogs["companies"] ?? []).some(
+        (c) =>
+          c.method === "in" &&
+          c.args[0] === "tier" &&
+          JSON.stringify(c.args[1]) === '["fintech"]'
+      )
+    ).toBe(true);
+  });
+
+  it("getHotRoles defaults to fintech-only", async () => {
+    await getHotRoles(cutoffs);
+    expect(tierFilterArgs("job_postings")).toEqual([["companies.tier", ["fintech"]]]);
+  });
+
+  it("getNetThisWeek filters BOTH the new- and closed-job pulls", async () => {
+    await getNetThisWeek(cutoffs);
+    const filters = tierFilterArgs("job_postings");
+    expect(filters).toEqual([
+      ["companies.tier", ["fintech"]],
+      ["companies.tier", ["fintech"]],
+    ]);
+  });
+
+  it("getPostingTrends filters on tier=fintech", async () => {
+    await getPostingTrends(30, cutoffs);
+    expect(tierFilterArgs("job_postings")).toEqual([["companies.tier", ["fintech"]]]);
+  });
+
+  it("getRawFunctionData filters on tier=fintech", async () => {
+    await getRawFunctionData(30, cutoffs);
+    expect(tierFilterArgs("job_postings")).toEqual([["companies.tier", ["fintech"]]]);
+  });
+
+  it("getNetHiringFlow filters on tier=fintech for BOTH new and closed pulls", async () => {
+    await getNetHiringFlow(30, cutoffs);
+    expect(tierFilterArgs("job_postings")).toEqual([
+      ["companies.tier", ["fintech"]],
+      ["companies.tier", ["fintech"]],
+    ]);
+  });
+
+  it("getFunctionHeatData filters on tier=fintech for both recent and long-range pulls", async () => {
+    await getFunctionHeatData();
+    expect(tierFilterArgs("job_postings")).toEqual([
+      ["companies.tier", ["fintech"]],
+      ["companies.tier", ["fintech"]],
+    ]);
+  });
+
+  it("getCrossCompanyThemes filters on tier=fintech", async () => {
+    await getCrossCompanyThemes();
+    expect(tierFilterArgs("job_postings")).toEqual([["companies.tier", ["fintech"]]]);
+  });
+});
+
+describe("volume aggregators accept an explicit tiers argument", () => {
+  const cutoffs = new Map<string, Date>();
+
+  it("getHotRoles can be scoped to incumbents only (Phase 2 'Incumbent Bets' rail)", async () => {
+    const tiers: CompanyTier[] = ["incumbent"];
+    await getHotRoles(cutoffs, 15, tiers);
+    expect(tierFilterArgs("job_postings")).toEqual([["companies.tier", ["incumbent"]]]);
+  });
+
+  it("getCompetitiveMatrixData can include both tiers via the 'include incumbents' toggle", async () => {
+    await getCompetitiveMatrixData(cutoffs, { tiers: ["fintech", "incumbent"] });
+    expect(tierFilterArgs("job_postings")).toEqual([
+      ["companies.tier", ["fintech", "incumbent"]],
+      ["companies.tier", ["fintech", "incumbent"]],
+    ]);
+  });
+});

--- a/web/lib/dashboard-queries.ts
+++ b/web/lib/dashboard-queries.ts
@@ -20,6 +20,24 @@ type SupabaseLike = SupabaseClient;
 
 const ROLLING_WEEK_DAYS = 7;
 
+/**
+ * Company tier classification.
+ *
+ * `fintech` is the platform's primary subject. `incumbent` covers big-bank /
+ * non-fintech companies whose hiring is useful as benchmark signal but would
+ * dominate volume aggregates if surfaced alongside fintechs. Every cross-
+ * company aggregator in this file accepts a `tiers` parameter that defaults
+ * to `DEFAULT_TIERS` (fintech-only). Surfaces that want bank signal — like
+ * the planned Incumbent Bets rail — opt in explicitly with `['incumbent']`
+ * or `['fintech','incumbent']`.
+ *
+ * Self-scoped helpers (company drill-down, sparkline, hiring delta) do not
+ * take a `tiers` argument: they're invoked with an explicit company id and
+ * the caller already knows the tier.
+ */
+export type CompanyTier = "fintech" | "incumbent";
+export const DEFAULT_TIERS: readonly CompanyTier[] = ["fintech"];
+
 function getRollingWeekStartIso(now: Date = new Date()): string {
   return subDays(now, ROLLING_WEEK_DAYS).toISOString();
 }
@@ -151,17 +169,22 @@ function isBackfill(
 
 /**
  * Get job posting volume trends grouped by week, excluding backfill.
+ *
+ * Filters to `tiers` (default fintech-only) via an inner join on companies so
+ * incumbent (big-bank) postings do not skew the headline trend.
  */
 export async function getPostingTrends(
   days: number,
-  cutoffs: Map<string, Date>
+  cutoffs: Map<string, Date>,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS
 ): Promise<WeeklyTrend[]> {
   const supabase = await createClient();
   const startDate = subDays(new Date(), days).toISOString();
 
   const { data: jobs, error } = await supabase
     .from("job_postings")
-    .select("company_id, first_seen_date")
+    .select("company_id, first_seen_date, companies!inner(tier)")
+    .in("companies.tier", [...tiers])
     .gte("first_seen_date", startDate)
     .order("first_seen_date", { ascending: true });
 
@@ -190,17 +213,22 @@ export async function getPostingTrends(
 
 /**
  * Get raw function category data for client-side filtering, excluding backfill.
+ *
+ * Filters to `tiers` (default fintech-only) so the dashboard function-mix
+ * view stays fintech-focused.
  */
 export async function getRawFunctionData(
   days: number,
-  cutoffs: Map<string, Date>
+  cutoffs: Map<string, Date>,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS
 ): Promise<RawFunctionData[]> {
   const supabase = await createClient();
   const startDate = subDays(new Date(), days).toISOString();
 
   const { data: jobs, error } = await supabase
     .from("job_postings")
-    .select("company_id, function_category, first_seen_date")
+    .select("company_id, function_category, first_seen_date, companies!inner(tier)")
+    .in("companies.tier", [...tiers])
     .gte("first_seen_date", startDate)
     .not("function_category", "is", null)
     .not("first_seen_date", "is", null);
@@ -214,23 +242,30 @@ export async function getRawFunctionData(
 
 /**
  * Get net hiring flow data: new vs closed jobs per week.
+ *
+ * Filters to `tiers` (default fintech-only) on both the new- and closed-job
+ * pulls so flow numbers remain peer-comparable.
  */
 export async function getNetHiringFlow(
   days: number,
-  cutoffs: Map<string, Date>
+  cutoffs: Map<string, Date>,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS
 ): Promise<NetHiringFlowPoint[]> {
   const supabase = await createClient();
   const startDate = subDays(new Date(), days).toISOString();
+  const tierList = [...tiers];
 
   const [{ data: newJobs }, { data: closedJobs }] = await Promise.all([
     supabase
       .from("job_postings")
-      .select("company_id, first_seen_date")
+      .select("company_id, first_seen_date, companies!inner(tier)")
+      .in("companies.tier", tierList)
       .gte("first_seen_date", startDate)
       .not("first_seen_date", "is", null),
     supabase
       .from("job_postings")
-      .select("company_id, first_seen_date, closed_date")
+      .select("company_id, first_seen_date, closed_date, companies!inner(tier)")
+      .in("companies.tier", tierList)
       .gte("closed_date", startDate)
       .not("closed_date", "is", null),
   ]);
@@ -287,26 +322,33 @@ export async function getCompetitiveMatrixData(
   options?: {
     windowDays?: number | null; // null = current active snapshot
     includeClosed?: boolean;
+    tiers?: readonly CompanyTier[];
   }
 ): Promise<CompetitiveMatrixRow[]> {
   const supabase = await createClient();
   const isHistorical = options?.windowDays != null;
   const includeClosed = isHistorical && (options?.includeClosed ?? false);
   const rollingWeekStart = getRollingWeekStartIso();
+  const tierList = [...(options?.tiers ?? DEFAULT_TIERS)];
 
-  // Always seed from active companies
+  // Always seed from active companies in the selected tier(s) so the matrix
+  // shows every fintech (or every incumbent in a tier-incumbent view), not
+  // just those with jobs in the window.
   const { data: allCompanies } = await supabase
     .from("companies")
     .select("id, name, slug")
-    .eq("is_active", true);
+    .eq("is_active", true)
+    .in("tier", tierList);
 
-  // Build jobs query based on mode
+  // Build jobs query based on mode. Inner-join companies and filter on tier
+  // so a future incumbent row cannot leak into the fintech matrix.
   let jobsQuery = supabase
     .from("job_postings")
     .select(
-      "company_id, function_category, first_seen_date, is_active, companies!inner(id, name, slug, is_active)"
+      "company_id, function_category, first_seen_date, is_active, companies!inner(id, name, slug, is_active, tier)"
     )
-    .eq("companies.is_active", true);
+    .eq("companies.is_active", true)
+    .in("companies.tier", tierList);
 
   if (includeClosed) {
     // Jobs that overlapped the window: active OR closed within the window
@@ -390,7 +432,8 @@ export async function getCompetitiveMatrixData(
   if (!isHistorical) {
     const { data: closedThisWeek } = await supabase
       .from("job_postings")
-      .select("company_id, function_category")
+      .select("company_id, function_category, companies!inner(tier)")
+      .in("companies.tier", tierList)
       .gte("closed_date", rollingWeekStart);
 
     for (const job of closedThisWeek ?? []) {
@@ -493,20 +536,26 @@ export async function getLatestDigest(): Promise<LatestDigest | null> {
 
 /**
  * Get most recent active job postings for the hot roles feed, excluding backfill.
+ *
+ * Filters to `tiers` (default fintech-only). Phase 2 will add an "Incumbent
+ * Bets" rail that queries with `tiers: ['incumbent']` and an additional
+ * seniority/function gate.
  */
 export async function getHotRoles(
   cutoffs: Map<string, Date>,
-  limit: number = 15
+  limit: number = 15,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS
 ): Promise<HotRole[]> {
   const supabase = await createClient();
 
   const { data: jobs } = await supabase
     .from("job_postings")
     .select(
-      "id, title, company_id, first_seen_date, function_category, companies!inner(name, slug, is_active)"
+      "id, title, company_id, first_seen_date, function_category, companies!inner(name, slug, is_active, tier)"
     )
     .eq("is_active", true)
     .eq("companies.is_active", true)
+    .in("companies.tier", [...tiers])
     .order("first_seen_date", { ascending: false })
     .limit(50); // Fetch extra to account for backfill filtering
 
@@ -534,21 +583,28 @@ export async function getHotRoles(
 
 /**
  * Get net new/closed jobs in the last 7 days, excluding backfill from new count.
+ *
+ * Filters to `tiers` (default fintech-only) on both pulls so the headline
+ * KPI cards stay peer-comparable.
  */
 export async function getNetThisWeek(
-  cutoffs: Map<string, Date>
+  cutoffs: Map<string, Date>,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS
 ): Promise<{ newCount: number; closedCount: number }> {
   const supabase = await createClient();
   const rollingWeekStart = getRollingWeekStartIso();
+  const tierList = [...tiers];
 
   const [{ data: newJobs }, { count: closedCount }] = await Promise.all([
     supabase
       .from("job_postings")
-      .select("company_id, first_seen_date")
+      .select("company_id, first_seen_date, companies!inner(tier)")
+      .in("companies.tier", tierList)
       .gte("first_seen_date", rollingWeekStart),
     supabase
       .from("job_postings")
-      .select("*", { count: "exact", head: true })
+      .select("*, companies!inner(tier)", { count: "exact", head: true })
+      .in("companies.tier", tierList)
       .gte("closed_date", rollingWeekStart),
   ]);
 
@@ -806,7 +862,8 @@ function relativeWhen(date: Date): string {
  * Returns 6 rows (top 6 groups by raw new-posting count in window).
  */
 export async function getFunctionHeatData(
-  days: number = 30
+  days: number = 30,
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS
 ): Promise<
   Array<{
     name: string;
@@ -820,16 +877,19 @@ export async function getFunctionHeatData(
   const recent4wStart = subDays(new Date(), 28);
   const recent12wStart = subDays(new Date(), 84);
   const longWindowStart = subDays(new Date(), COLD_START_DAYS).toISOString();
+  const tierList = [...tiers];
 
   const [{ data: recentJobs }, { data: longRangeJobs }] = await Promise.all([
     supabase
       .from("job_postings")
-      .select("function_category, first_seen_date")
+      .select("function_category, first_seen_date, companies!inner(tier)")
+      .in("companies.tier", tierList)
       .gte("first_seen_date", recent)
       .not("function_category", "is", null),
     supabase
       .from("job_postings")
-      .select("function_category, first_seen_date")
+      .select("function_category, first_seen_date, companies!inner(tier)")
+      .in("companies.tier", tierList)
       .gte("first_seen_date", longWindowStart)
       .not("function_category", "is", null)
       .not("first_seen_date", "is", null),
@@ -904,16 +964,19 @@ export interface CrossCompanyThemeRow {
   roles: number;
 }
 
-export async function getCrossCompanyThemes(): Promise<CrossCompanyThemeRow[]> {
+export async function getCrossCompanyThemes(
+  tiers: readonly CompanyTier[] = DEFAULT_TIERS
+): Promise<CrossCompanyThemeRow[]> {
   const supabase = await createClient();
 
   const { data: jobs } = await supabase
     .from("job_postings")
     .select(
-      "company_id, function_category, is_active, companies!inner(is_active)"
+      "company_id, function_category, is_active, companies!inner(is_active, tier)"
     )
     .eq("is_active", true)
     .eq("companies.is_active", true)
+    .in("companies.tier", [...tiers])
     .not("function_category", "is", null);
 
   const themeStats = new Map<string, { cos: Set<string>; roles: number }>();

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "1.12.0",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "1.12.0",
+      "version": "2.0.2",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/web/supabase/migrations/20260521000000_company_tier.sql
+++ b/web/supabase/migrations/20260521000000_company_tier.sql
@@ -1,0 +1,27 @@
+-- Company tier classification.
+--
+-- Adds a `tier` column so big-bank "incumbent" companies (RBC, TD, BMO, CIBC,
+-- National, Scotia parent) can live in the same store as fintechs but be
+-- excluded from cross-company volume aggregates by default. Aggregators that
+-- drive dashboard KPIs, the competitive matrix, weekly digest themes, and
+-- cross-company keyword bags filter to tier='fintech' by default.
+--
+-- Incumbent rows surface only through dedicated tier-aware views (planned:
+-- "Incumbent Bets" dashboard rail, "Incumbent Watch" digest block) and on
+-- self-scoped surfaces (jobs list filter, per-company drill-down page).
+--
+-- Default is 'fintech' so all existing rows are correctly classified without
+-- a backfill step. Tangerine stays 'fintech' (it's Scotia's direct-bank
+-- fintech brand, not the parent). The parent Scotiabank entry — if added
+-- later — gets 'incumbent'. CIBC is special-cased because its careers site
+-- also serves Simplii Financial postings; the scraper classifies each
+-- posting and routes Simplii to a separate 'fintech'-tier companies row.
+
+ALTER TABLE companies
+  ADD COLUMN tier TEXT NOT NULL DEFAULT 'fintech'
+    CHECK (tier IN ('fintech', 'incumbent'));
+
+CREATE INDEX idx_companies_tier ON companies(tier);
+
+COMMENT ON COLUMN companies.tier IS
+  'fintech (default) | incumbent. Cross-company volume aggregators filter to tier=fintech by default; incumbents surface only through dedicated tier-aware views.';


### PR DESCRIPTION
## Summary
Phase 0 of the [Big-6 Canadian bank integration plan](https://github.com/tascheidt/fintech_insights/blob/main/.claude/plans/) — schema + plumbing only, no observable behavior change. Sets up so future bank rows ("incumbent" tier) can live in the same store as fintechs without skewing cross-company volume views.

- **Migration `20260521000000_company_tier.sql`** — adds `companies.tier TEXT NOT NULL DEFAULT 'fintech' CHECK (tier IN ('fintech','incumbent'))` + `idx_companies_tier`. All 7 existing companies correctly default to `fintech`; already applied to the Supabase project.
- **Tier filter threaded through every cross-company aggregator**: `getPostingTrends`, `getRawFunctionData`, `getNetHiringFlow`, `getCompetitiveMatrixData` (both companies-seed and closed-this-week), `getHotRoles`, `getNetThisWeek`, `getFunctionHeatData`, `getCrossCompanyThemes`, `getWeeklyData` / `createWeeklyDigest`, `refreshAllThemeLabels`. Each accepts `tiers?: readonly CompanyTier[]` with `DEFAULT_TIERS = ['fintech']`.
- **Self-scoped helpers** (drill-down, sparkline, hiring delta) untouched — caller already knows the tier.
- **New tests** in `web/lib/dashboard-queries.test.ts` use a chain-recording Supabase proxy to assert every aggregator emits `.in("companies.tier", ["fintech"])` by default, and that explicit `['incumbent']` / `['fintech','incumbent']` overrides propagate.

## Phase context

This is part of a staged rollout. Phase 1 will add RBC (first incumbent) and a Workday-RBC scraper. Phase 2 builds the "Incumbent Bets" rail + "Incumbent Watch" digest block (Meredith reviews visualization before code). Phase 3 scales to remaining banks, with CIBC's scraper splitting Simplii Financial → `tier='fintech'` and CIBC-proper → `tier='incumbent'`.

## Test plan
- [x] `npm test` — 25 / 25 pass (12 new for tier filter)
- [x] `npm run build` — clean
- [x] `npm run lint` — only one pre-existing warning (unrelated, in `app/api/ai/generate-posting/route.ts`)
- [x] Migration applied to Supabase project `joqruwbipwmaysufhgyc`; `SELECT tier, count(*) FROM companies GROUP BY tier` → `{fintech: 7}`
- [ ] Visual diff in dev: dashboard, digest preview, companies list look identical to main (no incumbent rows yet)
- [ ] No changelog entry — Phase 0 has zero user-visible effect. Phase 1 will carry the version bump + entry when banks first appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)