### PR TITLE
fix(incumbent): close 6 tier-filter leaks (Phase 2 Step 1)

### DIFF
--- a/web/app/(dashboard)/companies/page.tsx
+++ b/web/app/(dashboard)/companies/page.tsx
@@ -74,10 +74,15 @@ export default async function CompaniesPage({
     .single();
   const canEdit = ["editor", "admin"].includes(profile?.role ?? "");
 
+  // Fintech-only. Incumbent (big-bank) companies are surfaced through a
+  // dedicated "Incumbents" lens (Phase 2), never mixed into the default
+  // companies list — they'd otherwise carry meaningless fintech pivot
+  // classifications and ~1,500-job counts.
   const { data: companies } = await supabase
     .from("companies")
     .select("id, name, slug, country, thesis, last_change, last_change_at, last_collected_at")
     .eq("is_active", true)
+    .eq("tier", "fintech")
     .order("name");
 
   const list = companies ?? [];

--- a/web/app/(dashboard)/dashboard/page.tsx
+++ b/web/app/(dashboard)/dashboard/page.tsx
@@ -75,12 +75,14 @@ export default async function DashboardPage({
     hotRoles,
     { data: companiesRaw },
   ] = await Promise.all([
-    // Active jobs count (current snapshot, no backfill filter needed)
+    // Active jobs count (current snapshot, no backfill filter needed).
+    // Fintech-only — incumbent (big-bank) postings must not inflate the KPI.
     supabase
       .from("job_postings")
-      .select("*, companies!inner(is_active)", { count: "exact", head: true })
+      .select("*, companies!inner(is_active, tier)", { count: "exact", head: true })
       .eq("is_active", true)
-      .eq("companies.is_active", true),
+      .eq("companies.is_active", true)
+      .eq("companies.tier", "fintech"),
     // Net new/closed this week
     getNetThisWeek(cutoffs),
     // Posting trends for sparkline
@@ -98,11 +100,13 @@ export default async function DashboardPage({
     getLatestDigest(),
     // Hot roles feed
     getHotRoles(cutoffs),
-    // Companies for filter dropdown
+    // Companies for filter dropdown (fintech-only — the dashboard is the
+    // fintech surface; incumbents are excluded from the count + dropdown).
     supabase
       .from("companies")
       .select("id, name")
       .eq("is_active", true)
+      .eq("tier", "fintech")
       .order("name"),
   ]);
 

--- a/web/app/api/insights/highlights/route.ts
+++ b/web/app/api/insights/highlights/route.ts
@@ -91,9 +91,10 @@ export async function GET(req: NextRequest) {
         significance_score,
         confidence,
         executive_summary,
-        companies!inner(id, name, slug, is_active)
+        companies!inner(id, name, slug, is_active, tier)
       `)
       .eq("companies.is_active", true)
+      .eq("companies.tier", "fintech")
       .gte("generated_at", cutoffDate.toISOString())
       .order("significance_score", { ascending: false, nullsFirst: false })
       .order("generated_at", { ascending: false })
@@ -127,11 +128,13 @@ export async function GET(req: NextRequest) {
       };
     });
     
-    // Get tracked company count
+    // Get tracked company count (fintech-only — incumbents aren't "tracked
+    // companies" in the dashboard's sense).
     const { count: trackedCompanyCount } = await supabase
       .from("companies")
       .select("*", { count: "exact", head: true })
-      .eq("is_active", true);
+      .eq("is_active", true)
+      .eq("tier", "fintech");
     
     return NextResponse.json({
       highlights,

--- a/web/lib/analysis/company-insights.ts
+++ b/web/lib/analysis/company-insights.ts
@@ -804,12 +804,16 @@ export async function getNextCompanyForInsight(): Promise<{
     throw new Error(`Failed to clean up insight locks: ${cleanupError.message}`);
   }
 
-  // Get active companies that don't have a recent insight
-  // Exclude companies that are currently being processed (have active locks)
+  // Get active companies that don't have a recent insight.
+  // Fintech-only: the scheduled insight generator must skip incumbents —
+  // each insight is an expensive Pro+grounded call, and we don't auto-
+  // generate company insights for big banks. (Admins can still trigger an
+  // incumbent insight by explicit company id.)
   const { data: companies } = await supabase
     .from("companies")
     .select("id, name")
-    .eq("is_active", true);
+    .eq("is_active", true)
+    .eq("tier", "fintech");
 
   if (!companies || companies.length === 0) {
     return null;

--- a/web/lib/dashboard-queries.test.ts
+++ b/web/lib/dashboard-queries.test.ts
@@ -56,6 +56,7 @@ import {
   getCrossCompanyThemes,
   getFunctionHeatData,
   getHotRoles,
+  getJobsListData,
   getNetHiringFlow,
   getNetThisWeek,
   getPostingTrends,
@@ -154,6 +155,26 @@ describe("volume aggregators apply the default fintech-only tier filter", () => 
   it("getCrossCompanyThemes filters on tier=fintech", async () => {
     await getCrossCompanyThemes();
     expect(tierFilterArgs("job_postings")).toEqual([["companies.tier", ["fintech"]]]);
+  });
+});
+
+describe("getJobsListData tier filter (Phase 2 Step 1 — leak G4)", () => {
+  it("defaults to fintech-only so RBC's ~1,500 jobs don't flood the /jobs list", async () => {
+    await getJobsListData();
+    expect(tierFilterArgs("job_postings")).toEqual([["companies.tier", ["fintech"]]]);
+  });
+
+  it("accepts an explicit tiers override (the Jobs-page Tier toggle opting into incumbents)", async () => {
+    await getJobsListData({ tiers: ["fintech", "incumbent"] });
+    expect(tierFilterArgs("job_postings")).toEqual([
+      ["companies.tier", ["fintech", "incumbent"]],
+    ]);
+  });
+
+  it("short-circuits an empty jobIds snapshot without issuing a query", async () => {
+    const result = await getJobsListData({ jobIds: [] });
+    expect(result).toEqual([]);
+    expect(tierFilterArgs("job_postings")).toEqual([]);
   });
 });
 

--- a/web/lib/dashboard-queries.ts
+++ b/web/lib/dashboard-queries.ts
@@ -1097,9 +1097,14 @@ function coerceKeywords(raw: unknown): string[] {
  * scope to an explicit set of job IDs — used when entering from a digest
  * deep link that captured a specific snapshot of jobs (the
  * `weekly_digest_companies.job_ids` payload).
+ *
+ * Tier-filtered (default fintech-only) via an inner join on companies, so
+ * incumbent (big-bank) postings do not flood the Jobs list, its company
+ * dropdown, or the eyebrow stats. The Jobs-page Tier toggle opts in by
+ * passing `tiers` explicitly.
  */
 export async function getJobsListData(
-  options: { jobIds?: string[] | null } = {}
+  options: { jobIds?: string[] | null; tiers?: readonly CompanyTier[] } = {}
 ): Promise<JobsListRow[]> {
   const supabase = await createClient();
 
@@ -1108,11 +1113,14 @@ export async function getJobsListData(
     return [];
   }
 
+  const tierList = [...(options.tiers ?? DEFAULT_TIERS)];
+
   let query = supabase
     .from("job_postings")
     .select(
-      "id, title, standardized_department, function_category, location, location_structured, is_active, first_seen_date, keywords, company_id, companies(id, name, slug)"
+      "id, title, standardized_department, function_category, location, location_structured, is_active, first_seen_date, keywords, company_id, companies!inner(id, name, slug, tier)"
     )
+    .in("companies.tier", tierList)
     .order("first_seen_date", { ascending: false });
 
   if (options.jobIds && options.jobIds.length > 0) {


### PR DESCRIPTION
## Summary
The Phase 2 app-wide audit found that Phase 0 threaded the `tiers` filter through the cross-company *aggregators* but **6 queries were never threaded** — and since RBC is `is_active=true`, bank rows are leaking into fintech-only surfaces on `main` right now. These are backend-only correctness/cost fixes (no UI, no design gate) — shipping ahead of the new Phase 2 surfaces.

| Gap | Surface | Fix |
|---|---|---|
| **G1** | Dashboard "Active Jobs" count + "Companies Tracked" / filter dropdown | `companies.tier='fintech'` — RBC's jobs would have inflated Active Jobs ~10× |
| **G4** (biggest) | `getJobsListData` → entire `/jobs` list, company dropdown, eyebrow stats | new `tiers` option (default `DEFAULT_TIERS`) + inner-join + `.in('companies.tier', …)` |
| **G2** | Companies list rows + job counts | `tier='fintech'` — RBC would show as a row with ~1,500 jobs + a meaningless pivot classification |
| **G5** | `/api/insights/highlights` (insights join + `trackedCompanyCount`) | `tier='fintech'` |
| **G6** | `getNextCompanyForInsight` (scheduled company-insight rotation) | `tier='fintech'` — the weekly cron would otherwise burn an expensive Pro+grounded insight on every bank |

Incumbents still surface deliberately — through the dedicated Phase 2 lens surfaces (Incumbent Bets rail, Incumbent Watch digest, the Jobs-page Tier toggle, a separate `Incumbents` companies lens). G6 keeps an admin escape hatch: admins can still trigger an incumbent company insight by explicit company id.

## Test plan
- [x] `npm test` — 107/107 (3 new `getJobsListData` tier-filter cases: default fintech-only, explicit `tiers` override, empty-snapshot short-circuit)
- [x] `npm run build` — clean
- [x] `npm run lint` — clean except the pre-existing unrelated warning

## Context
This is **Step 1** of Phase 2 (coherent app-wide incumbent integration). Steps 2+ (the `<TierBadge>` component, Incumbent Bets rail, Incumbent Watch digest block, Incumbents lens) are gated on a Meredith design review. Full plan + the 31-surface audit live in the planning docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)