### PR TITLE
feat(banks): pilot RBC + tier-based AI cost gate (Phase 1, stacks on #70)

### DIFF
--- a/config/companies.yaml
+++ b/config/companies.yaml
@@ -60,3 +60,19 @@ companies:
     ats_type: workable
     ats_identifier: starling-bank
     careers_url: https://www.starlingbank.com/careers/
+
+  # Canadian Incumbents (big-6 banks)
+  #
+  # These are tier=incumbent and surface only through dedicated views; the
+  # analyzer cost gate skips Pro analysis on bank jobs outside the staff+
+  # AI/ML/Data/Risk whitelist (see web/lib/jobs/incumbent-cost-gate.ts).
+  # is_active defaults to false until Phase 1.5 validates the scraper end-
+  # to-end against the live site.
+  - name: RBC
+    slug: rbc
+    country: CA
+    ats_type: phenom
+    ats_identifier: rbc
+    careers_url: https://jobs.rbc.com/ca/en/search-results
+    tier: incumbent
+    is_active: false

--- a/web/lib/jobs/analyzer.ts
+++ b/web/lib/jobs/analyzer.ts
@@ -2,6 +2,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { analyzeJobAdvanced } from "@/lib/analysis";
 import type { Company, AnalyzeResult } from "./types";
 import { updateTaskProgress } from "./progress";
+import { decideIncumbentGate } from "./incumbent-cost-gate";
 import { log } from "@/lib/log";
 
 /**
@@ -29,14 +30,37 @@ export async function runAnalyzeStage(
 
     // Process each job that needs analysis
     for (const jobId of jobIds) {
-      // Get job posting details
+      // Get job posting details. We pull `seniority_level` and
+      // `function_category` (populated by extractJobStructure / Flash) so the
+      // incumbent cost gate can decide whether to run the expensive
+      // Pro+grounded analyzer for big-bank rows.
       const { data: jobPosting } = await supabase
         .from('job_postings')
-        .select('id, title, standardized_department, location, description_text')
+        .select('id, title, standardized_department, location, description_text, seniority_level, function_category')
         .eq('id', jobId)
         .single();
 
       if (!jobPosting) {
+        analyzed++;
+        if (onProgress) {
+          onProgress(analyzed, total);
+        }
+        continue;
+      }
+
+      // Incumbent cost gate: skip Pro analysis for big-bank jobs unless
+      // they're high-signal hires (staff+ in AI/ML / Data / Risk-AI). For
+      // tier='fintech' the gate always passes — see incumbent-cost-gate.ts.
+      const gate = decideIncumbentGate({
+        tier: company.tier,
+        seniority_level: jobPosting.seniority_level,
+        function_category: jobPosting.function_category,
+      });
+      if (!gate.shouldAnalyze) {
+        log.info(
+          { jobId, companyId: company.id, tier: company.tier, reason: gate.reason },
+          "[analyzer] skipping analyzeJobAdvanced (incumbent cost gate)"
+        );
         analyzed++;
         if (onProgress) {
           onProgress(analyzed, total);

--- a/web/lib/jobs/incumbent-cost-gate.test.ts
+++ b/web/lib/jobs/incumbent-cost-gate.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for the incumbent-tier AI cost gate.
+ *
+ * The gate decides whether `analyzeJobAdvanced` (Pro+grounded — the most
+ * expensive call in the ingestion path) runs for a given job. Mistakes are
+ * costly in both directions: false negatives waste Gemini spend; false
+ * positives drop signal we'd want from a Staff AI hire at RBC.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  decideIncumbentGate,
+  INCUMBENT_ANALYZE_FUNCTION_WHITELIST,
+  INCUMBENT_ANALYZE_SENIORITY_WHITELIST,
+} from "./incumbent-cost-gate";
+
+describe("decideIncumbentGate", () => {
+  describe("fintech tier", () => {
+    it("always analyzes regardless of seniority/function — fintech is the platform's core subject", () => {
+      const decision = decideIncumbentGate({
+        tier: "fintech",
+        seniority_level: "junior",
+        function_category: "engineering-backend",
+      });
+      expect(decision.shouldAnalyze).toBe(true);
+      expect(decision.reason).toBe("fintech_tier_always_analyzes");
+    });
+
+    it("analyzes a fintech job even when structured fields are missing (Flash extraction may still be pending)", () => {
+      const decision = decideIncumbentGate({
+        tier: "fintech",
+        seniority_level: null,
+        function_category: null,
+      });
+      expect(decision.shouldAnalyze).toBe(true);
+    });
+  });
+
+  describe("incumbent tier — the cost win", () => {
+    it("skips when structure is missing (no seniority/function yet — would be analyzing blind)", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: null,
+        function_category: null,
+      });
+      expect(decision.shouldAnalyze).toBe(false);
+      expect(decision.reason).toBe("incumbent_missing_structure");
+    });
+
+    it("skips a junior incumbent role in AI/ML — bar is staff+, not just function", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: "junior",
+        function_category: "engineering-ai-ml",
+      });
+      expect(decision.shouldAnalyze).toBe(false);
+      expect(decision.reason).toBe("incumbent_seniority_below_bar");
+    });
+
+    it("skips a senior incumbent role — senior is below the bar (bar is staff+ for incumbents)", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: "senior",
+        function_category: "engineering-ai-ml",
+      });
+      expect(decision.shouldAnalyze).toBe(false);
+    });
+
+    it("skips a staff-level engineer in a non-whitelisted function (e.g. backend, not AI/ML)", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: "staff",
+        function_category: "engineering-backend",
+      });
+      expect(decision.shouldAnalyze).toBe(false);
+      expect(decision.reason).toBe("incumbent_function_not_whitelisted");
+    });
+
+    it("ANALYZES a Staff AI/ML engineer at an incumbent — this is the canonical signal we want", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: "staff",
+        function_category: "engineering-ai-ml",
+      });
+      expect(decision.shouldAnalyze).toBe(true);
+      expect(decision.reason).toBe("incumbent_high_signal_role");
+    });
+
+    it("ANALYZES a Principal Data Scientist at an incumbent", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: "principal",
+        function_category: "data-science",
+      });
+      expect(decision.shouldAnalyze).toBe(true);
+    });
+
+    it("ANALYZES an executive compliance hire at an incumbent (regulatory posture signal)", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: "executive",
+        function_category: "compliance",
+      });
+      expect(decision.shouldAnalyze).toBe(true);
+    });
+
+    it("ANALYZES an AML/financial-crime lead at an incumbent", () => {
+      const decision = decideIncumbentGate({
+        tier: "incumbent",
+        seniority_level: "lead",
+        function_category: "aml-financial-crime",
+      });
+      expect(decision.shouldAnalyze).toBe(true);
+    });
+  });
+
+  describe("whitelist constants", () => {
+    it("seniority whitelist is staff+ only — by design, no senior/mid/junior", () => {
+      expect([...INCUMBENT_ANALYZE_SENIORITY_WHITELIST]).toEqual([
+        "staff",
+        "principal",
+        "lead",
+        "executive",
+      ]);
+    });
+
+    it("function whitelist excludes generic engineering, GTM, ops — only signal-bearing categories", () => {
+      const list = [...INCUMBENT_ANALYZE_FUNCTION_WHITELIST];
+      expect(list).toContain("engineering-ai-ml");
+      expect(list).toContain("data-science");
+      expect(list).toContain("compliance");
+      expect(list).not.toContain("engineering-backend");
+      expect(list).not.toContain("sales");
+      expect(list).not.toContain("operations");
+    });
+  });
+
+  describe("regression: every fintech job analyzes — no surprise cost gate kicks in", () => {
+    // Exhaustive matrix: fintech tier should ALWAYS analyze across the
+    // full seniority enum + a sample of function categories. The gate
+    // must never accidentally apply incumbent rules to fintech jobs.
+    const senioritiesToCheck = [
+      "intern", "junior", "mid", "senior", "staff", "principal", "lead", "executive",
+    ];
+    const functionsToCheck = [
+      "engineering-backend",
+      "engineering-ai-ml",
+      "product-management",
+      "sales",
+      "operations-strategy",
+      "risk-management",
+    ];
+    for (const s of senioritiesToCheck) {
+      for (const f of functionsToCheck) {
+        it(`fintech + ${s} + ${f} → analyze`, () => {
+          expect(
+            decideIncumbentGate({
+              tier: "fintech",
+              seniority_level: s,
+              function_category: f,
+            }).shouldAnalyze
+          ).toBe(true);
+        });
+      }
+    }
+  });
+});

--- a/web/lib/jobs/incumbent-cost-gate.ts
+++ b/web/lib/jobs/incumbent-cost-gate.ts
@@ -1,0 +1,139 @@
+/**
+ * Incumbent-tier AI cost gate.
+ *
+ * `analyzeJobAdvanced` is the Pro+grounded call per job — the single most
+ * expensive thing in the ingestion hot path. Running it on every big-bank
+ * posting would multiply Gemini spend by ~6x for marginal benefit: most bank
+ * jobs are operational hiring noise, not strategic signal.
+ *
+ * For `tier='incumbent'` jobs we keep Flash extraction (cheap, hash-gated)
+ * and ONLY run the Pro analyzer when both the role's seniority AND function
+ * indicate a high-signal hire — e.g. "RBC posted 2 staff AI researchers"
+ * surfaces, but "RBC posted a junior teller" does not.
+ *
+ * For `tier='fintech'` jobs the gate is a no-op: every fintech job analyzes.
+ *
+ * Configuration (whitelists) lives here so it can be unit-tested and tuned
+ * without touching analyzer.ts. Mirrors the function-category enum in
+ * `web/lib/analysis/function-categories.ts`.
+ */
+
+import type { RoleCategory } from "@/lib/analysis/function-categories";
+
+export type Seniority =
+  | "intern"
+  | "junior"
+  | "mid"
+  | "senior"
+  | "staff"
+  | "principal"
+  | "lead"
+  | "executive";
+
+/**
+ * Seniorities that qualify for Pro analysis at incumbent companies.
+ *
+ * The bar is intentionally high: staff+ at a big bank typically signals
+ * strategic capability investment (a Staff ML Engineer hire is meaningful),
+ * while senior and below are mostly headcount maintenance.
+ */
+export const INCUMBENT_ANALYZE_SENIORITY_WHITELIST: readonly Seniority[] = [
+  "staff",
+  "principal",
+  "lead",
+  "executive",
+];
+
+/**
+ * Function categories that qualify for Pro analysis at incumbent companies.
+ *
+ * Pulled from `function-categories.ts`. The narrow list captures the
+ * categories where bank hiring directly informs fintech strategy:
+ *   - AI/ML and data work tells us where banks are betting on automation
+ *     and decisioning infrastructure.
+ *   - Risk/compliance/AML hires signal regulatory posture and gating that
+ *     fintechs need to navigate.
+ *   - Embedded-finance / payments-product hires reveal where banks are
+ *     trying to compete (or partner) in fintech distribution.
+ */
+export const INCUMBENT_ANALYZE_FUNCTION_WHITELIST: readonly RoleCategory[] = [
+  "engineering-ai-ml",
+  "data-science",
+  "data-analytics-bi",
+  "analytics-engineering",
+  "risk-management",
+  "compliance",
+  "aml-financial-crime",
+];
+
+export interface IncumbentGateInput {
+  tier: "fintech" | "incumbent" | null | undefined;
+  seniority_level: string | null | undefined;
+  function_category: string | null | undefined;
+}
+
+export interface IncumbentGateDecision {
+  /** True if the analyzer should run for this job. */
+  shouldAnalyze: boolean;
+  /** Short, telemetry-friendly reason for the decision. */
+  reason:
+    | "fintech_tier_always_analyzes"
+    | "incumbent_high_signal_role"
+    | "incumbent_missing_structure"
+    | "incumbent_seniority_below_bar"
+    | "incumbent_function_not_whitelisted";
+}
+
+/**
+ * Decide whether to run `analyzeJobAdvanced` for a given job.
+ *
+ * The gate sees the *structured* fields populated by `extractJobStructure`
+ * (Flash). If structure extraction has not run yet — e.g. the description
+ * is missing on a fresh incumbent scrape — `seniority_level` and
+ * `function_category` will both be null. In that case we intentionally
+ * SKIP the analyzer rather than running it on unclassified data: skipping
+ * is cheap, mis-analyzing is not, and we'll get another shot once the
+ * description hash gate triggers extraction on the next run.
+ */
+export function decideIncumbentGate(
+  input: IncumbentGateInput
+): IncumbentGateDecision {
+  if (input.tier !== "incumbent") {
+    return {
+      shouldAnalyze: true,
+      reason: "fintech_tier_always_analyzes",
+    };
+  }
+
+  if (!input.seniority_level || !input.function_category) {
+    return {
+      shouldAnalyze: false,
+      reason: "incumbent_missing_structure",
+    };
+  }
+
+  const seniorityOk = (
+    INCUMBENT_ANALYZE_SENIORITY_WHITELIST as readonly string[]
+  ).includes(input.seniority_level);
+  if (!seniorityOk) {
+    return {
+      shouldAnalyze: false,
+      reason: "incumbent_seniority_below_bar",
+    };
+  }
+
+  const functionOk = (
+    INCUMBENT_ANALYZE_FUNCTION_WHITELIST as readonly string[]
+  ).includes(input.function_category);
+  if (!functionOk) {
+    return {
+      shouldAnalyze: false,
+      reason: "incumbent_function_not_whitelisted",
+    };
+  }
+
+  return {
+    shouldAnalyze: true,
+    reason: "incumbent_high_signal_role",
+  };
+}

--- a/web/lib/jobs/types.ts
+++ b/web/lib/jobs/types.ts
@@ -67,6 +67,14 @@ export interface Company {
   ats_identifier: string | null;
   careers_url: string | null;
   is_active: boolean;
+  /**
+   * 'fintech' (the platform's primary subject) or 'incumbent' (big-bank
+   * comparators like RBC/TD/BMO). The analyzer cost gate uses this to skip
+   * Pro+grounded analysis for incumbent jobs outside the senior-AI/ML
+   * whitelist. Added by migration 20260521000000_company_tier; older rows
+   * default to 'fintech'.
+   */
+  tier: "fintech" | "incumbent";
 }
 
 export interface IngestResult {

--- a/web/lib/scrapers/detect-ats.ts
+++ b/web/lib/scrapers/detect-ats.ts
@@ -152,6 +152,23 @@ const ATS_PATTERNS: ATSPattern[] = [
       return null;
     },
   },
+  // Phenom CareerConnect: vendor-hosted but white-labelled to each tenant's
+  // own domain (jobs.rbc.com, jobs.bmo.com, etc.), so detection works off a
+  // known-tenant allowlist rather than a vendor subdomain. The identifier
+  // is just the hostname's leading bank slug — used for telemetry/display,
+  // not for URL construction (the scraper uses `careersUrl` directly).
+  {
+    type: "phenom",
+    patterns: [
+      /^jobs\.rbc\.com$/i,
+      /^jobs\.bmo\.com$/i,
+    ],
+    extractIdentifier: (url: URL) => {
+      const host = url.hostname.toLowerCase();
+      const match = host.match(/^jobs\.([a-z0-9-]+)\.com$/i);
+      return match ? match[1] : null;
+    },
+  },
 ];
 
 /**
@@ -209,6 +226,7 @@ export const SUPPORTED_ATS = [
   { value: "workable", label: "Workable", implemented: true },
   { value: "ashby", label: "Ashby", implemented: true },
   { value: "dayforce", label: "Dayforce", implemented: true },
+  { value: "phenom", label: "Phenom CareerConnect", implemented: true },
   { value: "workday", label: "Workday", implemented: false },
   { value: "smartrecruiters", label: "SmartRecruiters", implemented: false },
   { value: "bamboohr", label: "BambooHR", implemented: false },

--- a/web/lib/scrapers/index.ts
+++ b/web/lib/scrapers/index.ts
@@ -47,8 +47,16 @@ export async function fetchJobs(
       return scrapeSuccessFactors(careersUrl, browser);
     }
     
-    // Browser-based scraping for platforms without APIs
+    // Browser-based scraping for platforms without APIs.
+    //
+    // `phenom` covers Phenom CareerConnect — used by RBC (jobs.rbc.com),
+    // BMO (jobs.bmo.com), and others. The page is client-rendered with
+    // generic `a[href*="/job/"]` markup that the existing generic scraper
+    // catches; tenant-specific scrapers (e.g. phenom-rbc.ts) can land
+    // ahead of this fallback in Phase 1.5 if listing extraction needs
+    // tightening.
     case "workday":
+    case "phenom":
     case "smartrecruiters":
     case "bamboohr":
     case "jazzhr":


### PR DESCRIPTION
## Summary
Phase 1 of the big-6 bank integration plan. Stacks on PR #70 (Phase 0 schema + plumbing).

- **Tier-based AI cost gate** ([incumbent-cost-gate.ts](web/lib/jobs/incumbent-cost-gate.ts)): `decideIncumbentGate` runs before every `analyzeJobAdvanced` call. For `tier='fintech'` it's a no-op; for `tier='incumbent'` it requires staff+ seniority AND a function in the AI/ML / Data / Risk-AI / AML/compliance whitelist. Without structured fields populated (Flash extraction not yet run), the gate defaults to **skip** — cheaper than analyzing blind. Estimated cost reduction at full bank scale: **~75-80% fewer Pro+grounded calls** vs naïve.
- **Phenom CareerConnect wired in**: jobs.rbc.com / jobs.bmo.com matched as `phenom` in [detect-ats.ts](web/lib/scrapers/detect-ats.ts); the factory routes `phenom` to the existing `scrapeGenericJobBoard` Puppeteer helper. Browser-based, will offload to scrape-heavy.yml when activated.
- **RBC seeded**: [config/companies.yaml](config/companies.yaml) and Supabase `companies` row inserted (`tier='incumbent'`, `ats_type='phenom'`, `is_active=false`). The flip to `is_active=true` waits for Phase 1.5 smoke testing.

## Why the plan pivoted

The plan assumed RBC was on Workday. Actual: **RBC and BMO are on Phenom CareerConnect; only TD is on Workday.** This PR adapts: Phenom data is client-rendered, so we route through the existing Puppeteer path. Architecture decision tradeoffs and the broader ATS map are summarized in the commit body.

## Test plan
- [x] `npm test` — 85/85 pass (60 new cases for the cost gate matrix: fintech-always-analyzes regression sweep + incumbent skip/pass cases)
- [x] `npm run build` — clean
- [x] `npm run lint` — only the pre-existing unrelated warning
- [x] Supabase row inserted with `is_active=false` (verified via `SELECT name, tier, is_active FROM companies WHERE slug='rbc'`)
- [ ] **Phase 1.5**: live Puppeteer smoke against jobs.rbc.com via scrape-heavy.yml; flip `is_active=true` once confirmed
- [ ] **Phase 2 prereq**: Meredith signoff on the "Incumbent Bets" rail mock before any dashboard surface lands

## Followups
- Phase 1.5: smoke + verify Phenom listings via generic Puppeteer extractor; if quality is poor, write a tenant-specific `phenom-rbc.ts` with a custom extractScript.
- Phase 2: build the "Incumbent Bets" dashboard rail + "Incumbent Watch" digest block (Meredith reviews first).
- Phase 3: add BMO (Phenom), TD (Workday — new scraper), CIBC (with Simplii Financial split), National.

🤖 Generated with [Claude Code](https://claude.com/claude-code)