### PR TITLE
fix(phenom-rbc): process full corpus in batches of 50, not a hard 50-job cap

### DIFF
--- a/web/lib/scrapers/phenom-rbc.test.ts
+++ b/web/lib/scrapers/phenom-rbc.test.ts
@@ -15,6 +15,7 @@ import {
   decodeHtmlEntities,
   extractEagerLoadPayload,
   mapPhenomJob,
+  resolveJobCap,
   type PhenomRawJob,
   type PhenomSearchPayload,
 } from "./phenom-rbc";
@@ -151,6 +152,30 @@ describe("mapPhenomJob", () => {
     const sales = FIXTURE.data!.jobs!.find((j) => j.reqId === "R-0000170325");
     const job = mapPhenomJob(sales as PhenomRawJob);
     expect(job.location).toBe("WINNIPEG, Manitoba, Canada");
+  });
+});
+
+describe("resolveJobCap", () => {
+  it("returns null when unset — production default is the FULL corpus", () => {
+    expect(resolveJobCap(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(resolveJobCap("")).toBeNull();
+  });
+
+  it("returns null for a non-numeric value rather than throwing", () => {
+    expect(resolveJobCap("all")).toBeNull();
+    expect(resolveJobCap("50x")).toBeNull();
+  });
+
+  it("parses a positive integer cap (smoke tests / cost ceilings)", () => {
+    expect(resolveJobCap("5")).toBe(5);
+    expect(resolveJobCap("1500")).toBe(1500);
+  });
+
+  it("clamps a zero cap up to 1 — a cap of 0 would be a useless run", () => {
+    expect(resolveJobCap("0")).toBe(1);
   });
 });
 

--- a/web/lib/scrapers/phenom-rbc.ts
+++ b/web/lib/scrapers/phenom-rbc.ts
@@ -20,17 +20,22 @@
  *      `phApp.ddo.jobDetail.data.job.description` is a structurally
  *      equivalent fallback.
  *
- * The scraper visits the listing pages first (cheap — one page-load per
- * 10 jobs), then enriches each posting's description with a per-job
- * detail-page fetch. Description enrichment runs at concurrency=4 with
- * a dedicated puppeteer page per worker.
+ * The scraper paginates the FULL listing first (cheap — one page-load
+ * per 10 jobs), then enriches every posting's description with a per-job
+ * detail-page fetch. Description enrichment runs in batches of
+ * `ENRICH_BATCH_SIZE` (50): each batch uses concurrency=4 with fresh
+ * puppeteer pages that are closed when the batch finishes, so page
+ * memory doesn't accumulate across a multi-thousand-job run. Progress is
+ * logged per batch.
  *
- * Cost knob: `PHENOM_RBC_MAX_JOBS` env var caps the corpus to fetch per
- * run (default 50). Tune up after smoke confirms the pipeline. Full RBC
- * is ~1,500 jobs; at 4-concurrent description fetches × ~5s each that's
- * ~30min on cold-start. The processor's `description_hash` gate makes
- * subsequent runs cheap (no Gemini re-extraction on unchanged jobs), but
- * the per-page Puppeteer load is still incurred — that's the next
+ * Cost knob: `PHENOM_RBC_MAX_JOBS` env var is an OPTIONAL cap. Unset (the
+ * production default) means "process the entire RBC corpus" — pagination
+ * runs until totalHits is exhausted. Set it for smoke tests or to impose
+ * a cost ceiling. Full RBC is ~1,500 jobs; at 4-concurrent description
+ * fetches × ~5s each that's ~30min on cold-start (fine for GitHub
+ * Actions). The processor's `description_hash` gate makes subsequent
+ * runs cheap (no Gemini re-extraction on unchanged jobs), but the
+ * per-page Puppeteer load is still incurred — that's the next
  * optimization frontier if cost becomes real.
  */
 
@@ -40,8 +45,11 @@ import { detectLocationType, htmlToText } from "./utils";
 import { log } from "@/lib/log";
 
 const RBC_LISTING_URL = "https://jobs.rbc.com/ca/en/search-results";
-const DEFAULT_MAX_JOBS = 50;
 const DESCRIPTION_CONCURRENCY = 4;
+// Description enrichment is processed in batches of this size: fresh
+// puppeteer pages per batch, closed at batch end. Bounds page-memory
+// growth over a full ~1,500-job corpus and gives per-batch progress logs.
+const ENRICH_BATCH_SIZE = 50;
 const USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
@@ -334,16 +342,22 @@ async function enrichOne(page: Page, job: JobData): Promise<void> {
   job.description_text = htmlToText(decoded);
 }
 
-async function enrichDescriptions(
+/**
+ * Enrich one batch of jobs. Spins up `concurrency` fresh pages, drains a
+ * shared queue, and closes the pages when done — so page memory is
+ * released at the end of every batch rather than accumulating across the
+ * whole corpus.
+ */
+async function enrichBatch(
   browser: Browser,
-  jobs: JobData[],
+  batch: JobData[],
   concurrency: number
-): Promise<void> {
-  const queue = [...jobs];
+): Promise<{ enriched: number; failed: number }> {
+  const queue = [...batch];
   let enriched = 0;
   let failed = 0;
   await Promise.all(
-    Array.from({ length: Math.min(concurrency, jobs.length) }, async () => {
+    Array.from({ length: Math.min(concurrency, batch.length) }, async () => {
       const page = await browser.newPage();
       try {
         await page.setUserAgent(USER_AGENT);
@@ -369,8 +383,44 @@ async function enrichDescriptions(
       }
     })
   );
+  return { enriched, failed };
+}
+
+/**
+ * Enrich every job's description, walking the corpus in chunks of
+ * `batchSize`. Each chunk is a self-contained `enrichBatch` call; progress
+ * is logged after each so a long (~1,500-job) run is observable and a
+ * crash leaves a clear high-water mark in the logs.
+ */
+async function enrichDescriptions(
+  browser: Browser,
+  jobs: JobData[],
+  concurrency: number,
+  batchSize: number
+): Promise<void> {
+  const batchCount = Math.ceil(jobs.length / batchSize);
+  let totalEnriched = 0;
+  let totalFailed = 0;
+  for (let i = 0; i < jobs.length; i += batchSize) {
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const batch = jobs.slice(i, i + batchSize);
+    const { enriched, failed } = await enrichBatch(browser, batch, concurrency);
+    totalEnriched += enriched;
+    totalFailed += failed;
+    log.info(
+      {
+        batch: batchNum,
+        batchCount,
+        processed: Math.min(i + batchSize, jobs.length),
+        total: jobs.length,
+        enrichedSoFar: totalEnriched,
+        failedSoFar: totalFailed,
+      },
+      "[phenom-rbc] enrichment batch complete"
+    );
+  }
   log.info(
-    { enriched, failed, total: jobs.length },
+    { enriched: totalEnriched, failed: totalFailed, total: jobs.length },
     "[phenom-rbc] description enrichment complete"
   );
 }
@@ -378,6 +428,22 @@ async function enrichDescriptions(
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
+
+/**
+ * Resolve the optional per-run cap. `PHENOM_RBC_MAX_JOBS`:
+ *   - unset (production default) → null → process the entire corpus
+ *   - a positive integer → cap the run to that many jobs (smoke tests,
+ *     cost ceilings)
+ * Exported for unit testing.
+ */
+export function resolveJobCap(
+  rawEnv: string | undefined = process.env.PHENOM_RBC_MAX_JOBS
+): number | null {
+  if (rawEnv && /^\d+$/.test(rawEnv)) {
+    return Math.max(1, parseInt(rawEnv, 10));
+  }
+  return null;
+}
 
 export async function fetchPhenomRbcJobs(
   atsIdentifier: string,
@@ -387,11 +453,7 @@ export async function fetchPhenomRbcJobs(
   // factory can dispatch by tenant once more Phenom tenants land.
   void atsIdentifier;
 
-  const maxJobsEnv = process.env.PHENOM_RBC_MAX_JOBS;
-  const maxJobs =
-    maxJobsEnv && /^\d+$/.test(maxJobsEnv)
-      ? Math.max(1, parseInt(maxJobsEnv, 10))
-      : DEFAULT_MAX_JOBS;
+  const cap = resolveJobCap();
 
   const { browser: browserInstance, owned } = await acquireBrowser(browser);
 
@@ -403,28 +465,39 @@ export async function fetchPhenomRbcJobs(
     let totalHits: number | null = null;
     let from = 0;
 
-    // Paginate listings. Stop when: corpus exhausted, page is empty, or
-    // we hit the per-run cap.
-    while (jobs.length < maxJobs) {
+    // Paginate the FULL listing. Phenom serves 10 per page. Stop when the
+    // corpus is exhausted, a page comes back empty, or the optional cap
+    // is reached.
+    while (true) {
       const payload = await fetchListingPage(listingPage, from);
       if (!payload?.data?.jobs?.length) break;
       totalHits = payload.totalHits ?? totalHits;
-      const pageJobs = payload.data.jobs.map(mapPhenomJob);
-      jobs.push(...pageJobs);
-      from += pageJobs.length;
+      jobs.push(...payload.data.jobs.map(mapPhenomJob));
+      from += payload.data.jobs.length;
+      if (cap != null && jobs.length >= cap) break;
       if (totalHits != null && from >= totalHits) break;
     }
 
-    if (jobs.length > maxJobs) jobs.length = maxJobs;
+    if (cap != null && jobs.length > cap) jobs.length = cap;
     await listingPage.close();
 
     log.info(
-      { fetched: jobs.length, totalHits, maxJobs },
-      "[phenom-rbc] listings complete; enriching descriptions"
+      {
+        fetched: jobs.length,
+        totalHits,
+        cap: cap ?? "uncapped",
+        batchSize: ENRICH_BATCH_SIZE,
+      },
+      "[phenom-rbc] listings complete; enriching descriptions in batches"
     );
 
     if (jobs.length > 0) {
-      await enrichDescriptions(browserInstance, jobs, DESCRIPTION_CONCURRENCY);
+      await enrichDescriptions(
+        browserInstance,
+        jobs,
+        DESCRIPTION_CONCURRENCY,
+        ENRICH_BATCH_SIZE
+      );
     }
 
     return jobs;

--- a/web/scripts/smoke-phenom-rbc.ts
+++ b/web/scripts/smoke-phenom-rbc.ts
@@ -19,8 +19,9 @@
  *     point).
  *
  * Cap: forces PHENOM_RBC_MAX_JOBS=5 so a local smoke costs ~30s, not the
- * ~30 minutes a full RBC scrape would. Adjust the constant below if you
- * want more data.
+ * ~30 minutes a full RBC scrape would. The env var is an optional cap —
+ * unset (the production default) the scraper processes the whole corpus.
+ * Adjust the constant below if you want more data.
  */
 
 import { writeFileSync, mkdirSync } from "node:fs";
@@ -65,7 +66,7 @@ async function main(): Promise<void> {
     jobCount: jobs.length,
     notes: [
       "Driven through the real fetchJobs(\"phenom\", \"rbc\", …) factory and the production phenom-rbc.ts scraper.",
-      "PHENOM_RBC_MAX_JOBS env var caps the scrape; default is 50, this smoke forces 5.",
+      "PHENOM_RBC_MAX_JOBS is an optional cap; unset = full corpus, this smoke forces 5.",
       "description_text on each job is the FULL extracted text from the per-detail-page JSON-LD JobPosting block.",
     ],
     jobs,


### PR DESCRIPTION
## Summary
The Phase 1.5 scraper stopped after `PHENOM_RBC_MAX_JOBS` (default 50) — it scraped 50 jobs and quit, leaving ~1,430 RBC postings uncollected. Confirmed empirically: the first production run scraped exactly 50.

This makes the scraper process the **full corpus**:
- `PHENOM_RBC_MAX_JOBS` is now an **optional cap**. Unset (production default) → paginate until `totalHits` is exhausted (~1,500 RBC jobs). Set it for smoke tests / cost ceilings. `resolveJobCap` centralises the unset→null→uncapped logic.
- Description enrichment walks the corpus in **batches of 50** (`ENRICH_BATCH_SIZE`). Each batch = 4 concurrent workers with fresh Puppeteer pages closed at batch end, so page memory is released every 50 jobs instead of accumulating across a multi-thousand-job session. Per-batch progress logs give a visible high-water mark if a long run dies midway.

## Test plan
- [x] `npm test` — 104/104 pass (5 new `resolveJobCap` cases)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean except the pre-existing unrelated warning
- [ ] After merge: the daily 6am cron picks RBC up and does the full ~1,500-job corpus (~30 min on GitHub Actions)

## Note — `PHENOM_RBC_MAX_JOBS` in CI
`scrape-heavy.yml` does not pass this env var, so GitHub Actions runs uncapped (full corpus) — which is the intended production behavior. To impose a ceiling later, add `PHENOM_RBC_MAX_JOBS: ${{ vars.PHENOM_RBC_MAX_JOBS }}` to the workflow `env:` block.

## Related — separate gap (not fixed here)
The first RBC run scraped 50 jobs, all Flash-extracted (seniority + function + description populated), but produced **0 strategic_insights** — offloaded browser scrapers never reach the analysis stage / incumbent cost gate. Tracked in the implementation plan as its own phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)