### PR TITLE
feat(scrapers): productionize Phenom-RBC scraper (Phase 1.5, stacks on #71)

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -45,3 +45,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 .env*.local
+
+# Smoke-script debug artifacts (transient; rebuilt on each smoke run).
+# Baseline JSON files committed under scripts/artifacts/baseline-*.json
+# are kept; the transient *-page.html and *-smoke.json outputs aren't.
+scripts/artifacts/*-smoke.json
+scripts/artifacts/*-page.html

--- a/web/lib/scrapers/__fixtures__/phenom-rbc-listing.json
+++ b/web/lib/scrapers/__fixtures__/phenom-rbc-listing.json
@@ -1,0 +1,120 @@
+{
+  "totalHits": 1482,
+  "hits": 3,
+  "data": {
+    "jobs": [
+      {
+        "subCategory": "Research",
+        "ml_skills": [
+          "machine learning",
+          "python",
+          "deep learning",
+          "natural language processing",
+          "information retrieval",
+          "pytorch",
+          "jax",
+          "tensorflow",
+          "software development life cycle",
+          "software engineering best practices",
+          "stakeholder management",
+          "testing methods",
+          "code reviews",
+          "source control management",
+          "product development design",
+          "decision making",
+          "quantitative research",
+          "research and development operations",
+          "long term planning"
+        ],
+        "type": "Full time",
+        "descriptionTeaser": "Embrace the role of a Research Engineer and drive innovation in machine learning at RBC Borealis. Collaborate with top researchers, develop cutting-edge AI solutions, and work with massive datasets and computational resources. If you have a passion for applied machine learning and a strong Python skills, this is your opportunity to make an impact.",
+        "state": "Quebec",
+        "multi_category": [
+          "Technology | Analytics | Research"
+        ],
+        "reqId": "R-0000153556",
+        "city": "MONTR\u00c9AL",
+        "multi_location": [
+          "MONTR\u00c9AL, Quebec, Canada"
+        ],
+        "applyUrl": "https://rbc.wd3.myworkdayjobs.com/RBCGLOBAL1/job/MONTRAL-Quebec-Canada/Research-Engineer-II_R-0000153556/apply",
+        "country": "Canada",
+        "jobId": "R-0000153556",
+        "title": "Research Engineer",
+        "postedDate": "2026-02-12T00:00:00.000+0000",
+        "category": "Technology | Analytics | Research"
+      },
+      {
+        "subCategory": "Enterprise and Financial Risk",
+        "ml_skills": [
+          "asset liability management",
+          "interest rate risk management",
+          "liquidity risk management",
+          "risk analytics",
+          "data analysis",
+          "regulatory compliance",
+          "financial reporting",
+          "ms office",
+          "analytical skills",
+          "communication skills",
+          "problem solving",
+          "interpersonal skills"
+        ],
+        "type": "Full time",
+        "descriptionTeaser": "Join our team as a US ALM Risk Manager and play a crucial role in overseeing banking book market risk. Leverage your expertise in asset liability management and risk analytics to drive effective risk management strategies. If you thrive in a dynamic environment and have a passion for financial services, we want to hear from you!",
+        "state": "California",
+        "multi_category": [
+          "Audit | Compliance | Legal | Risk"
+        ],
+        "reqId": "R-0000040439",
+        "city": "Los Angeles",
+        "multi_location": [
+          "Los Angeles, California, United States of America"
+        ],
+        "applyUrl": "https://rbc.wd3.myworkdayjobs.com/RBCGLOBAL1/job/Los-Angeles-California-United-States-of-America/US-ALM-Risk-Manager_R-0000040439/apply",
+        "country": "United States of America",
+        "jobId": "R-0000040439",
+        "title": "US ALM Risk Manager",
+        "postedDate": "2022-12-05T00:00:00.000+0000",
+        "category": "Audit | Compliance | Legal | Risk"
+      },
+      {
+        "subCategory": "Sales and Advisory",
+        "ml_skills": [
+          "mergers and acquisitions",
+          "private company transactions",
+          "canadian accounting",
+          "valuation analysis",
+          "legal compliance",
+          "tax planning",
+          "client relationship management",
+          "pitch development",
+          "stakeholder management",
+          "mentoring",
+          "networking",
+          "presentation skills",
+          "private equity advisory",
+          "wealth management advisory",
+          "capital markets advisory"
+        ],
+        "type": "Full time",
+        "descriptionTeaser": "Join our team as Senior Director, Mid-Market Mergers & Acquisitions and lead high-impact transactions across Manitoba and Saskatchewan. Drive growth through strategic origination, negotiation, and stakeholder management. Mentor junior staff and shape RBC\u2019s M&A presence in a dynamic, collaborative environment. Make a lasting impact with your expertise in commercial banking and M&A.",
+        "state": "Manitoba",
+        "multi_category": [
+          "Customer Service | Client Advice | Sales"
+        ],
+        "reqId": "R-0000170325",
+        "city": "WINNIPEG",
+        "multi_location": [
+          "WINNIPEG, Manitoba, Canada"
+        ],
+        "applyUrl": "https://rbc.wd3.myworkdayjobs.com/RBCGLOBAL1/job/WINNIPEG-Manitoba-Canada/Senior-Director--Mid-Market-Mergers---Acquisitions_R-0000170325-1/apply",
+        "country": "Canada",
+        "jobId": "R-0000170325",
+        "title": "Senior Director, Mid-Market Mergers & Acquisitions",
+        "postedDate": "2026-04-29T00:00:00.000+0000",
+        "category": "Customer Service | Client Advice | Sales"
+      }
+    ]
+  }
+}

--- a/web/lib/scrapers/index.ts
+++ b/web/lib/scrapers/index.ts
@@ -6,6 +6,7 @@ import { fetchWorkableJobs } from "./workable";
 import { fetchAshbyJobs } from "./ashby";
 import { fetchDayforceJobs } from "./dayforce";
 import { fetchScotiabankJobs } from "./scotiabank";
+import { fetchPhenomRbcJobs } from "./phenom-rbc";
 
 export type { JobData } from "./types";
 export { jobToRow } from "./types";
@@ -38,7 +39,23 @@ export async function fetchJobs(
       return fetchDayforceJobs(atsIdentifier, browser);
     case "scotiabank":
       return fetchScotiabankJobs(atsIdentifier);
-    
+
+    case "phenom": {
+      // Phenom CareerConnect is white-labelled to each bank's own domain
+      // (jobs.rbc.com, jobs.bmo.com, etc.). Dispatch by tenant since the
+      // listing-page URL and per-tenant quirks differ. The pure-logic
+      // pieces (eagerLoadRefineSearch parsing, JSON-LD enrichment) are
+      // exported from phenom-rbc.ts and can be reused by future
+      // phenom-bmo.ts etc. — extract a shared helper once 2+ tenants ship.
+      const tenant = atsIdentifier.toLowerCase();
+      if (tenant === "rbc") {
+        return fetchPhenomRbcJobs(atsIdentifier, browser);
+      }
+      throw new Error(
+        `No Phenom scraper for tenant '${atsIdentifier}'. Add a tenant-specific scraper modeled on phenom-rbc.ts.`
+      );
+    }
+
     case "successfactors": {
       if (!careersUrl) {
         throw new Error(`${atsType} requires a careers URL for browser-based scraping`);
@@ -46,17 +63,12 @@ export async function fetchJobs(
       const { scrapeSuccessFactors } = await import("./browser");
       return scrapeSuccessFactors(careersUrl, browser);
     }
-    
-    // Browser-based scraping for platforms without APIs.
-    //
-    // `phenom` covers Phenom CareerConnect — used by RBC (jobs.rbc.com),
-    // BMO (jobs.bmo.com), and others. The page is client-rendered with
-    // generic `a[href*="/job/"]` markup that the existing generic scraper
-    // catches; tenant-specific scrapers (e.g. phenom-rbc.ts) can land
-    // ahead of this fallback in Phase 1.5 if listing extraction needs
-    // tightening.
+
+    // Browser-based scraping for platforms without APIs / without a
+    // tenant-specific scraper. Falls back to the generic Puppeteer
+    // extractor — works on enough sites to be useful but trades reliability
+    // for breadth.
     case "workday":
-    case "phenom":
     case "smartrecruiters":
     case "bamboohr":
     case "jazzhr":
@@ -106,6 +118,7 @@ export function isBrowserScraper(atsType: string): boolean {
     'smartrecruiters',
     'dayforce',
     'successfactors',
+    'phenom',
     'taleo',
     'icims',
   ];

--- a/web/lib/scrapers/phenom-rbc.test.ts
+++ b/web/lib/scrapers/phenom-rbc.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for the pure-logic pieces of the Phenom-RBC scraper.
+ *
+ * The Puppeteer driver (pagination loop, description enrichment with
+ * concurrency=4) requires a real browser and is exercised by the smoke
+ * script under `web/scripts/smoke-phenom-rbc.ts`. The tests here cover
+ * the parts that don't need a browser: HTML payload extraction, the
+ * Phenom-row → JobData mapper, and HTML-entity decoding.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  decodeHtmlEntities,
+  extractEagerLoadPayload,
+  mapPhenomJob,
+  type PhenomRawJob,
+  type PhenomSearchPayload,
+} from "./phenom-rbc";
+
+const FIXTURE_PATH = resolve(__dirname, "__fixtures__/phenom-rbc-listing.json");
+const FIXTURE: PhenomSearchPayload = JSON.parse(
+  readFileSync(FIXTURE_PATH, "utf8")
+);
+
+describe("extractEagerLoadPayload", () => {
+  it("returns null when the marker is missing", () => {
+    expect(extractEagerLoadPayload("<html><body>nothing here</body></html>")).toBeNull();
+  });
+
+  it("returns null when the JSON object is malformed", () => {
+    // Truncated object — brace counter walks off the end.
+    const html = `<script>var x = "eagerLoadRefineSearch":{"status":200,</script>`;
+    expect(extractEagerLoadPayload(html)).toBeNull();
+  });
+
+  it("extracts the embedded payload from a representative HTML chunk", () => {
+    // Wrap the fixture in a minimal HTML scaffolding that mirrors Phenom's
+    // actual rendered structure. The extractor must walk past the leading
+    // chrome and return the eagerLoadRefineSearch object intact.
+    const wrapped = `<!DOCTYPE html><html><body><script>
+      var phApp = phApp || {};
+      phApp.ddo = { "flashParams": {}, "eagerLoadRefineSearch": ${JSON.stringify(FIXTURE)} };
+    </script></body></html>`;
+
+    const got = extractEagerLoadPayload(wrapped);
+    expect(got).not.toBeNull();
+    expect(got!.totalHits).toBe(FIXTURE.totalHits);
+    expect(got!.data?.jobs?.length).toBe(FIXTURE.data?.jobs?.length);
+  });
+
+  it("does not confuse braces inside string literals for object boundaries", () => {
+    // A `}` inside a quoted string should NOT close the outer object.
+    const wrapped = `garbage "eagerLoadRefineSearch":{"trick":"this has a } in it","status":200,"data":{"jobs":[]}}`;
+    const got = extractEagerLoadPayload(wrapped);
+    expect(got).not.toBeNull();
+    // The parser must walk past the `}` inside the "trick" string and
+    // close on the OUTER object's closing brace.
+    expect(got!.data?.jobs).toEqual([]);
+  });
+});
+
+describe("decodeHtmlEntities", () => {
+  it("decodes the entity set Phenom uses in JSON-LD descriptions", () => {
+    const encoded =
+      "&lt;div&gt;Hello &amp; goodbye &quot;world&quot; with &nbsp; spaces and &#39;apostrophes&#39;&lt;/div&gt;";
+    const decoded = decodeHtmlEntities(encoded);
+    expect(decoded).toBe(
+      "<div>Hello & goodbye \"world\" with   spaces and 'apostrophes'</div>"
+    );
+  });
+
+  it("decodes &amp; LAST so doubled-encoded sequences don't re-encode", () => {
+    // The encoded form `&amp;lt;` should decode to `&lt;` (a literal &lt;),
+    // not get pre-decoded to `<` by an out-of-order &lt; pass.
+    expect(decodeHtmlEntities("&amp;lt;")).toBe("&lt;");
+  });
+});
+
+describe("mapPhenomJob", () => {
+  it("maps a research-engineer fixture row to a complete JobData", () => {
+    const research = FIXTURE.data!.jobs!.find(
+      (j) => j.reqId === "R-0000153556"
+    );
+    expect(research).toBeDefined();
+
+    const job = mapPhenomJob(research as PhenomRawJob);
+    expect(job.external_id).toBe("R-0000153556");
+    expect(job.title).toBe("Research Engineer");
+    expect(job.department).toBe("Technology | Analytics | Research");
+    expect(job.team).toBe("Research");
+    expect(job.location).toBe("MONTRÉAL, Quebec, Canada");
+    expect(job.url).toBe(
+      "https://jobs.rbc.com/ca/en/job/R-0000153556/Research-Engineer"
+    );
+    expect(job.description_text).toMatch(/RBC Borealis/);
+    expect(job.description_html).toBeNull(); // populated by enrichment, not the mapper
+    expect(job.commitment).toBe("full-time");
+    expect(job.posted_date?.toISOString()).toBe("2026-02-12T00:00:00.000Z");
+  });
+
+  it("derives team from subCategory (not duplicated from department)", () => {
+    const risk = FIXTURE.data!.jobs!.find((j) => j.reqId === "R-0000040439");
+    const job = mapPhenomJob(risk as PhenomRawJob);
+    expect(job.department).toBe("Audit | Compliance | Legal | Risk");
+    expect(job.team).toBe("Enterprise and Financial Risk");
+    expect(job.team).not.toBe(job.department); // regression: was duplicating title before
+  });
+
+  it("handles missing reqId by falling back to jobUrl/applyUrl", () => {
+    const raw: PhenomRawJob = {
+      title: "Foo",
+      jobUrl: "https://jobs.rbc.com/ca/en/job/FOO-1/Foo",
+    };
+    const job = mapPhenomJob(raw);
+    expect(job.external_id).toBe("");
+    expect(job.url).toBe("https://jobs.rbc.com/ca/en/job/FOO-1/Foo");
+  });
+
+  it("infers commitment from the type field when present", () => {
+    expect(mapPhenomJob({ title: "X", type: "Contract" }).commitment).toBe("contract");
+    expect(mapPhenomJob({ title: "X", type: "Internship" }).commitment).toBe("internship");
+    expect(mapPhenomJob({ title: "X", type: "Part time" }).commitment).toBe("part-time");
+    expect(mapPhenomJob({ title: "X", type: "Full time" }).commitment).toBe("full-time");
+    expect(mapPhenomJob({ title: "X" }).commitment).toBe("full-time"); // default
+  });
+
+  it("respects explicit remote/hybrid flags before falling back to text heuristics", () => {
+    expect(mapPhenomJob({ title: "X", remote: true }).location_type).toBe("remote");
+    expect(mapPhenomJob({ title: "X", hybrid: "true" }).location_type).toBe("hybrid");
+  });
+
+  it("produces a valid Phenom URL even when applyUrl points into Workday", () => {
+    // RBC's applyUrl routes into rbc.wd3.myworkdayjobs.com — we ignore it
+    // and synthesize the Phenom-facing /ca/en/job/<id>/<slug> URL.
+    const raw: PhenomRawJob = {
+      reqId: "R-X",
+      title: "Cloud MLOps & GenAI Lead",
+      applyUrl:
+        "https://rbc.wd3.myworkdayjobs.com/RBCGLOBAL1/job/whatever/apply",
+    };
+    const job = mapPhenomJob(raw);
+    expect(job.url).toBe(
+      "https://jobs.rbc.com/ca/en/job/R-X/Cloud-MLOps-GenAI-Lead"
+    );
+    expect(job.url).not.toContain("workday");
+  });
+
+  it("aggregates multi_location into the canonical city/state/country string", () => {
+    const sales = FIXTURE.data!.jobs!.find((j) => j.reqId === "R-0000170325");
+    const job = mapPhenomJob(sales as PhenomRawJob);
+    expect(job.location).toBe("WINNIPEG, Manitoba, Canada");
+  });
+});
+
+describe("fixture sanity", () => {
+  it("contains the three reference jobs the tests depend on", () => {
+    const ids = FIXTURE.data?.jobs?.map((j) => j.reqId);
+    expect(ids).toEqual(
+      expect.arrayContaining(["R-0000153556", "R-0000040439", "R-0000170325"])
+    );
+  });
+});

--- a/web/lib/scrapers/phenom-rbc.ts
+++ b/web/lib/scrapers/phenom-rbc.ts
@@ -1,0 +1,434 @@
+/**
+ * RBC (Royal Bank of Canada) — Phenom CareerConnect scraper.
+ *
+ * Browser-based. Lives in scrape-heavy.yml's offload set (see
+ * `isBrowserScraper` in `./index.ts`). Daily cadence is fine — fragility
+ * budget is wide because we read from documented surfaces, not CSS.
+ *
+ * Two data surfaces, both server-rendered into the HTML:
+ *
+ *   1. Listing pages embed `phApp.eagerLoadRefineSearch.data.jobs[]` with
+ *      ~40 fields per posting: title, reqId, city/state/country,
+ *      multi_category (department), subCategory (team), postedDate,
+ *      descriptionTeaser. Pagination via `?from=<offset>`; default page
+ *      size is 10, totalHits indicates the corpus size.
+ *
+ *   2. Detail pages embed a `<script type="application/ld+json">`
+ *      JobPosting (schema.org) block with the full HTML description as
+ *      `description` (HTML-entity-encoded). schema.org is documented and
+ *      Google-indexed, so Phenom is unlikely to drop it. Phenom's own
+ *      `phApp.ddo.jobDetail.data.job.description` is a structurally
+ *      equivalent fallback.
+ *
+ * The scraper visits the listing pages first (cheap — one page-load per
+ * 10 jobs), then enriches each posting's description with a per-job
+ * detail-page fetch. Description enrichment runs at concurrency=4 with
+ * a dedicated puppeteer page per worker.
+ *
+ * Cost knob: `PHENOM_RBC_MAX_JOBS` env var caps the corpus to fetch per
+ * run (default 50). Tune up after smoke confirms the pipeline. Full RBC
+ * is ~1,500 jobs; at 4-concurrent description fetches × ~5s each that's
+ * ~30min on cold-start. The processor's `description_hash` gate makes
+ * subsequent runs cheap (no Gemini re-extraction on unchanged jobs), but
+ * the per-page Puppeteer load is still incurred — that's the next
+ * optimization frontier if cost becomes real.
+ */
+
+import type { JobData } from "./types";
+import type { Browser, Page } from "puppeteer-core";
+import { detectLocationType, htmlToText } from "./utils";
+import { log } from "@/lib/log";
+
+const RBC_LISTING_URL = "https://jobs.rbc.com/ca/en/search-results";
+const DEFAULT_MAX_JOBS = 50;
+const DESCRIPTION_CONCURRENCY = 4;
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+// ---------------------------------------------------------------------------
+// Phenom listing JSON shape (subset)
+// ---------------------------------------------------------------------------
+
+export interface PhenomRawJob {
+  reqId?: string;
+  jobId?: string;
+  title?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  multi_location?: string[];
+  category?: string;
+  multi_category?: string[];
+  subCategory?: string;
+  postedDate?: string;
+  applyUrl?: string;
+  jobUrl?: string;
+  description?: string;
+  descriptionTeaser?: string;
+  ml_job_parser?: { descriptionTeaser?: string };
+  remote?: boolean | string;
+  hybrid?: boolean | string;
+  type?: string;
+}
+
+export interface PhenomSearchPayload {
+  totalHits?: number;
+  hits?: number;
+  data?: { jobs?: PhenomRawJob[] };
+}
+
+// ---------------------------------------------------------------------------
+// Pure-logic helpers (testable without a browser)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the rendered HTML, find the `"eagerLoadRefineSearch":` marker, and
+ * return the embedded JSON object via brace-counting. Null on any kind of
+ * failure (marker not found, JSON malformed, etc.) — caller decides how
+ * to react.
+ */
+export function extractEagerLoadPayload(
+  html: string
+): PhenomSearchPayload | null {
+  const marker = '"eagerLoadRefineSearch":';
+  const start = html.indexOf(marker);
+  if (start === -1) return null;
+  const objStart = html.indexOf("{", start + marker.length);
+  if (objStart === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = objStart; i < html.length; i++) {
+    const ch = html[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        try {
+          return JSON.parse(
+            html.substring(objStart, i + 1)
+          ) as PhenomSearchPayload;
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Schema.org `description` from JSON-LD arrives HTML-entity-encoded
+ * (`&lt;div&gt;…`). Decode so what we store is real HTML.
+ */
+export function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&"); // last — otherwise we re-encode the above
+}
+
+/**
+ * Map one Phenom row to the canonical `JobData` shape. Pure transformation
+ * — no I/O, fully unit-testable.
+ *
+ * Phenom splits role taxonomy two ways:
+ *   - `multi_category` (broad pipe-joined family) → `department`
+ *   - `subCategory` (finer-grained) → `team`
+ *
+ * `description_text` is set to the listing-time teaser as a stand-in; the
+ * description-enrichment pass replaces it with the full extracted text.
+ */
+export function mapPhenomJob(raw: PhenomRawJob): JobData {
+  const externalId = raw.reqId || raw.jobId || "";
+  const locationParts = raw.multi_location?.length
+    ? raw.multi_location.join("; ")
+    : [raw.city, raw.state, raw.country].filter(Boolean).join(", ");
+  const department = raw.multi_category?.[0] || raw.category || null;
+  const team = raw.subCategory || null;
+  const teaser =
+    raw.descriptionTeaser ||
+    raw.ml_job_parser?.descriptionTeaser ||
+    raw.description ||
+    null;
+
+  let locationType: string | null = null;
+  if (raw.remote === true || raw.remote === "true") locationType = "remote";
+  else if (raw.hybrid === true || raw.hybrid === "true")
+    locationType = "hybrid";
+  else locationType = detectLocationType(locationParts, teaser || "");
+
+  let postedDate: Date | null = null;
+  if (raw.postedDate) {
+    const parsed = new Date(raw.postedDate);
+    if (!isNaN(parsed.getTime())) postedDate = parsed;
+  }
+
+  // Canonical Phenom URL — independent of whatever applyUrl Phenom rendered
+  // (apply URLs route into Workday). Slug is title with non-alnum collapsed.
+  const slug = (raw.title || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const url = externalId
+    ? `https://jobs.rbc.com/ca/en/job/${externalId}/${slug}`
+    : raw.jobUrl || raw.applyUrl || "";
+
+  // Phenom occasionally encodes employment type as "Full time" / "Contract".
+  let commitment: string = "full-time";
+  if (raw.type) {
+    const t = raw.type.toLowerCase();
+    if (/contract/.test(t)) commitment = "contract";
+    else if (/intern/.test(t)) commitment = "internship";
+    else if (/part/.test(t)) commitment = "part-time";
+  }
+
+  return {
+    external_id: externalId,
+    title: raw.title || "",
+    department,
+    team,
+    location: locationParts || null,
+    location_type: locationType,
+    description_html: null,
+    description_text: teaser,
+    commitment,
+    posted_date: postedDate,
+    url,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Browser-side extractor (string-sourced so tsx's `__name` helper can't
+// leak into the page context — see smoke history).
+// ---------------------------------------------------------------------------
+
+export const PHENOM_DETAIL_EXTRACTOR_SRC = `(function () {
+  // Strategy 1: JSON-LD JobPosting (schema.org). Documented + Google-
+  // indexed, so most stable surface available.
+  var ldNodes = document.querySelectorAll('script[type="application/ld+json"]');
+  for (var i = 0; i < ldNodes.length; i++) {
+    var raw = ldNodes[i].textContent || "";
+    if (!raw) continue;
+    try {
+      var parsed = JSON.parse(raw);
+      var candidates = Array.isArray(parsed) ? parsed : [parsed];
+      for (var c = 0; c < candidates.length; c++) {
+        var entry = candidates[c];
+        if (entry && entry["@type"] === "JobPosting" && typeof entry.description === "string" && entry.description.length > 200) {
+          return { html: entry.description, source: "json-ld-JobPosting" };
+        }
+      }
+    } catch (e) {}
+  }
+
+  // Strategy 2: phApp.ddo.jobDetail.data.job.description (Phenom's
+  // internal blob — backup in case schema.org disappears).
+  var html = document.documentElement.innerHTML;
+  var marker = '"jobDetail":';
+  var start = html.indexOf(marker);
+  if (start !== -1) {
+    var objStart = html.indexOf("{", start + marker.length);
+    if (objStart !== -1) {
+      var depth = 0, inStr = false, esc = false;
+      for (var p = objStart; p < html.length; p++) {
+        var ch = html[p];
+        if (esc) { esc = false; continue; }
+        if (ch === '\\\\') { esc = true; continue; }
+        if (ch === '"') { inStr = !inStr; continue; }
+        if (inStr) continue;
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            try {
+              var obj = JSON.parse(html.substring(objStart, p + 1));
+              var desc = obj && obj.data && obj.data.job && (obj.data.job.description || obj.data.job.descriptionHtml);
+              if (desc && desc.length > 200) {
+                return { html: desc, source: "phApp-jobDetail" };
+              }
+            } catch (e) {}
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
+})()`;
+
+// ---------------------------------------------------------------------------
+// Puppeteer driver
+// ---------------------------------------------------------------------------
+
+interface BrowserHandles {
+  browser: Browser;
+  owned: boolean;
+}
+
+async function acquireBrowser(injected?: Browser): Promise<BrowserHandles> {
+  if (injected) return { browser: injected, owned: false };
+  // Match the loader in `./browser.ts`. We don't reach into that module
+  // directly because we want to manage our own pages/lifecycle.
+  const puppeteer = await import("puppeteer-core");
+  const chromiumModule = await import("@sparticuz/chromium");
+  type ChromiumLike = {
+    args: string[];
+    defaultViewport?: { width: number; height: number } | null;
+    executablePath: () => Promise<string>;
+  };
+  const chromium = (
+    (chromiumModule as { default?: ChromiumLike }).default ?? chromiumModule
+  ) as unknown as ChromiumLike;
+  const executablePath = await chromium.executablePath();
+  const browser = await puppeteer.default.launch({
+    args: chromium.args,
+    defaultViewport: chromium.defaultViewport,
+    executablePath,
+    headless: true,
+  });
+  return { browser, owned: true };
+}
+
+async function fetchListingPage(
+  page: Page,
+  from: number
+): Promise<PhenomSearchPayload | null> {
+  const url = from === 0 ? RBC_LISTING_URL : `${RBC_LISTING_URL}?from=${from}`;
+  await page.goto(url, { waitUntil: "networkidle2", timeout: 45_000 });
+  // Phenom hydrates after initial paint — small wait gives the SSR blob
+  // time to settle on slow connections.
+  await new Promise((r) => setTimeout(r, 2_000));
+  const html = await page.content();
+  return extractEagerLoadPayload(html);
+}
+
+async function enrichOne(page: Page, job: JobData): Promise<void> {
+  if (!job.url) return;
+  await page.goto(job.url, { waitUntil: "networkidle2", timeout: 45_000 });
+  await new Promise((r) => setTimeout(r, 2_500));
+  const result = (await page.evaluate(PHENOM_DETAIL_EXTRACTOR_SRC)) as
+    | { html: string; source: string }
+    | null;
+  if (!result?.html) return;
+  const decoded = decodeHtmlEntities(result.html);
+  job.description_html = decoded;
+  job.description_text = htmlToText(decoded);
+}
+
+async function enrichDescriptions(
+  browser: Browser,
+  jobs: JobData[],
+  concurrency: number
+): Promise<void> {
+  const queue = [...jobs];
+  let enriched = 0;
+  let failed = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, jobs.length) }, async () => {
+      const page = await browser.newPage();
+      try {
+        await page.setUserAgent(USER_AGENT);
+        while (queue.length > 0) {
+          const job = queue.shift();
+          if (!job) break;
+          try {
+            await enrichOne(page, job);
+            enriched++;
+          } catch (e) {
+            failed++;
+            log.warn(
+              {
+                reqId: job.external_id,
+                err: e instanceof Error ? e.message : String(e),
+              },
+              "[phenom-rbc] description enrichment failed"
+            );
+          }
+        }
+      } finally {
+        await page.close();
+      }
+    })
+  );
+  log.info(
+    { enriched, failed, total: jobs.length },
+    "[phenom-rbc] description enrichment complete"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+export async function fetchPhenomRbcJobs(
+  atsIdentifier: string,
+  browser?: Browser
+): Promise<JobData[]> {
+  // `atsIdentifier` is "rbc" today — accepted in the signature so the
+  // factory can dispatch by tenant once more Phenom tenants land.
+  void atsIdentifier;
+
+  const maxJobsEnv = process.env.PHENOM_RBC_MAX_JOBS;
+  const maxJobs =
+    maxJobsEnv && /^\d+$/.test(maxJobsEnv)
+      ? Math.max(1, parseInt(maxJobsEnv, 10))
+      : DEFAULT_MAX_JOBS;
+
+  const { browser: browserInstance, owned } = await acquireBrowser(browser);
+
+  try {
+    const listingPage = await browserInstance.newPage();
+    await listingPage.setUserAgent(USER_AGENT);
+
+    const jobs: JobData[] = [];
+    let totalHits: number | null = null;
+    let from = 0;
+
+    // Paginate listings. Stop when: corpus exhausted, page is empty, or
+    // we hit the per-run cap.
+    while (jobs.length < maxJobs) {
+      const payload = await fetchListingPage(listingPage, from);
+      if (!payload?.data?.jobs?.length) break;
+      totalHits = payload.totalHits ?? totalHits;
+      const pageJobs = payload.data.jobs.map(mapPhenomJob);
+      jobs.push(...pageJobs);
+      from += pageJobs.length;
+      if (totalHits != null && from >= totalHits) break;
+    }
+
+    if (jobs.length > maxJobs) jobs.length = maxJobs;
+    await listingPage.close();
+
+    log.info(
+      { fetched: jobs.length, totalHits, maxJobs },
+      "[phenom-rbc] listings complete; enriching descriptions"
+    );
+
+    if (jobs.length > 0) {
+      await enrichDescriptions(browserInstance, jobs, DESCRIPTION_CONCURRENCY);
+    }
+
+    return jobs;
+  } finally {
+    if (owned) await browserInstance.close();
+  }
+}

--- a/web/scripts/smoke-phenom-rbc.ts
+++ b/web/scripts/smoke-phenom-rbc.ts
@@ -1,0 +1,82 @@
+/**
+ * Integration smoke: drive the production Phenom-RBC scraper through the
+ * real `fetchJobs("phenom", "rbc", ...)` factory and dump the result for
+ * human inspection.
+ *
+ * Usage (from web/):
+ *   npx tsx scripts/smoke-phenom-rbc.ts
+ *
+ * Output: scripts/artifacts/phenom-rbc-smoke.json
+ *
+ * What this exercises:
+ *   - The real factory dispatch in web/lib/scrapers/index.ts
+ *   - The real scraper in web/lib/scrapers/phenom-rbc.ts (pagination over
+ *     phApp.eagerLoadRefineSearch + concurrent JSON-LD description
+ *     enrichment)
+ *   - Browser injection (we hand the factory a locally-launched Chrome so
+ *     the script runs reliably on a developer laptop; in prod, GitHub
+ *     Actions provides a full-puppeteer Browser via the same injection
+ *     point).
+ *
+ * Cap: forces PHENOM_RBC_MAX_JOBS=5 so a local smoke costs ~30s, not the
+ * ~30 minutes a full RBC scrape would. Adjust the constant below if you
+ * want more data.
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import puppeteer from "puppeteer";
+import type { Browser as CoreBrowser } from "puppeteer-core";
+import { fetchJobs } from "../lib/scrapers";
+
+const SMOKE_JOB_CAP = 5;
+const OUT = resolve(__dirname, "artifacts/phenom-rbc-smoke.json");
+
+async function main(): Promise<void> {
+  // Cap the production scraper to a small, fast run.
+  process.env.PHENOM_RBC_MAX_JOBS = String(SMOKE_JOB_CAP);
+
+  console.log(`[smoke] launching local Chrome (bundled puppeteer)…`);
+  const browser = await puppeteer.launch({ headless: true });
+
+  let error: string | null = null;
+  let jobs: Awaited<ReturnType<typeof fetchJobs>> = [];
+
+  try {
+    console.log(`[smoke] dispatching fetchJobs("phenom", "rbc", …)`);
+    jobs = await fetchJobs(
+      "phenom",
+      "rbc",
+      undefined,
+      browser as unknown as CoreBrowser
+    );
+    console.log(`[smoke] factory returned ${jobs.length} jobs`);
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+    console.error(`[smoke] fetchJobs failed:`, error);
+  } finally {
+    await browser.close();
+  }
+
+  const payload = {
+    ranAt: new Date().toISOString(),
+    cap: SMOKE_JOB_CAP,
+    error,
+    jobCount: jobs.length,
+    notes: [
+      "Driven through the real fetchJobs(\"phenom\", \"rbc\", …) factory and the production phenom-rbc.ts scraper.",
+      "PHENOM_RBC_MAX_JOBS env var caps the scrape; default is 50, this smoke forces 5.",
+      "description_text on each job is the FULL extracted text from the per-detail-page JSON-LD JobPosting block.",
+    ],
+    jobs,
+  };
+
+  mkdirSync(dirname(OUT), { recursive: true });
+  writeFileSync(OUT, JSON.stringify(payload, null, 2));
+  console.log(`[smoke] wrote ${OUT}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
Phase 1.5: promotes the smoke-script extraction into the real `fetchJobs("phenom", "rbc", …)` factory path. Stacks on #71 (Phase 1) which stacks on #70 (Phase 0).

The scraper reads from two **documented, schema.org-grounded** surfaces:

1. **Listing**: `phApp.eagerLoadRefineSearch.data.jobs[]` embedded in the rendered HTML — ~40 fields per posting (title, reqId, city/state/country, `multi_category`, `subCategory`, postedDate, descriptionTeaser).
2. **Detail**: `<script type="application/ld+json">` JobPosting block — full HTML description as `description` (HTML-entity-encoded; decoded by `decodeHtmlEntities`).

JSON-LD is Google-indexed for job-search SEO so Phenom is unlikely to drop it. Pagination via `?from=<offset>`. Description enrichment runs at **concurrency=4** with a dedicated Puppeteer page per worker.

### Cost knob
`PHENOM_RBC_MAX_JOBS` env var (default **50**) caps the per-run corpus. Full RBC is ~1,500 jobs; at ~5s/detail-page × 4-concurrent that's ~30 min cold-start. Daily after that is cheap thanks to the `description_hash` gate skipping Flash extraction on unchanged jobs. Tune the cap up after smoke confirms.

### Test & verification
- [x] `npm test` — **99/99** pass, **14 new cases** for the scraper (JSON extraction edge cases, brace-counter behavior on strings containing `}`, entity-decoder ordering, mapper completeness, commitment/location-type inference, Workday→Phenom URL hygiene)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean except the pre-existing unrelated warning
- [x] **End-to-end integration smoke** via `fetchJobs("phenom", "rbc", undefined, browser)`: 5/5 jobs returned, 5/5 enriched with 6–17K char descriptions, 0 failed, totalHits=1,482

### Architecture / factory wiring
- `case "phenom"` in [web/lib/scrapers/index.ts](web/lib/scrapers/index.ts) dispatches by `atsIdentifier`: `"rbc"` → `fetchPhenomRbcJobs`; any other tenant throws with an actionable error ("Add a tenant-specific scraper modeled on phenom-rbc.ts").
- Removed `phenom` from the generic browser fallback group.
- `isBrowserScraper` now includes `"phenom"` so RBC offloads via `scrape-heavy.yml` on GitHub Actions in prod.

### What's NOT in this PR
- Activating RBC (`is_active=true`) — stays false until you review the smoke artifact and decide to enable.
- BMO / TD / CIBC / National — Phase 3.
- Caching across runs — current scraper enriches every job every run; processor's `description_hash` gate saves Flash cost but not Puppeteer time. Optimization frontier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)