### PR TITLE
fix(jobs): run analysis for offloaded scrapers (Phase 1.6)

### DIFF
--- a/web/lib/jobs/runner.ts
+++ b/web/lib/jobs/runner.ts
@@ -391,6 +391,57 @@ export async function triggerAnalysisJobIfNeeded(
 }
 
 /**
+ * Create and RUN an analysis job for a specific set of newly-ingested job
+ * IDs at one company, awaiting it to completion.
+ *
+ * This is the offload-path counterpart to `triggerAnalysisJobIfNeeded`.
+ * That function is invoked by the Vercel collect route the instant
+ * `executeCollectionJob` returns — which is too early for browser-scraper
+ * companies (RBC etc.), whose scrape + ingest is still running on GitHub
+ * Actions at that point. The GH Actions entrypoint (`scrape-heavy.ts`)
+ * calls THIS right after `runIngestStage`, so the analysis stage — and
+ * the incumbent cost gate inside `runAnalyzeStage` — actually executes
+ * for offloaded companies instead of being silently skipped.
+ *
+ * Scoped to a single company on purpose: re-running the collection run's
+ * `triggerAnalysisJobIfNeeded` would re-analyze sibling fintech tasks
+ * whose `pending_analysis_job_ids` are never cleared, double-billing Pro
+ * calls and duplicating `strategic_insights`.
+ *
+ * Unlike `triggerAnalysisJobIfNeeded` (fire-and-forget, suited to the
+ * serverless route), this AWAITS `executeAnalysisJob` — a GH Actions
+ * process must not exit before analysis finishes.
+ *
+ * @returns the analysis job run id, or null if there was nothing to analyze.
+ */
+export async function triggerAnalysisForJobs(
+  companyId: string,
+  jobIds: string[],
+  parentJobRunId?: string
+): Promise<string | null> {
+  if (jobIds.length === 0) return null;
+  const supabase = createAdminClient();
+
+  const analysisJobRunId = await createJobRun({
+    jobType: 'analyze',
+    triggerType: 'cron',
+    companyIds: [companyId],
+    parentJobRunId,
+  });
+
+  // createJobRun has already inserted the single task for this company;
+  // populate the job IDs it should analyze.
+  await supabase
+    .from('job_run_tasks')
+    .update({ pending_analysis_job_ids: jobIds })
+    .eq('job_run_id', analysisJobRunId)
+    .eq('company_id', companyId);
+
+  await executeAnalysisJob(analysisJobRunId);
+  return analysisJobRunId;
+}
+
+/**
  * Refresh news cache for companies that had new jobs in the collection run.
  * This pre-computes the expensive Gemini + web search calls so they're ready
  * for weekly digest generation.

--- a/web/scripts/scrape-heavy.ts
+++ b/web/scripts/scrape-heavy.ts
@@ -19,6 +19,7 @@ import type { Browser } from "puppeteer-core";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { fetchJobs } from "@/lib/scrapers";
 import { runIngestStage } from "@/lib/jobs/processor";
+import { triggerAnalysisForJobs } from "@/lib/jobs/runner";
 import type { Company } from "@/lib/jobs/types";
 
 async function main() {
@@ -257,6 +258,39 @@ async function main() {
       .eq("id", jobRun.id);
 
     console.log("✅ Scraping completed successfully!");
+
+    // Step 9: Analysis. The Vercel collect route fires analysis the moment
+    // executeCollectionJob returns — far too early for an offloaded scraper
+    // whose scrape + ingest only just finished here. Without this call the
+    // analysis stage (and the incumbent cost gate inside runAnalyzeStage)
+    // never runs for browser-scraped companies. Scoped to this company's
+    // newly-ingested jobs so sibling fintech tasks aren't re-analyzed.
+    if (ingestResult.newJobIds.length > 0) {
+      console.log(
+        `🧠 Triggering analysis for ${ingestResult.newJobIds.length} new job(s)...`
+      );
+      try {
+        const analysisRunId = await triggerAnalysisForJobs(
+          companyId,
+          ingestResult.newJobIds,
+          jobRun.id
+        );
+        console.log(`✅ Analysis stage complete (run ${analysisRunId})`);
+      } catch (analysisError) {
+        // Collection data is already saved and the task is marked
+        // completed — an analysis failure is recoverable (re-runnable), so
+        // log loudly but don't fail the whole script.
+        console.error(
+          `⚠️  Analysis stage failed (collection data is safe): ${
+            analysisError instanceof Error
+              ? analysisError.message
+              : String(analysisError)
+          }`
+        );
+      }
+    } else {
+      console.log("ℹ️  No new jobs — skipping analysis stage.");
+    }
   } catch (error) {
     console.error(`❌ Error during scraping: ${error instanceof Error ? error.message : String(error)}`);
     


### PR DESCRIPTION
## Summary
Closes the gap surfaced + confirmed empirically in the last round: **browser-scraped companies (RBC) were scraped, ingested, and Flash-extracted but never Pro-analyzed** — the incumbent cost gate in `runAnalyzeStage` was unreachable on the offload path, so RBC accrued ~50 job rows with **0 `strategic_insights`**.

### Root cause
`scrape-heavy.ts` (the GitHub Actions entrypoint) ran scrape + `runIngestStage` only. The Vercel collect route fires `triggerAnalysisJobIfNeeded` the instant `executeCollectionJob` returns — ~5s in, while the offloaded scrape is still running on GH Actions — so the company's `pending_analysis_job_ids` are empty then and it's excluded. Nothing re-triggers analysis when GH Actions finishes ~30 min later.

### Fix
- **`runner.ts`** — new `triggerAnalysisForJobs(companyId, jobIds, parentJobRunId?)`: creates a single-company analyze job run, populates the task's `pending_analysis_job_ids`, and **awaits** `executeAnalysisJob` (a GH Actions process must not exit before analysis finishes). Scoped to one company on purpose — re-running the collection run's `triggerAnalysisJobIfNeeded` would re-analyze sibling fintech tasks whose `pending_analysis_job_ids` are never cleared.
- **`scrape-heavy.ts`** — after `runIngestStage`, calls it for the company's newly-ingested jobs. `try/catch`-wrapped: collection data is already saved, so an analysis failure logs loudly but doesn't fail the run.

## Verification (live, against the 50 RBC jobs already in prod)
Ran `triggerAnalysisForJobs` against RBC's existing 50 postings — exactly what `scrape-heavy.ts` now does after ingest:

| metric | value |
|---|---|
| RBC jobs analyzed | 50 |
| `strategic_insights` before → after | 0 → 1 |
| `analyzeJobAdvanced` Pro calls | 1 |
| cost-gate skip rate | **98%** |

The gate executes (49 skipped, reason `incumbent_seniority_below_bar`), insights are created only for the gate-passing job, Pro spend stays bounded.

- [x] `npm test` — 104/104
- [x] `npm run build` — clean
- [x] `npm run lint` — clean (pre-existing unrelated warning only)

## Calibration note (not a blocker)
1/50 passing is tighter than the plan's 15-25% estimate. The first 50 are a page-1 sample (not the curated corpus) and the seniority whitelist (`staff`/`principal`/`lead`/`executive`) is strict — note "Director"/"VP" titles aren't distinct enum values in structure extraction. Worth recalibrating once the full ~1,500-job corpus is analyzed; tracked alongside the Phase 2 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)