### PR TITLE
feat(phase3): all 4 remaining Big-6 banks + calibration + canary (v2.2.0)

### DIFF
--- a/config/companies.yaml
+++ b/config/companies.yaml
@@ -76,3 +76,49 @@ companies:
     careers_url: https://jobs.rbc.com/ca/en/search-results
     tier: incumbent
     is_active: false
+
+  # Phase 3 additions — each ships is_active=false; flip after the first
+  # smoke + 24h of clean job_runs entries. The 4 banks together roughly 5×
+  # the active job_postings volume; see the perf indexes migration
+  # 20260522000000_phase3_indexes.sql and the scraper-break canary.
+  - name: BMO
+    slug: bmo
+    country: CA
+    ats_type: phenom
+    ats_identifier: bmo
+    careers_url: https://jobs.bmo.com/ca/en/search-results
+    tier: incumbent
+    is_active: false
+
+  - name: TD
+    slug: td
+    country: CA
+    ats_type: workday-td
+    ats_identifier: td
+    careers_url: https://td.wd3.myworkdayjobs.com/en-US/TD_Bank_Careers
+    tier: incumbent
+    is_active: false
+
+  - name: CIBC
+    slug: cibc
+    country: CA
+    ats_type: workday-cibc
+    ats_identifier: cibc
+    careers_url: https://cibc.wd3.myworkdayjobs.com/search
+    tier: incumbent
+    is_active: false
+    # Note: Simplii Financial postings (if any) surface inside CIBC's
+    # Workday tenant. The scraper's `isSimpliiPosting` classifier runs in
+    # log-only mode for Phase 3 — no row is added for Simplii yet. After
+    # the first scrape confirms Simplii postings appear in the data, a
+    # follow-up adds the `simplii` row (tier=fintech) and flips the
+    # classifier to actually route via `companySlugOverride`.
+
+  - name: National Bank
+    slug: bnc
+    country: CA
+    ats_type: phenom
+    ats_identifier: bnc
+    careers_url: https://emplois.bnc.ca/fr_CA/careers/searchjobs
+    tier: incumbent
+    is_active: false

--- a/docs/CRON_TOPOLOGY.md
+++ b/docs/CRON_TOPOLOGY.md
@@ -55,6 +55,33 @@ it needs Supabase + Gemini credentials in addition to `CRON_SECRET`:
    `job_runs` row (`job_type` from the approved enum, see `CLAUDE.md`).
 4. Update this file.
 
+## Heavy-scraper offload (`scrape-heavy.yml`)
+
+The daily `collect` cron does not directly run browser-based / long-running
+scrapers. When `isBrowserScraper(atsType)` is true (see
+`web/lib/scrapers/index.ts`), the collect route calls
+`triggerScrapeWorkflow(companyId, taskId)` in `web/lib/github.ts`, which
+`workflow_dispatch`-es `.github/workflows/scrape-heavy.yml` for that one
+company. Each bank scrape is its own GH Actions run — they execute in
+parallel, independent of each other and the cron tick.
+
+Currently offloaded:
+
+| Type            | Companies (live + planned)                     | Why                             |
+|-----------------|------------------------------------------------|---------------------------------|
+| `phenom`        | RBC, BMO, National Bank                        | Phenom is client-rendered → Puppeteer |
+| `workday-td`    | TD                                             | API-based but a ~1,500-job cold scrape exceeds Vercel's 300s |
+| `workday-cibc`  | CIBC (+ Simplii classifier log-only)           | Same                            |
+| `dayforce`      | (none currently active)                        | Browser scrape                  |
+| `successfactors`| Tangerine                                      | Browser scrape (Scotia portal)  |
+
+The `workday-td` and `workday-cibc` scrapers are HTTP-only and could in
+principle run inline in Vercel, but a cold corpus run with description
+enrichment exceeds the 300s function budget — so they're routed through
+GH Actions like the Puppeteer scrapers. Daily-incremental runs (≤ ~100
+new postings) would fit inline, but the offload path is simpler and
+isolates Workday's rate-limit posture from the live cron tick.
+
 ## Sentry alerts
 
 Every cron route is wrapped in `Sentry.withMonitor(...)` (slug + `crontab`

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -46,6 +46,22 @@ Sentry dashboard → "Issues". The cron monitors live under "Crons". Alerts rout
 
 If you add a new outbound `resend.emails.send(...)` or `resend.batch.send(...)` call, wrap it with `retryResendCall` for symmetry.
 
+## Scraper-break canary (partial-corpus drop)
+
+Outright scraper errors and zero-result wipes are already caught by [`web/lib/email/scraper-health.ts`](../web/lib/email/scraper-health.ts) at the end of every `/api/cron/collect` run (issue types `failed` and `empty`). Silent partial drops — the scraper still returns *some* jobs but is missing pagination or a careers-site section — used to slip through.
+
+The Phase-3 fragility canary closes that gap for `tier='incumbent'` companies. For each active incumbent at the end of `collect`, it computes:
+
+- `todayNewJobs` — new postings whose `first_seen_date` falls in the current UTC day.
+- `rollingAvg7d` — average new-postings per day over the 7 calendar days *before* today.
+
+The canary fires for a bank when BOTH thresholds hold:
+
+- `todayNewJobs < 0.5 * rollingAvg7d` (a >50% day-over-day drop), AND
+- `rollingAvg7d > 5` (suppress the alert on banks with low baseline volume so a legitimately quiet day doesn't page).
+
+The pure threshold rule is `evaluateCanary({today, rolling}) → { fire, reason }` in [`web/lib/email/scraper-health.ts`](../web/lib/email/scraper-health.ts); it has unit tests in `scraper-health.test.ts`. Firing canaries are appended to the existing scraper-alert email under a "Scraper-break canary" section so admins don't get a second message. Failed canary detection logs a structured `log.error` but never blocks the rest of the scraper-health flow.
+
 ## Daily Gemini cost alarm
 
 A GitHub Actions workflow ([`gemini-cost-alarm.yml`](../.github/workflows/gemini-cost-alarm.yml)) runs daily at 14:00 UTC and `curl`s `/api/admin/cost-alarm` with `Authorization: Bearer ${CRON_SECRET}`.

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "2.2.0",
+    "date": "2026-05-22",
+    "changes": [
+      { "type": "feature", "description": "Phase 3 — scaled the incumbent lens from RBC alone to all 5 Big-6 Canadian banks. BMO and National Bank join via Phenom CareerConnect (mirror of the RBC scraper); TD and CIBC join via dedicated Workday scrapers built on a shared `workday-utils.ts` (no base class — fork-per-tenant). Each bank seeded `is_active=false`; flip after smoke." },
+      { "type": "feature", "description": "Simplii Financial classifier — `workday-cibc.ts` exports `isSimpliiPosting` and runs in log-only mode for now. Once production logs confirm Simplii postings actually surface inside CIBC's Workday tenant, a follow-up adds the `simplii` companies row (tier=fintech) and routes via `companySlugOverride`." },
+      { "type": "feature", "description": "Cost-gate calibration script (`web/scripts/calibrate-incumbent-gate.ts`) — read-only Markdown + JSON report on the incumbent corpus: seniority distribution, function-category distribution, pass rate under the production whitelist, simulated pass rates under candidate whitelists (e.g. include `senior`, drop `aml-financial-crime`), and the top-20 near-miss `senior`-in-whitelisted-function titles. Run after each Phase-3 ramp." },
+      { "type": "improvement", "description": "Scraper-break canary — the scraper-health alert email now fires on partial-corpus drops, not only outages. For each tracked incumbent bank, if today's new-jobs count is below 50% of the 7-day rolling average AND that rolling average is above 5, a \"Scraper-break canary\" section appears in the next alert email." },
+      { "type": "improvement", "description": "Two partial indexes on the read-hot tables (`idx_job_postings_company_active_first_seen`, `idx_companies_tier_active`) for the per-company windowed queries and the cross-company tier joins. Pre-empts the query-plan degradation Luke's plan review flagged at 5× scale." },
+      { "type": "improvement", "description": "`/jobs` hard-capped at the 500 most-recent postings (`JOBS_LIST_MAX_ROWS`). Without it, a `?tier=incumbent` or `?tier=all` view would ship ~22 MB of JSON on every page render once the bank ramp finishes." },
+      { "type": "improvement", "description": "`decodeHtmlEntities` consolidated into `web/lib/scrapers/utils.ts` (was duplicated twice; scotiabank's copy decoded `&amp;` first — a subtle bug that collapsed doubly-encoded sequences like `&amp;lt;` to `<` instead of leaving them as `&lt;`)." }
+    ]
+  },
+  {
     "version": "2.1.0",
     "date": "2026-05-21",
     "changes": [

--- a/web/lib/dashboard-queries.ts
+++ b/web/lib/dashboard-queries.ts
@@ -1105,7 +1105,14 @@ function coerceKeywords(raw: unknown): string[] {
  * incumbent (big-bank) postings do not flood the Jobs list, its company
  * dropdown, or the eyebrow stats. The Jobs-page Tier toggle opts in by
  * passing `tiers` explicitly.
+ *
+ * Hard-capped at `JOBS_LIST_MAX_ROWS` (most-recent first). Without a cap, an
+ * `?tier=incumbent` or `?tier=all` query would ship the entire ~7k-row
+ * active corpus on every page render (~22MB JSON, painful client-side).
+ * Phase 3 follow-up will replace this with server-side pagination.
  */
+export const JOBS_LIST_MAX_ROWS = 500;
+
 export async function getJobsListData(
   options: { jobIds?: string[] | null; tiers?: readonly CompanyTier[] } = {}
 ): Promise<JobsListRow[]> {
@@ -1124,7 +1131,8 @@ export async function getJobsListData(
       "id, title, standardized_department, function_category, location, location_structured, is_active, first_seen_date, keywords, company_id, companies!inner(id, name, slug, tier)"
     )
     .in("companies.tier", tierList)
-    .order("first_seen_date", { ascending: false });
+    .order("first_seen_date", { ascending: false })
+    .limit(JOBS_LIST_MAX_ROWS);
 
   if (options.jobIds && options.jobIds.length > 0) {
     query = query.in("id", options.jobIds);

--- a/web/lib/email/scraper-health.test.ts
+++ b/web/lib/email/scraper-health.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the partial-corpus-drop canary threshold helper.
+ *
+ * The canary in `scraper-health.ts` is the Phase-3 fragility tripwire: it
+ * fires when an incumbent scraper returns visibly less than its 7-day
+ * baseline today. Silent partial drops are worse than outages (Luke #10)
+ * because they look healthy in alerts but rot the dataset.
+ *
+ * `evaluateCanary` is the pure threshold check extracted so the rule is
+ * unit-testable without DB / email infrastructure. Two thresholds must
+ * BOTH hold for the canary to fire:
+ *   - today < 50% of the 7-day rolling average (the drop)
+ *   - rolling > 5 (filter out quiet weeks)
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  evaluateCanary,
+  CANARY_DROP_RATIO,
+  CANARY_MIN_ROLLING_AVG,
+} from "./scraper-health";
+
+describe("evaluateCanary", () => {
+  describe("fires the canary", () => {
+    it("fires when today is well below 50% of the 7-day rolling average", () => {
+      // 7-day avg = 10/day, today = 2 → 20% of baseline; well below ratio.
+      const decision = evaluateCanary({ today: 2, rolling: 10 });
+      expect(decision.fire).toBe(true);
+      expect(decision.reason).toBe("fire_partial_corpus_drop");
+    });
+
+    it("fires when today is exactly zero against a healthy baseline", () => {
+      // The canonical partial-corpus failure: the scraper returns no NEW
+      // jobs even though the bank has been posting 10/day all week.
+      const decision = evaluateCanary({ today: 0, rolling: 10 });
+      expect(decision.fire).toBe(true);
+    });
+
+    it("fires at a high-volume bank dropping from 20/day to 5", () => {
+      const decision = evaluateCanary({ today: 5, rolling: 20 });
+      expect(decision.fire).toBe(true);
+    });
+  });
+
+  describe("suppresses the canary on quiet baselines", () => {
+    it("does NOT fire when rolling average is below the floor (5)", () => {
+      // Even a 100% drop should not fire if the baseline is too quiet:
+      // a bank that posts 2/day on average can legitimately post 0 today.
+      const decision = evaluateCanary({ today: 0, rolling: 2 });
+      expect(decision.fire).toBe(false);
+      expect(decision.reason).toBe("skip_rolling_avg_below_floor");
+    });
+
+    it("does NOT fire when rolling average sits exactly at the floor", () => {
+      // The floor uses strict `>`, so 5 is treated as "still too quiet".
+      // This keeps the canary silent on borderline-low-volume companies.
+      const decision = evaluateCanary({
+        today: 0,
+        rolling: CANARY_MIN_ROLLING_AVG,
+      });
+      expect(decision.fire).toBe(false);
+      expect(decision.reason).toBe("skip_rolling_avg_below_floor");
+    });
+
+    it("does NOT fire when both today and rolling are zero (silent week)", () => {
+      const decision = evaluateCanary({ today: 0, rolling: 0 });
+      expect(decision.fire).toBe(false);
+      expect(decision.reason).toBe("skip_rolling_avg_below_floor");
+    });
+  });
+
+  describe("suppresses the canary on healthy drops", () => {
+    it("does NOT fire when today is above 50% of the rolling avg (e.g. 30% drop)", () => {
+      // 7-day avg = 10, today = 7 → only a 30% drop. Normal day-to-day
+      // variation, not a scraper break.
+      const decision = evaluateCanary({ today: 7, rolling: 10 });
+      expect(decision.fire).toBe(false);
+      expect(decision.reason).toBe("skip_today_not_below_threshold");
+    });
+
+    it("does NOT fire when today equals the rolling average", () => {
+      const decision = evaluateCanary({ today: 10, rolling: 10 });
+      expect(decision.fire).toBe(false);
+    });
+
+    it("does NOT fire when today is exactly 50% of rolling (boundary, strict <)", () => {
+      // Threshold is strict `<`, so the boundary case stays silent — a
+      // bank that drops exactly to half its baseline is borderline, not
+      // alertable.
+      const decision = evaluateCanary({ today: 5, rolling: 10 });
+      expect(decision.fire).toBe(false);
+      expect(decision.reason).toBe("skip_today_not_below_threshold");
+    });
+
+    it("does NOT fire when today exceeds the rolling average (busy day)", () => {
+      const decision = evaluateCanary({ today: 25, rolling: 10 });
+      expect(decision.fire).toBe(false);
+    });
+  });
+
+  describe("constants reflect documented thresholds", () => {
+    it("drop ratio is 50% — anything less than that of baseline trips the alarm", () => {
+      expect(CANARY_DROP_RATIO).toBe(0.5);
+    });
+
+    it("rolling-average floor is 5 — banks below this don't fire", () => {
+      expect(CANARY_MIN_ROLLING_AVG).toBe(5);
+    });
+  });
+});

--- a/web/lib/email/scraper-health.ts
+++ b/web/lib/email/scraper-health.ts
@@ -1,8 +1,63 @@
 import { Resend } from "resend";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { getResendError } from "@/lib/email/resend-result";
-import { ScraperAlertEmail, type ScraperIssue } from "./templates/scraper-alert";
+import {
+  ScraperAlertEmail,
+  type ScraperIssue,
+  type ScraperCanary,
+} from "./templates/scraper-alert";
 import { log } from "@/lib/log";
+
+/**
+ * Fragility canary thresholds (Luke #10 — silent partial drops are scarier
+ * than outages).
+ *
+ * `DROP_RATIO`: today's new postings must be below this fraction of the
+ *   7-day rolling average to fire (50% drop).
+ * `MIN_ROLLING_AVG`: rolling average must exceed this floor or we suppress
+ *   the alert. Banks legitimately post 1-2 jobs on a quiet day; we only
+ *   want to page on companies with meaningful baseline volume.
+ */
+export const CANARY_DROP_RATIO = 0.5;
+export const CANARY_MIN_ROLLING_AVG = 5;
+
+export interface CanaryInput {
+  today: number;
+  rolling: number;
+}
+
+export type CanaryReason =
+  | "fire_partial_corpus_drop"
+  | "skip_rolling_avg_below_floor"
+  | "skip_today_not_below_threshold";
+
+export interface CanaryDecision {
+  fire: boolean;
+  reason: CanaryReason;
+}
+
+/**
+ * Pure threshold check for the partial-corpus-drop canary.
+ *
+ * Fires when BOTH:
+ *  - `today < DROP_RATIO * rolling` (>=50% day-over-day drop), AND
+ *  - `rolling > MIN_ROLLING_AVG` (filter out quiet weeks).
+ *
+ * The strict `>` on the floor means a `rolling === MIN_ROLLING_AVG` boundary
+ * is treated as "too quiet to alert on." This intentionally keeps the
+ * canary silent on borderline-low-volume companies.
+ *
+ * No side effects, no DB access — call from anywhere safely.
+ */
+export function evaluateCanary({ today, rolling }: CanaryInput): CanaryDecision {
+  if (!(rolling > CANARY_MIN_ROLLING_AVG)) {
+    return { fire: false, reason: "skip_rolling_avg_below_floor" };
+  }
+  if (!(today < CANARY_DROP_RATIO * rolling)) {
+    return { fire: false, reason: "skip_today_not_below_threshold" };
+  }
+  return { fire: true, reason: "fire_partial_corpus_drop" };
+}
 
 /**
  * After a collection job run, detect companies with scraper issues and notify
@@ -96,14 +151,27 @@ export async function checkAndAlertScraperHealth(
       }
     }
 
-    if (issues.length === 0) {
+    // Independent fragility check: partial-corpus drop for incumbent
+    // (big-bank) scrapers. A scraper that returns SOME but not all jobs
+    // can silently rot the dataset for days; the canary fires when today's
+    // new-postings count is well below the 7-day baseline.
+    const canaries = await detectIncumbentCanaries(supabase);
+
+    if (issues.length === 0 && canaries.length === 0) {
       log.info("Scraper health check passed — no issues detected.");
       return;
     }
 
-    log.warn(
-      `Scraper health alert: ${issues.length} issue(s) detected for [${issues.map((i) => i.companyName).join(", ")}]`
-    );
+    if (issues.length > 0) {
+      log.warn(
+        `Scraper health alert: ${issues.length} issue(s) detected for [${issues.map((i) => i.companyName).join(", ")}]`
+      );
+    }
+    if (canaries.length > 0) {
+      log.warn(
+        `Scraper-break canary: ${canaries.length} incumbent scraper(s) showing partial-corpus drop for [${canaries.map((c) => c.companyName).join(", ")}]`
+      );
+    }
 
     // Fetch admin emails
     const { data: admins } = await supabase
@@ -127,16 +195,26 @@ export async function checkAndAlertScraperHealth(
       process.env.NEXT_PUBLIC_APP_URL ||
       "https://fintech-talent-brief.vercel.app";
 
-    const subject =
-      issues.length === 1
-        ? `⚠️ Scraper alert: ${issues[0].companyName}`
-        : `⚠️ Scraper alert: ${issues.length} companies need attention`;
+    const issueCount = issues.length;
+    const canaryCount = canaries.length;
+    const totalCount = issueCount + canaryCount;
+    const subject = (() => {
+      if (issueCount === 0 && canaryCount > 0) {
+        return canaryCount === 1
+          ? `⚠️ Scraper-break canary: ${canaries[0].companyName}`
+          : `⚠️ Scraper-break canary: ${canaryCount} incumbent scrapers`;
+      }
+      if (issueCount === 1 && canaryCount === 0) {
+        return `⚠️ Scraper alert: ${issues[0].companyName}`;
+      }
+      return `⚠️ Scraper alert: ${totalCount} ${totalCount === 1 ? "issue" : "issues"} need attention`;
+    })();
 
     const emails = adminEmails.map((email) => ({
       from,
       to: email,
       subject,
-      react: ScraperAlertEmail({ issues, jobRunId, appUrl }),
+      react: ScraperAlertEmail({ issues, canaries, jobRunId, appUrl }),
     }));
 
     const result = await resend.batch.send(emails);
@@ -150,5 +228,109 @@ export async function checkAndAlertScraperHealth(
     );
   } catch (err) {
     log.error({ err: err }, "Failed to send scraper health alert:");
+  }
+}
+
+/**
+ * Detect incumbent scrapers showing a partial-corpus drop today.
+ *
+ * For each `tier='incumbent' AND is_active=true` company, computes:
+ *   - todayNewJobs: postings with `first_seen_date >= start-of-today (UTC)`.
+ *   - rollingAvg7d: avg new-postings per day for the 7 days BEFORE today.
+ *
+ * Fires the canary when `evaluateCanary` returns true. Read-only; safe to
+ * call on every collect run. Errors are swallowed and logged — a failed
+ * canary check must never block the existing scraper-health email.
+ */
+type SupabaseAdminClient = ReturnType<typeof createAdminClient>;
+
+export async function detectIncumbentCanaries(
+  supabase: SupabaseAdminClient
+): Promise<ScraperCanary[]> {
+  try {
+    const { data: companies, error: companiesError } = await supabase
+      .from("companies")
+      .select("id, name, slug")
+      .eq("tier", "incumbent")
+      .eq("is_active", true);
+
+    if (companiesError) {
+      log.error(
+        { err: companiesError.message },
+        "Canary: failed to fetch incumbent companies"
+      );
+      return [];
+    }
+
+    if (!companies || companies.length === 0) return [];
+
+    // UTC day boundaries. "Today" = postings with first_seen_date in the
+    // 24h window starting at 00:00 UTC of the current calendar day.
+    // "Rolling" = the 7 calendar days before that (UTC).
+    const now = new Date();
+    const todayStart = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+    );
+    const rollingStart = new Date(
+      todayStart.getTime() - 7 * 24 * 60 * 60 * 1000
+    );
+    const todayStartIso = todayStart.toISOString();
+    const rollingStartIso = rollingStart.toISOString();
+
+    const companyIds = companies.map((c) => c.id);
+
+    // One round-trip for the last 8 days' worth of incumbent postings.
+    // ~7,500 incumbent rows in steady state across 5 banks — this is cheap.
+    const { data: rows, error: rowsError } = await supabase
+      .from("job_postings")
+      .select("company_id, first_seen_date")
+      .in("company_id", companyIds)
+      .gte("first_seen_date", rollingStartIso)
+      .not("first_seen_date", "is", null);
+
+    if (rowsError) {
+      log.error(
+        { err: rowsError.message },
+        "Canary: failed to fetch recent postings"
+      );
+      return [];
+    }
+
+    const todayByCompany = new Map<string, number>();
+    const rollingByCompany = new Map<string, number>();
+    for (const row of rows ?? []) {
+      if (!row.first_seen_date) continue;
+      if (row.first_seen_date >= todayStartIso) {
+        todayByCompany.set(
+          row.company_id,
+          (todayByCompany.get(row.company_id) ?? 0) + 1
+        );
+      } else {
+        rollingByCompany.set(
+          row.company_id,
+          (rollingByCompany.get(row.company_id) ?? 0) + 1
+        );
+      }
+    }
+
+    const canaries: ScraperCanary[] = [];
+    for (const company of companies) {
+      const today = todayByCompany.get(company.id) ?? 0;
+      const rolling = (rollingByCompany.get(company.id) ?? 0) / 7;
+      const decision = evaluateCanary({ today, rolling });
+      if (!decision.fire) continue;
+      canaries.push({
+        companyName: company.name,
+        companySlug: company.slug,
+        todayNewJobs: today,
+        rollingAvg7d: Number(rolling.toFixed(2)),
+        explanation: `Today's new postings (${today}) are below 50% of the 7-day rolling average (${rolling.toFixed(1)}/day). Likely a partial-corpus scrape — verify the scraper isn't dropping pagination, location filters, or a section of the careers site.`,
+      });
+    }
+
+    return canaries;
+  } catch (err) {
+    log.error({ err }, "Canary detection failed");
+    return [];
   }
 }

--- a/web/lib/email/templates/scraper-alert.tsx
+++ b/web/lib/email/templates/scraper-alert.tsx
@@ -21,8 +21,23 @@ export interface ScraperIssue {
   closedThisRun: number;
 }
 
+/**
+ * Fragility canary — fired when an incumbent scraper shows a >50% drop in
+ * new postings versus its 7-day rolling average. Distinct from `issues`
+ * because the scraper itself did not error: it just returned less than
+ * expected. See `lib/email/scraper-health.ts#detectIncumbentCanaries`.
+ */
+export interface ScraperCanary {
+  companyName: string;
+  companySlug: string;
+  todayNewJobs: number;
+  rollingAvg7d: number;
+  explanation: string;
+}
+
 interface ScraperAlertEmailProps {
   issues: ScraperIssue[];
+  canaries?: ScraperCanary[];
   jobRunId: string;
   appUrl?: string;
 }
@@ -34,14 +49,23 @@ const ISSUE_LABELS: Record<ScraperIssue["issueType"], string> = {
 
 export function ScraperAlertEmail({
   issues,
+  canaries = [],
   jobRunId,
   appUrl = "https://fintech-talent-brief.vercel.app",
 }: ScraperAlertEmailProps) {
   const adminUrl = `${appUrl}/admin`;
-  const subject =
-    issues.length === 1
-      ? `Scraper alert: ${issues[0].companyName} — ${ISSUE_LABELS[issues[0].issueType]}`
-      : `Scraper alert: ${issues.length} companies need attention`;
+  const totalCount = issues.length + canaries.length;
+  const subject = (() => {
+    if (issues.length === 0 && canaries.length > 0) {
+      return canaries.length === 1
+        ? `Scraper-break canary: ${canaries[0].companyName}`
+        : `Scraper-break canary: ${canaries.length} incumbent scrapers`;
+    }
+    if (issues.length === 1 && canaries.length === 0) {
+      return `Scraper alert: ${issues[0].companyName} — ${ISSUE_LABELS[issues[0].issueType]}`;
+    }
+    return `Scraper alert: ${totalCount} ${totalCount === 1 ? "issue" : "issues"} need attention`;
+  })();
 
   return (
     <Html>
@@ -57,41 +81,72 @@ export function ScraperAlertEmail({
           <Hr style={divider} />
 
           <Section style={content}>
-            <Text style={body}>
-              {issues.length === 1
-                ? "1 company had a collection issue in the latest run."
-                : `${issues.length} companies had collection issues in the latest run.`}{" "}
-              Review and fix to ensure data stays accurate.
-            </Text>
-
-            {issues.map((issue) => (
-              <Section key={issue.companySlug} style={issueCard}>
-                <Text style={companyName}>{issue.companyName}</Text>
-                <Text
-                  style={
-                    issue.issueType === "failed" ? tagError : tagWarning
-                  }
-                >
-                  {ISSUE_LABELS[issue.issueType]}
+            {issues.length > 0 && (
+              <>
+                <Text style={body}>
+                  {issues.length === 1
+                    ? "1 company had a collection issue in the latest run."
+                    : `${issues.length} companies had collection issues in the latest run.`}{" "}
+                  Review and fix to ensure data stays accurate.
                 </Text>
-                {issue.issueType === "empty" && (
-                  <Text style={detail}>
-                    Scraper returned 0 jobs —{" "}
-                    <strong>{issue.closedThisRun} role(s)</strong> were closed
-                    as a result. Active count is now{" "}
-                    <strong>0</strong>.
-                  </Text>
-                )}
-                {issue.issueType === "failed" && issue.errorMessage && (
-                  <Text style={errorText}>{issue.errorMessage}</Text>
-                )}
-                {issue.issueType === "failed" && (
-                  <Text style={detail}>
-                    Active job count: <strong>{issue.activeJobCount}</strong>
-                  </Text>
-                )}
-              </Section>
-            ))}
+
+                {issues.map((issue) => (
+                  <Section key={issue.companySlug} style={issueCard}>
+                    <Text style={companyName}>{issue.companyName}</Text>
+                    <Text
+                      style={
+                        issue.issueType === "failed" ? tagError : tagWarning
+                      }
+                    >
+                      {ISSUE_LABELS[issue.issueType]}
+                    </Text>
+                    {issue.issueType === "empty" && (
+                      <Text style={detail}>
+                        Scraper returned 0 jobs —{" "}
+                        <strong>{issue.closedThisRun} role(s)</strong> were
+                        closed as a result. Active count is now{" "}
+                        <strong>0</strong>.
+                      </Text>
+                    )}
+                    {issue.issueType === "failed" && issue.errorMessage && (
+                      <Text style={errorText}>{issue.errorMessage}</Text>
+                    )}
+                    {issue.issueType === "failed" && (
+                      <Text style={detail}>
+                        Active job count:{" "}
+                        <strong>{issue.activeJobCount}</strong>
+                      </Text>
+                    )}
+                  </Section>
+                ))}
+              </>
+            )}
+
+            {canaries.length > 0 && (
+              <>
+                <Text style={canaryHeading}>Scraper-break canary</Text>
+                <Text style={body}>
+                  {canaries.length === 1
+                    ? "1 incumbent scraper is showing a partial-corpus drop today."
+                    : `${canaries.length} incumbent scrapers are showing partial-corpus drops today.`}{" "}
+                  Silent partial drops are scarier than outages — confirm
+                  pagination, location filters, and site sections still
+                  resolve.
+                </Text>
+
+                {canaries.map((canary) => (
+                  <Section key={canary.companySlug} style={canaryCard}>
+                    <Text style={companyName}>{canary.companyName}</Text>
+                    <Text style={tagCanary}>Partial corpus drop</Text>
+                    <Text style={detail}>
+                      Today: <strong>{canary.todayNewJobs}</strong> new — 7-day
+                      avg: <strong>{canary.rollingAvg7d.toFixed(1)}/day</strong>
+                    </Text>
+                    <Text style={detail}>{canary.explanation}</Text>
+                  </Section>
+                ))}
+              </>
+            )}
 
             <Text style={metaText}>Job run ID: {jobRunId}</Text>
           </Section>
@@ -196,6 +251,28 @@ const tagWarning: React.CSSProperties = {
   ...tagError,
   backgroundColor: EMAIL_COLORS.accentSoft,
   color: EMAIL_COLORS.accentSoftFg,
+};
+
+const tagCanary: React.CSSProperties = {
+  ...tagError,
+  backgroundColor: EMAIL_COLORS.highlightSoft,
+  color: EMAIL_COLORS.highlightSoftFg,
+};
+
+const canaryHeading: React.CSSProperties = {
+  color: EMAIL_COLORS.fg,
+  fontSize: "15px",
+  fontWeight: "700",
+  margin: "24px 0 8px",
+  letterSpacing: "0.2px",
+};
+
+const canaryCard: React.CSSProperties = {
+  backgroundColor: EMAIL_COLORS.surfaceMuted,
+  borderLeft: `3px solid ${EMAIL_COLORS.highlight}`,
+  padding: "12px 16px",
+  marginBottom: "12px",
+  borderRadius: "0 6px 6px 0",
 };
 
 const detail: React.CSSProperties = {

--- a/web/lib/scrapers/CLAUDE.md
+++ b/web/lib/scrapers/CLAUDE.md
@@ -19,7 +19,18 @@ These need Puppeteer because the ATS doesn't expose a clean JSON feed. They are 
 
 - **`dayforce.ts`** — Dayforce boards.
 - **`scotiabank.ts`** — Scotiabank custom careers site.
+- **`phenom-rbc.ts`** — RBC's Phenom CareerConnect tenant (`jobs.rbc.com`). Reads server-rendered `phApp.eagerLoadRefineSearch` + JSON-LD `JobPosting` per detail page. Chunked enrichment (50/batch, concurrency=4).
+- **`phenom-bmo.ts`** — BMO's Phenom tenant (`jobs.bmo.com`). Same shape as phenom-rbc.
+- **`phenom-bnc.ts`** — National Bank's Phenom tenant (white-labelled `emplois.bnc.ca`). Same shape.
 - **`browser.ts`** — Generic Puppeteer helpers (`scrapeJobsWithBrowser`, `scrapeGenericJobBoard`, `scrapeSuccessFactors`).
+
+## Offloaded API scrapers — Workday tenants
+
+Workday exposes a documented JSON POST endpoint (`/wday/cxs/<tenant>/<site>/jobs`) so these are HTTP fetch-based, not Puppeteer. They are nonetheless **offloaded to GitHub Actions** (see `isBrowserScraper` in `index.ts`) because a cold ~1,500-job scrape with per-job description GETs exceeds Vercel's 300s function budget. `AbortSignal.timeout(15_000)` on every fetch; non-2xx throws (no in-code retry — the daily cron is the retry).
+
+- **`workday-utils.ts`** — pure shared helpers: `buildWorkdayUrls`, `parseWorkdayListingRow`, `parseWorkdayJobDetail`, `resolveWorkdayJobCap`. Used by every tenant-specific Workday scraper. Intentionally NOT a base class — fork-per-tenant.
+- **`workday-td.ts`** — TD Bank (`td.wd3.myworkdayjobs.com/en-US/TD_Bank_Careers`).
+- **`workday-cibc.ts`** — CIBC (`cibc.wd3.myworkdayjobs.com/search`). Also exports `isSimpliiPosting` — a Simplii-Financial classifier currently running in **log-only mode**. The companies row for Simplii and the `companySlugOverride` routing land in a follow-up after production logs confirm Simplii postings actually surface in CIBC's Workday.
 
 ### `browser.ts` is 1131 LOC — leave it alone pre-launch
 

--- a/web/lib/scrapers/__fixtures__/phenom-bmo-listing.json
+++ b/web/lib/scrapers/__fixtures__/phenom-bmo-listing.json
@@ -1,0 +1,92 @@
+{
+  "totalHits": 1247,
+  "hits": 3,
+  "data": {
+    "jobs": [
+      {
+        "subCategory": "Data Science & Machine Learning",
+        "ml_skills": [
+          "machine learning",
+          "python",
+          "deep learning",
+          "model risk",
+          "credit risk modeling",
+          "statistical analysis",
+          "pytorch",
+          "sql",
+          "regulatory model validation"
+        ],
+        "type": "Full time",
+        "descriptionTeaser": "Join BMO's AI & Data team as a Senior Machine Learning Engineer driving credit-risk modeling across our retail and commercial portfolios. Partner with model-risk management to ship production-grade Python/PyTorch systems while navigating OSFI and SR 11-7 compliance.",
+        "state": "Ontario",
+        "multi_category": [
+          "Technology | Data | Analytics"
+        ],
+        "reqId": "R-2400512",
+        "city": "Toronto",
+        "multi_location": [
+          "Toronto, Ontario, Canada"
+        ],
+        "applyUrl": "https://bmo.wd3.myworkdayjobs.com/External/job/Toronto-Ontario-Canada/Senior-Machine-Learning-Engineer_R-2400512/apply",
+        "country": "Canada",
+        "jobId": "R-2400512",
+        "title": "Senior Machine Learning Engineer",
+        "postedDate": "2026-03-04T00:00:00.000+0000",
+        "category": "Technology | Data | Analytics"
+      },
+      {
+        "subCategory": "Capital Markets & Investment Banking",
+        "ml_skills": [
+          "equity research",
+          "financial modeling",
+          "valuation",
+          "client coverage",
+          "presentation skills"
+        ],
+        "type": "Full time",
+        "descriptionTeaser": "BMO Capital Markets is hiring a Vice President, Equity Research covering North American banks. Build differentiated coverage models, drive thought leadership, and partner with sales & trading on actionable client narratives.",
+        "state": "New York",
+        "multi_category": [
+          "Capital Markets | Investment Banking | Wealth"
+        ],
+        "reqId": "R-2400771",
+        "city": "New York",
+        "multi_location": [
+          "New York, New York, United States of America"
+        ],
+        "applyUrl": "https://bmo.wd3.myworkdayjobs.com/External/job/New-York-United-States/Vice-President-Equity-Research_R-2400771/apply",
+        "country": "United States of America",
+        "jobId": "R-2400771",
+        "title": "Vice President, Equity Research",
+        "postedDate": "2026-01-22T00:00:00.000+0000",
+        "category": "Capital Markets | Investment Banking | Wealth"
+      },
+      {
+        "subCategory": "Branch Banking",
+        "ml_skills": [
+          "customer service",
+          "cash handling",
+          "retail banking",
+          "sales targets"
+        ],
+        "type": "Part time",
+        "descriptionTeaser": "We are looking for a Customer Service Representative to join our team in Calgary. Deliver exceptional in-branch service, identify customer needs, and connect clients to the right BMO products. Bilingual French/English an asset.",
+        "state": "Alberta",
+        "multi_category": [
+          "Personal & Commercial Banking"
+        ],
+        "reqId": "R-2400988",
+        "city": "CALGARY",
+        "multi_location": [
+          "CALGARY, Alberta, Canada"
+        ],
+        "applyUrl": "https://bmo.wd3.myworkdayjobs.com/External/job/Calgary-Alberta-Canada/Customer-Service-Representative_R-2400988/apply",
+        "country": "Canada",
+        "jobId": "R-2400988",
+        "title": "Customer Service Representative",
+        "postedDate": "2026-04-18T00:00:00.000+0000",
+        "category": "Personal & Commercial Banking"
+      }
+    ]
+  }
+}

--- a/web/lib/scrapers/__fixtures__/phenom-bnc-listing.json
+++ b/web/lib/scrapers/__fixtures__/phenom-bnc-listing.json
@@ -1,0 +1,93 @@
+{
+  "totalHits": 612,
+  "hits": 3,
+  "data": {
+    "jobs": [
+      {
+        "subCategory": "Cloud Platform Engineering",
+        "ml_skills": [
+          "aws",
+          "kubernetes",
+          "terraform",
+          "platform engineering",
+          "ci cd",
+          "python",
+          "go"
+        ],
+        "type": "Full time",
+        "descriptionTeaser": "Joignez-vous à l'équipe Plateforme Infonuagique de la Banque Nationale et contribuez au déploiement de notre plateforme AWS multi-comptes. Vous travaillerez sur Kubernetes, Terraform et l'automatisation CI/CD au cœur de la transformation numérique de la Banque.",
+        "state": "Quebec",
+        "multi_category": [
+          "Technology | Data | Cyber"
+        ],
+        "reqId": "JR-23541",
+        "city": "Montréal",
+        "multi_location": [
+          "Montréal, Quebec, Canada"
+        ],
+        "applyUrl": "https://bnc.wd3.myworkdayjobs.com/External/job/Montreal-Quebec-Canada/Principal-Cloud-Engineer_JR-23541/apply",
+        "country": "Canada",
+        "jobId": "JR-23541",
+        "title": "Principal Cloud Engineer",
+        "postedDate": "2026-02-28T00:00:00.000+0000",
+        "category": "Technology | Data | Cyber",
+        "remote": true
+      },
+      {
+        "subCategory": "Wealth Management Advisory",
+        "ml_skills": [
+          "wealth management",
+          "client relationship management",
+          "financial planning",
+          "bilingual french english",
+          "investment products"
+        ],
+        "type": "Full time",
+        "descriptionTeaser": "Banque Nationale Investissements recrute un Conseiller en gestion de patrimoine senior pour notre bureau de Québec. Accompagnez une clientèle haut de gamme dans une approche-conseil intégrée. Bilinguisme français/anglais requis.",
+        "state": "Quebec",
+        "multi_category": [
+          "Wealth Management | Private Banking"
+        ],
+        "reqId": "JR-23789",
+        "city": "Québec",
+        "multi_location": [
+          "Québec, Quebec, Canada"
+        ],
+        "applyUrl": "https://bnc.wd3.myworkdayjobs.com/External/job/Quebec-Canada/Conseiller-gestion-patrimoine-senior_JR-23789/apply",
+        "country": "Canada",
+        "jobId": "JR-23789",
+        "title": "Conseiller principal en gestion de patrimoine",
+        "postedDate": "2026-04-02T00:00:00.000+0000",
+        "category": "Wealth Management | Private Banking",
+        "hybrid": "true"
+      },
+      {
+        "subCategory": "Credit Risk Management",
+        "ml_skills": [
+          "credit risk",
+          "ifrs 9",
+          "model validation",
+          "regulatory reporting",
+          "commercial lending"
+        ],
+        "type": "Contract",
+        "descriptionTeaser": "We are hiring a Credit Risk Analyst on a 12-month contract to support our commercial book under IFRS 9. Build provisioning models, prepare regulatory submissions to OSFI, and partner with Model Risk Management.",
+        "state": "Ontario",
+        "multi_category": [
+          "Risk | Compliance | Audit"
+        ],
+        "reqId": "JR-24012",
+        "city": "Toronto",
+        "multi_location": [
+          "Toronto, Ontario, Canada"
+        ],
+        "applyUrl": "https://bnc.wd3.myworkdayjobs.com/External/job/Toronto-Ontario-Canada/Credit-Risk-Analyst_JR-24012/apply",
+        "country": "Canada",
+        "jobId": "JR-24012",
+        "title": "Credit Risk Analyst",
+        "postedDate": "2026-05-10T00:00:00.000+0000",
+        "category": "Risk | Compliance | Audit"
+      }
+    ]
+  }
+}

--- a/web/lib/scrapers/__fixtures__/workday-cibc-detail.json
+++ b/web/lib/scrapers/__fixtures__/workday-cibc-detail.json
@@ -1,0 +1,12 @@
+{
+  "jobPostingInfo": {
+    "title": "Manager, Capital Markets Technology",
+    "jobDescription": "<div><p>We&#39;re building the next generation of capital markets technology at CIBC. Join a team that ships fast and obsesses over data quality.</p><h3>What you&#39;ll do</h3><ul><li>Own the roadmap for our pricing engine.</li><li>Partner with traders on latency-sensitive rollouts.</li></ul></div>",
+    "location": "Toronto, ON, Canada",
+    "country": { "descriptor": "Canada" },
+    "postedOn": "2026-05-15",
+    "jobReqId": "2521234",
+    "externalUrl": "https://cibc.wd3.myworkdayjobs.com/search/job/Toronto-ON/Manager--Capital-Markets-Technology_2521234",
+    "timeType": "Full time"
+  }
+}

--- a/web/lib/scrapers/__fixtures__/workday-cibc-listing.json
+++ b/web/lib/scrapers/__fixtures__/workday-cibc-listing.json
@@ -1,0 +1,34 @@
+{
+  "total": 4,
+  "jobPostings": [
+    {
+      "title": "Manager, Capital Markets Technology",
+      "externalPath": "/job/Toronto-ON/Manager--Capital-Markets-Technology_2521234",
+      "locationsText": "Toronto, ON",
+      "postedOn": "2026-05-15",
+      "bulletFields": ["2521234", "CIBC", "Regular"]
+    },
+    {
+      "title": "Banking Advisor, Simplii Financial",
+      "externalPath": "/job/Mississauga-ON/Banking-Advisor--Simplii-Financial_2521456",
+      "locationsText": "Mississauga, ON",
+      "postedOn": "2026-05-14",
+      "bulletFields": ["2521456", "Simplii Financial", "Full time"]
+    },
+    {
+      "title": "Senior Data Engineer",
+      "externalPath": "/job/Toronto-ON/Senior-Data-Engineer_2521789",
+      "locationsText": "Toronto, ON",
+      "postedOn": "2026-05-10",
+      "bulletFields": ["2521789", "CIBC", "Full time"],
+      "businessUnit": "Simplii Financial Direct Bank"
+    },
+    {
+      "title": "Simply Excellent Service Representative",
+      "externalPath": "/job/Vancouver-BC/Simply-Excellent-Service-Representative_2522000",
+      "locationsText": "Vancouver, BC",
+      "postedOn": "2026-05-09",
+      "bulletFields": ["2522000", "CIBC", "Part time"]
+    }
+  ]
+}

--- a/web/lib/scrapers/__fixtures__/workday-td-detail.json
+++ b/web/lib/scrapers/__fixtures__/workday-td-detail.json
@@ -1,0 +1,12 @@
+{
+  "jobPostingInfo": {
+    "title": "Senior Software Engineer",
+    "jobDescription": "<div><h2>About this opportunity</h2><p>TD is hiring a <strong>Senior Software Engineer</strong> to join our Cloud Platform team in Toronto. You will design, build, and operate microservices that power core banking experiences.</p><h3>Responsibilities</h3><ul><li>Lead the design of scalable backend systems.</li><li>Mentor mid-level engineers.</li></ul></div>",
+    "location": "Toronto, Ontario, Canada",
+    "country": { "descriptor": "Canada" },
+    "postedOn": "2026-05-12",
+    "jobReqId": "R-0000123456",
+    "externalUrl": "https://td.wd3.myworkdayjobs.com/TD_Bank_Careers/job/Toronto-Ontario/Senior-Software-Engineer_R-0000123456",
+    "timeType": "Full time"
+  }
+}

--- a/web/lib/scrapers/__fixtures__/workday-td-listing.json
+++ b/web/lib/scrapers/__fixtures__/workday-td-listing.json
@@ -1,0 +1,26 @@
+{
+  "total": 3,
+  "jobPostings": [
+    {
+      "title": "Senior Software Engineer",
+      "externalPath": "/job/Toronto-Ontario/Senior-Software-Engineer_R-0000123456",
+      "locationsText": "Toronto, Ontario, Canada",
+      "postedOn": "2026-05-12",
+      "bulletFields": ["R-0000123456", "Regular"]
+    },
+    {
+      "title": "Data Analytics Intern",
+      "externalPath": "/job/Montreal-Quebec/Data-Analytics-Intern_R-0000123789",
+      "locationsText": "Montreal, Quebec, Canada",
+      "postedOn": "Posted Yesterday",
+      "bulletFields": ["R-0000123789", "Internship"]
+    },
+    {
+      "title": "Director, Risk Management",
+      "externalPath": "/job/New-York/Director--Risk-Management_R-0000124001",
+      "locationsText": "New York, New York, United States of America",
+      "postedOn": "2026-05-08T00:00:00.000Z",
+      "bulletFields": ["R-0000124001", "Full time"]
+    }
+  ]
+}

--- a/web/lib/scrapers/detect-ats.ts
+++ b/web/lib/scrapers/detect-ats.ts
@@ -79,7 +79,21 @@ const ATS_PATTERNS: ATSPattern[] = [
       return parts[0] || null;
     },
   },
-  // Workday: {company}.wd{number}.myworkdayjobs.com or {company}.myworkdayjobs.com
+  // Workday tenants with dedicated scrapers (must precede the generic
+  // Workday entry below so they win the iteration).
+  {
+    type: "workday-td",
+    patterns: [/^td\.wd\d+\.myworkdayjobs\.com$/i],
+    extractIdentifier: () => "td",
+  },
+  {
+    type: "workday-cibc",
+    patterns: [/^cibc\.wd\d+\.myworkdayjobs\.com$/i],
+    extractIdentifier: () => "cibc",
+  },
+  // Workday (generic fallback): {company}.wd{number}.myworkdayjobs.com or
+  // {company}.myworkdayjobs.com — for any tenant we don't have a dedicated
+  // scraper for yet. Routed to scrapeGenericJobBoard.
   {
     type: "workday",
     patterns: [
@@ -153,18 +167,22 @@ const ATS_PATTERNS: ATSPattern[] = [
     },
   },
   // Phenom CareerConnect: vendor-hosted but white-labelled to each tenant's
-  // own domain (jobs.rbc.com, jobs.bmo.com, etc.), so detection works off a
-  // known-tenant allowlist rather than a vendor subdomain. The identifier
-  // is just the hostname's leading bank slug — used for telemetry/display,
-  // not for URL construction (the scraper uses `careersUrl` directly).
+  // own domain (jobs.rbc.com, jobs.bmo.com, emplois.bnc.ca, etc.), so
+  // detection works off a known-tenant allowlist rather than a vendor
+  // subdomain. The identifier is the canonical bank slug — used to dispatch
+  // to the right tenant-specific scraper in `fetchJobs`.
   {
     type: "phenom",
     patterns: [
       /^jobs\.rbc\.com$/i,
       /^jobs\.bmo\.com$/i,
+      /^emplois\.bnc\.ca$/i,
+      /^jobs\.nbc\.ca$/i, // National Bank also serves jobs.nbc.ca → 301 to emplois.bnc.ca
     ],
     extractIdentifier: (url: URL) => {
       const host = url.hostname.toLowerCase();
+      if (/^emplois\.bnc\.ca$/i.test(host)) return "bnc";
+      if (/^jobs\.nbc\.ca$/i.test(host)) return "bnc";
       const match = host.match(/^jobs\.([a-z0-9-]+)\.com$/i);
       return match ? match[1] : null;
     },
@@ -227,7 +245,9 @@ export const SUPPORTED_ATS = [
   { value: "ashby", label: "Ashby", implemented: true },
   { value: "dayforce", label: "Dayforce", implemented: true },
   { value: "phenom", label: "Phenom CareerConnect", implemented: true },
-  { value: "workday", label: "Workday", implemented: false },
+  { value: "workday-td", label: "Workday (TD Bank)", implemented: true },
+  { value: "workday-cibc", label: "Workday (CIBC)", implemented: true },
+  { value: "workday", label: "Workday (generic)", implemented: false },
   { value: "smartrecruiters", label: "SmartRecruiters", implemented: false },
   { value: "bamboohr", label: "BambooHR", implemented: false },
   { value: "jazzhr", label: "JazzHR", implemented: false },

--- a/web/lib/scrapers/index.ts
+++ b/web/lib/scrapers/index.ts
@@ -7,6 +7,10 @@ import { fetchAshbyJobs } from "./ashby";
 import { fetchDayforceJobs } from "./dayforce";
 import { fetchScotiabankJobs } from "./scotiabank";
 import { fetchPhenomRbcJobs } from "./phenom-rbc";
+import { fetchPhenomBmoJobs } from "./phenom-bmo";
+import { fetchPhenomBncJobs } from "./phenom-bnc";
+import { fetchWorkdayTdJobs } from "./workday-td";
+import { fetchWorkdayCibcJobs } from "./workday-cibc";
 
 export type { JobData } from "./types";
 export { jobToRow } from "./types";
@@ -42,19 +46,33 @@ export async function fetchJobs(
 
     case "phenom": {
       // Phenom CareerConnect is white-labelled to each bank's own domain
-      // (jobs.rbc.com, jobs.bmo.com, etc.). Dispatch by tenant since the
-      // listing-page URL and per-tenant quirks differ. The pure-logic
-      // pieces (eagerLoadRefineSearch parsing, JSON-LD enrichment) are
-      // exported from phenom-rbc.ts and can be reused by future
-      // phenom-bmo.ts etc. — extract a shared helper once 2+ tenants ship.
+      // (jobs.rbc.com, jobs.bmo.com, emplois.bnc.ca, etc.). Dispatch by
+      // tenant since each tenant's listing URL and per-site quirks differ.
+      // The pure-logic pieces (eagerLoadRefineSearch parsing, JSON-LD
+      // enrichment, decodeHtmlEntities in ./utils) are shared across the
+      // tenant scrapers; no Workday-style base class — pattern is
+      // fork-per-tenant.
       const tenant = atsIdentifier.toLowerCase();
-      if (tenant === "rbc") {
-        return fetchPhenomRbcJobs(atsIdentifier, browser);
-      }
+      if (tenant === "rbc") return fetchPhenomRbcJobs(atsIdentifier, browser);
+      if (tenant === "bmo") return fetchPhenomBmoJobs(atsIdentifier, browser);
+      if (tenant === "bnc") return fetchPhenomBncJobs(atsIdentifier, browser);
       throw new Error(
         `No Phenom scraper for tenant '${atsIdentifier}'. Add a tenant-specific scraper modeled on phenom-rbc.ts.`
       );
     }
+
+    // Workday tenants with dedicated scrapers. Each is a distinct ats_type
+    // (workday-td, workday-cibc) rather than a single "workday" with tenant
+    // dispatch — keeps the existing generic `case "workday"` fallback below
+    // available for any new Workday tenant we don't yet have a tenant-
+    // specific scraper for. Both these are API-based (HTTP fetch) but are
+    // still routed through scrape-heavy.yml (offloaded — see
+    // isBrowserScraper) because a cold ~1,500-job scrape with description
+    // enrichment exceeds the 300s Vercel function budget.
+    case "workday-td":
+      return fetchWorkdayTdJobs();
+    case "workday-cibc":
+      return fetchWorkdayCibcJobs();
 
     case "successfactors": {
       if (!careersUrl) {
@@ -114,6 +132,8 @@ export function isBrowserScraper(atsType: string): boolean {
   // These will be offloaded to GitHub Actions
   const browserScrapers = [
     'workday',
+    'workday-td',     // API-based, but still offloaded — see fetchJobs comment.
+    'workday-cibc',   // API-based, but still offloaded.
     'bamboohr',
     'smartrecruiters',
     'dayforce',

--- a/web/lib/scrapers/phenom-bmo.test.ts
+++ b/web/lib/scrapers/phenom-bmo.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for the pure-logic pieces of the Phenom-BMO scraper.
+ *
+ * The Puppeteer driver (pagination loop, description enrichment with
+ * concurrency=4) requires a real browser. The tests here cover the parts
+ * that don't need a browser: HTML payload extraction, the Phenom-row →
+ * JobData mapper, and the env-var cap resolver.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  decodeHtmlEntities,
+  extractEagerLoadPayload,
+  mapBmoJob,
+  resolveJobCap,
+  type PhenomRawJob,
+  type PhenomSearchPayload,
+} from "./phenom-bmo";
+
+const FIXTURE_PATH = resolve(__dirname, "__fixtures__/phenom-bmo-listing.json");
+const FIXTURE: PhenomSearchPayload = JSON.parse(
+  readFileSync(FIXTURE_PATH, "utf8")
+);
+
+describe("extractEagerLoadPayload (BMO)", () => {
+  it("returns null when the marker is missing", () => {
+    expect(extractEagerLoadPayload("<html><body>nothing here</body></html>")).toBeNull();
+  });
+
+  it("returns null when the JSON object is malformed", () => {
+    // Truncated object — brace counter walks off the end.
+    const html = `<script>var x = "eagerLoadRefineSearch":{"status":200,</script>`;
+    expect(extractEagerLoadPayload(html)).toBeNull();
+  });
+
+  it("extracts the embedded payload from a representative HTML chunk", () => {
+    const wrapped = `<!DOCTYPE html><html><body><script>
+      var phApp = phApp || {};
+      phApp.ddo = { "flashParams": {}, "eagerLoadRefineSearch": ${JSON.stringify(FIXTURE)} };
+    </script></body></html>`;
+
+    const got = extractEagerLoadPayload(wrapped);
+    expect(got).not.toBeNull();
+    expect(got!.totalHits).toBe(FIXTURE.totalHits);
+    expect(got!.data?.jobs?.length).toBe(FIXTURE.data?.jobs?.length);
+  });
+
+  it("does not confuse braces inside string literals for object boundaries", () => {
+    // A `}` inside a quoted string should NOT close the outer object.
+    const wrapped = `garbage "eagerLoadRefineSearch":{"trick":"this has a } in it","status":200,"data":{"jobs":[]}}`;
+    const got = extractEagerLoadPayload(wrapped);
+    expect(got).not.toBeNull();
+    expect(got!.data?.jobs).toEqual([]);
+  });
+});
+
+describe("decodeHtmlEntities (BMO re-export)", () => {
+  it("decodes the entity set Phenom uses in JSON-LD descriptions", () => {
+    const encoded =
+      "&lt;div&gt;Hello &amp; goodbye &quot;world&quot; with &nbsp; spaces and &#39;apostrophes&#39;&lt;/div&gt;";
+    const decoded = decodeHtmlEntities(encoded);
+    expect(decoded).toBe(
+      "<div>Hello & goodbye \"world\" with   spaces and 'apostrophes'</div>"
+    );
+  });
+});
+
+describe("mapBmoJob", () => {
+  it("maps the senior ML engineer fixture row to a complete JobData", () => {
+    const ml = FIXTURE.data!.jobs!.find((j) => j.reqId === "R-2400512");
+    expect(ml).toBeDefined();
+
+    const job = mapBmoJob(ml as PhenomRawJob);
+    expect(job.external_id).toBe("R-2400512");
+    expect(job.title).toBe("Senior Machine Learning Engineer");
+    expect(job.department).toBe("Technology | Data | Analytics");
+    expect(job.team).toBe("Data Science & Machine Learning");
+    expect(job.location).toBe("Toronto, Ontario, Canada");
+    expect(job.url).toBe(
+      "https://jobs.bmo.com/ca/en/job/R-2400512/Senior-Machine-Learning-Engineer"
+    );
+    expect(job.description_text).toMatch(/BMO's AI & Data team/);
+    expect(job.description_html).toBeNull(); // populated by enrichment, not the mapper
+    expect(job.commitment).toBe("full-time");
+    expect(job.posted_date?.toISOString()).toBe("2026-03-04T00:00:00.000Z");
+  });
+
+  it("derives team from subCategory, distinct from department", () => {
+    const vp = FIXTURE.data!.jobs!.find((j) => j.reqId === "R-2400771");
+    const job = mapBmoJob(vp as PhenomRawJob);
+    expect(job.department).toBe("Capital Markets | Investment Banking | Wealth");
+    expect(job.team).toBe("Capital Markets & Investment Banking");
+    expect(job.team).not.toBe(job.department);
+  });
+
+  it("handles missing reqId by falling back to jobUrl/applyUrl", () => {
+    const raw: PhenomRawJob = {
+      title: "Foo",
+      jobUrl: "https://jobs.bmo.com/ca/en/job/FOO-1/Foo",
+    };
+    const job = mapBmoJob(raw);
+    expect(job.external_id).toBe("");
+    expect(job.url).toBe("https://jobs.bmo.com/ca/en/job/FOO-1/Foo");
+  });
+
+  it("infers commitment from the type field when present", () => {
+    expect(mapBmoJob({ title: "X", type: "Contract" }).commitment).toBe("contract");
+    expect(mapBmoJob({ title: "X", type: "Internship" }).commitment).toBe("internship");
+    expect(mapBmoJob({ title: "X", type: "Part time" }).commitment).toBe("part-time");
+    expect(mapBmoJob({ title: "X", type: "Full time" }).commitment).toBe("full-time");
+    expect(mapBmoJob({ title: "X" }).commitment).toBe("full-time"); // default
+
+    // Part-time fixture row should land at "part-time".
+    const csr = FIXTURE.data!.jobs!.find((j) => j.reqId === "R-2400988");
+    expect(mapBmoJob(csr as PhenomRawJob).commitment).toBe("part-time");
+  });
+
+  it("respects explicit remote/hybrid flags before falling back to text heuristics", () => {
+    expect(mapBmoJob({ title: "X", remote: true }).location_type).toBe("remote");
+    expect(mapBmoJob({ title: "X", hybrid: "true" }).location_type).toBe("hybrid");
+  });
+
+  it("produces a canonical jobs.bmo.com URL even when applyUrl routes into Workday", () => {
+    // BMO's applyUrl routes into bmo.wd3.myworkdayjobs.com — we ignore it
+    // and synthesize the Phenom-facing /ca/en/job/<id>/<slug> URL.
+    const raw: PhenomRawJob = {
+      reqId: "R-X",
+      title: "Cloud MLOps & GenAI Lead",
+      applyUrl:
+        "https://bmo.wd3.myworkdayjobs.com/External/job/whatever/apply",
+    };
+    const job = mapBmoJob(raw);
+    expect(job.url).toBe(
+      "https://jobs.bmo.com/ca/en/job/R-X/Cloud-MLOps-GenAI-Lead"
+    );
+    expect(job.url).not.toContain("workday");
+  });
+
+  it("aggregates multi_location into the canonical city/state/country string", () => {
+    const csr = FIXTURE.data!.jobs!.find((j) => j.reqId === "R-2400988");
+    const job = mapBmoJob(csr as PhenomRawJob);
+    expect(job.location).toBe("CALGARY, Alberta, Canada");
+  });
+
+  it("falls back to city/state/country when multi_location is absent", () => {
+    const raw: PhenomRawJob = {
+      reqId: "R-Y",
+      title: "Test",
+      city: "Toronto",
+      state: "Ontario",
+      country: "Canada",
+    };
+    const job = mapBmoJob(raw);
+    expect(job.location).toBe("Toronto, Ontario, Canada");
+  });
+});
+
+describe("resolveJobCap (BMO)", () => {
+  it("returns null when unset — production default is the FULL corpus", () => {
+    expect(resolveJobCap(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(resolveJobCap("")).toBeNull();
+  });
+
+  it("returns null for a non-numeric value rather than throwing", () => {
+    expect(resolveJobCap("all")).toBeNull();
+    expect(resolveJobCap("50x")).toBeNull();
+  });
+
+  it("parses a positive integer cap (smoke tests / cost ceilings)", () => {
+    expect(resolveJobCap("5")).toBe(5);
+    expect(resolveJobCap("1500")).toBe(1500);
+  });
+
+  it("clamps a zero cap up to 1 — a cap of 0 would be a useless run", () => {
+    expect(resolveJobCap("0")).toBe(1);
+  });
+});
+
+describe("fixture sanity (BMO)", () => {
+  it("contains the three reference jobs the tests depend on", () => {
+    const ids = FIXTURE.data?.jobs?.map((j) => j.reqId);
+    expect(ids).toEqual(
+      expect.arrayContaining(["R-2400512", "R-2400771", "R-2400988"])
+    );
+  });
+
+  it("contains at least 3 jobs from distinct departments", () => {
+    const jobs = FIXTURE.data?.jobs ?? [];
+    expect(jobs.length).toBeGreaterThanOrEqual(3);
+    const departments = new Set(jobs.map((j) => j.multi_category?.[0]));
+    expect(departments.size).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/web/lib/scrapers/phenom-bmo.ts
+++ b/web/lib/scrapers/phenom-bmo.ts
@@ -1,0 +1,472 @@
+/**
+ * BMO (Bank of Montreal) — Phenom CareerConnect scraper.
+ *
+ * Mirrors the proven RBC scraper (`./phenom-rbc.ts`) exactly — BMO runs on
+ * the same Phenom CareerConnect platform, so the two data surfaces are
+ * identical:
+ *
+ *   1. Listing pages embed `phApp.eagerLoadRefineSearch.data.jobs[]` with
+ *      ~40 fields per posting (title, reqId, city/state/country,
+ *      multi_category → department, subCategory → team, postedDate,
+ *      descriptionTeaser). Pagination via `?from=<offset>` at 10/page;
+ *      `totalHits` indicates corpus size.
+ *
+ *   2. Detail pages embed a `<script type="application/ld+json">`
+ *      JobPosting (schema.org) block with the full HTML description as
+ *      `description` (HTML-entity-encoded). schema.org is the most stable
+ *      surface; `phApp.ddo.jobDetail.data.job.description` is the fallback.
+ *
+ * Lives in scrape-heavy.yml's offload set (browser-based via puppeteer).
+ *
+ * Cost knob: `PHENOM_BMO_MAX_JOBS` env var is an OPTIONAL cap. Unset (the
+ * production default) means "process the entire BMO corpus." Set it for
+ * smoke tests or to impose a cost ceiling.
+ */
+
+import type { JobData } from "./types";
+import type { Browser, Page } from "puppeteer-core";
+import { decodeHtmlEntities, detectLocationType, htmlToText } from "./utils";
+import { log } from "@/lib/log";
+
+const BMO_LISTING_URL = "https://jobs.bmo.com/ca/en/search-results";
+const DESCRIPTION_CONCURRENCY = 4;
+const ENRICH_BATCH_SIZE = 50;
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+// ---------------------------------------------------------------------------
+// Phenom listing JSON shape (subset)
+// ---------------------------------------------------------------------------
+
+export interface PhenomRawJob {
+  reqId?: string;
+  jobId?: string;
+  title?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  multi_location?: string[];
+  category?: string;
+  multi_category?: string[];
+  subCategory?: string;
+  postedDate?: string;
+  applyUrl?: string;
+  jobUrl?: string;
+  description?: string;
+  descriptionTeaser?: string;
+  ml_job_parser?: { descriptionTeaser?: string };
+  remote?: boolean | string;
+  hybrid?: boolean | string;
+  type?: string;
+}
+
+export interface PhenomSearchPayload {
+  totalHits?: number;
+  hits?: number;
+  data?: { jobs?: PhenomRawJob[] };
+}
+
+// ---------------------------------------------------------------------------
+// Pure-logic helpers (testable without a browser)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the rendered HTML, find the `"eagerLoadRefineSearch":` marker, and
+ * return the embedded JSON object via brace-counting. Null on any kind of
+ * failure (marker not found, JSON malformed, etc.) — caller decides how
+ * to react.
+ */
+export function extractEagerLoadPayload(
+  html: string
+): PhenomSearchPayload | null {
+  const marker = '"eagerLoadRefineSearch":';
+  const start = html.indexOf(marker);
+  if (start === -1) return null;
+  const objStart = html.indexOf("{", start + marker.length);
+  if (objStart === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = objStart; i < html.length; i++) {
+    const ch = html[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        try {
+          return JSON.parse(
+            html.substring(objStart, i + 1)
+          ) as PhenomSearchPayload;
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Map one Phenom row to the canonical `JobData` shape. Pure transformation
+ * — no I/O, fully unit-testable.
+ *
+ * Phenom splits role taxonomy two ways:
+ *   - `multi_category` (broad pipe-joined family) → `department`
+ *   - `subCategory` (finer-grained) → `team`
+ *
+ * `description_text` is set to the listing-time teaser as a stand-in; the
+ * description-enrichment pass replaces it with the full extracted text.
+ */
+export function mapBmoJob(raw: PhenomRawJob): JobData {
+  const externalId = raw.reqId || raw.jobId || "";
+  const locationParts = raw.multi_location?.length
+    ? raw.multi_location.join("; ")
+    : [raw.city, raw.state, raw.country].filter(Boolean).join(", ");
+  const department = raw.multi_category?.[0] || raw.category || null;
+  const team = raw.subCategory || null;
+  const teaser =
+    raw.descriptionTeaser ||
+    raw.ml_job_parser?.descriptionTeaser ||
+    raw.description ||
+    null;
+
+  let locationType: string | null = null;
+  if (raw.remote === true || raw.remote === "true") locationType = "remote";
+  else if (raw.hybrid === true || raw.hybrid === "true")
+    locationType = "hybrid";
+  else locationType = detectLocationType(locationParts, teaser || "");
+
+  let postedDate: Date | null = null;
+  if (raw.postedDate) {
+    const parsed = new Date(raw.postedDate);
+    if (!isNaN(parsed.getTime())) postedDate = parsed;
+  }
+
+  // Canonical Phenom URL — independent of whatever applyUrl Phenom rendered
+  // (apply URLs route into Workday). Slug is title with non-alnum collapsed.
+  const slug = (raw.title || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const url = externalId
+    ? `https://jobs.bmo.com/ca/en/job/${externalId}/${slug}`
+    : raw.jobUrl || raw.applyUrl || "";
+
+  // Phenom occasionally encodes employment type as "Full time" / "Contract".
+  let commitment: string = "full-time";
+  if (raw.type) {
+    const t = raw.type.toLowerCase();
+    if (/contract/.test(t)) commitment = "contract";
+    else if (/intern/.test(t)) commitment = "internship";
+    else if (/part/.test(t)) commitment = "part-time";
+  }
+
+  return {
+    external_id: externalId,
+    title: raw.title || "",
+    department,
+    team,
+    location: locationParts || null,
+    location_type: locationType,
+    description_html: null,
+    description_text: teaser,
+    commitment,
+    posted_date: postedDate,
+    url,
+  };
+}
+
+// Re-exported for the existing test + any external imports.
+export { decodeHtmlEntities } from "./utils";
+
+// ---------------------------------------------------------------------------
+// Browser-side extractor (string-sourced so tsx's `__name` helper can't
+// leak into the page context — see smoke history).
+// ---------------------------------------------------------------------------
+
+export const PHENOM_DETAIL_EXTRACTOR_SRC = `(function () {
+  // Strategy 1: JSON-LD JobPosting (schema.org). Documented + Google-
+  // indexed, so most stable surface available.
+  var ldNodes = document.querySelectorAll('script[type="application/ld+json"]');
+  for (var i = 0; i < ldNodes.length; i++) {
+    var raw = ldNodes[i].textContent || "";
+    if (!raw) continue;
+    try {
+      var parsed = JSON.parse(raw);
+      var candidates = Array.isArray(parsed) ? parsed : [parsed];
+      for (var c = 0; c < candidates.length; c++) {
+        var entry = candidates[c];
+        if (entry && entry["@type"] === "JobPosting" && typeof entry.description === "string" && entry.description.length > 200) {
+          return { html: entry.description, source: "json-ld-JobPosting" };
+        }
+      }
+    } catch (e) {}
+  }
+
+  // Strategy 2: phApp.ddo.jobDetail.data.job.description (Phenom's
+  // internal blob — backup in case schema.org disappears).
+  var html = document.documentElement.innerHTML;
+  var marker = '"jobDetail":';
+  var start = html.indexOf(marker);
+  if (start !== -1) {
+    var objStart = html.indexOf("{", start + marker.length);
+    if (objStart !== -1) {
+      var depth = 0, inStr = false, esc = false;
+      for (var p = objStart; p < html.length; p++) {
+        var ch = html[p];
+        if (esc) { esc = false; continue; }
+        if (ch === '\\\\') { esc = true; continue; }
+        if (ch === '"') { inStr = !inStr; continue; }
+        if (inStr) continue;
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            try {
+              var obj = JSON.parse(html.substring(objStart, p + 1));
+              var desc = obj && obj.data && obj.data.job && (obj.data.job.description || obj.data.job.descriptionHtml);
+              if (desc && desc.length > 200) {
+                return { html: desc, source: "phApp-jobDetail" };
+              }
+            } catch (e) {}
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
+})()`;
+
+// ---------------------------------------------------------------------------
+// Puppeteer driver
+// ---------------------------------------------------------------------------
+
+interface BrowserHandles {
+  browser: Browser;
+  owned: boolean;
+}
+
+async function acquireBrowser(injected?: Browser): Promise<BrowserHandles> {
+  if (injected) return { browser: injected, owned: false };
+  const puppeteer = await import("puppeteer-core");
+  const chromiumModule = await import("@sparticuz/chromium");
+  type ChromiumLike = {
+    args: string[];
+    defaultViewport?: { width: number; height: number } | null;
+    executablePath: () => Promise<string>;
+  };
+  const chromium = (
+    (chromiumModule as { default?: ChromiumLike }).default ?? chromiumModule
+  ) as unknown as ChromiumLike;
+  const executablePath = await chromium.executablePath();
+  const browser = await puppeteer.default.launch({
+    args: chromium.args,
+    defaultViewport: chromium.defaultViewport,
+    executablePath,
+    headless: true,
+  });
+  return { browser, owned: true };
+}
+
+async function fetchListingPage(
+  page: Page,
+  from: number
+): Promise<PhenomSearchPayload | null> {
+  const url = from === 0 ? BMO_LISTING_URL : `${BMO_LISTING_URL}?from=${from}`;
+  await page.goto(url, { waitUntil: "networkidle2", timeout: 45_000 });
+  await new Promise((r) => setTimeout(r, 2_000));
+  const html = await page.content();
+  return extractEagerLoadPayload(html);
+}
+
+async function enrichOne(page: Page, job: JobData): Promise<void> {
+  if (!job.url) return;
+  await page.goto(job.url, { waitUntil: "networkidle2", timeout: 45_000 });
+  await new Promise((r) => setTimeout(r, 2_500));
+  const result = (await page.evaluate(PHENOM_DETAIL_EXTRACTOR_SRC)) as
+    | { html: string; source: string }
+    | null;
+  if (!result?.html) return;
+  const decoded = decodeHtmlEntities(result.html);
+  job.description_html = decoded;
+  job.description_text = htmlToText(decoded);
+}
+
+/**
+ * Enrich one batch of jobs. Spins up `concurrency` fresh pages, drains a
+ * shared queue, and closes the pages when done — so page memory is
+ * released at the end of every batch rather than accumulating across the
+ * whole corpus.
+ */
+async function enrichBatch(
+  browser: Browser,
+  batch: JobData[],
+  concurrency: number
+): Promise<{ enriched: number; failed: number }> {
+  const queue = [...batch];
+  let enriched = 0;
+  let failed = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, batch.length) }, async () => {
+      const page = await browser.newPage();
+      try {
+        await page.setUserAgent(USER_AGENT);
+        while (queue.length > 0) {
+          const job = queue.shift();
+          if (!job) break;
+          try {
+            await enrichOne(page, job);
+            enriched++;
+          } catch (e) {
+            failed++;
+            log.warn(
+              {
+                reqId: job.external_id,
+                err: e instanceof Error ? e.message : String(e),
+              },
+              "[phenom-bmo] description enrichment failed"
+            );
+          }
+        }
+      } finally {
+        await page.close();
+      }
+    })
+  );
+  return { enriched, failed };
+}
+
+/**
+ * Enrich every job's description, walking the corpus in chunks of
+ * `batchSize`. Each chunk is a self-contained `enrichBatch` call; progress
+ * is logged after each so a long-running scrape is observable and a crash
+ * leaves a clear high-water mark in the logs.
+ */
+async function enrichDescriptions(
+  browser: Browser,
+  jobs: JobData[],
+  concurrency: number,
+  batchSize: number
+): Promise<void> {
+  const batchCount = Math.ceil(jobs.length / batchSize);
+  let totalEnriched = 0;
+  let totalFailed = 0;
+  for (let i = 0; i < jobs.length; i += batchSize) {
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const batch = jobs.slice(i, i + batchSize);
+    const { enriched, failed } = await enrichBatch(browser, batch, concurrency);
+    totalEnriched += enriched;
+    totalFailed += failed;
+    log.info(
+      {
+        batch: batchNum,
+        batchCount,
+        processed: Math.min(i + batchSize, jobs.length),
+        total: jobs.length,
+        enrichedSoFar: totalEnriched,
+        failedSoFar: totalFailed,
+      },
+      "[phenom-bmo] enrichment batch complete"
+    );
+  }
+  log.info(
+    { enriched: totalEnriched, failed: totalFailed, total: jobs.length },
+    "[phenom-bmo] description enrichment complete"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the optional per-run cap. `PHENOM_BMO_MAX_JOBS`:
+ *   - unset (production default) → null → process the entire corpus
+ *   - a positive integer → cap the run to that many jobs (smoke tests,
+ *     cost ceilings)
+ * Exported for unit testing.
+ */
+export function resolveJobCap(
+  rawEnv: string | undefined = process.env.PHENOM_BMO_MAX_JOBS
+): number | null {
+  if (rawEnv && /^\d+$/.test(rawEnv)) {
+    return Math.max(1, parseInt(rawEnv, 10));
+  }
+  return null;
+}
+
+export async function fetchPhenomBmoJobs(
+  atsIdentifier: string,
+  browser?: Browser
+): Promise<JobData[]> {
+  // `atsIdentifier` is "bmo" today — accepted so the factory can dispatch
+  // by tenant once more Phenom tenants land.
+  void atsIdentifier;
+
+  const cap = resolveJobCap();
+
+  const { browser: browserInstance, owned } = await acquireBrowser(browser);
+
+  try {
+    const listingPage = await browserInstance.newPage();
+    await listingPage.setUserAgent(USER_AGENT);
+
+    const jobs: JobData[] = [];
+    let totalHits: number | null = null;
+    let from = 0;
+
+    // Paginate the FULL listing. Phenom serves 10 per page. Stop when the
+    // corpus is exhausted, a page comes back empty, or the optional cap
+    // is reached.
+    while (true) {
+      const payload = await fetchListingPage(listingPage, from);
+      if (!payload?.data?.jobs?.length) break;
+      totalHits = payload.totalHits ?? totalHits;
+      jobs.push(...payload.data.jobs.map(mapBmoJob));
+      from += payload.data.jobs.length;
+      if (cap != null && jobs.length >= cap) break;
+      if (totalHits != null && from >= totalHits) break;
+    }
+
+    if (cap != null && jobs.length > cap) jobs.length = cap;
+    await listingPage.close();
+
+    log.info(
+      {
+        fetched: jobs.length,
+        totalHits,
+        cap: cap ?? "uncapped",
+        batchSize: ENRICH_BATCH_SIZE,
+      },
+      "[phenom-bmo] listings complete; enriching descriptions in batches"
+    );
+
+    if (jobs.length > 0) {
+      await enrichDescriptions(
+        browserInstance,
+        jobs,
+        DESCRIPTION_CONCURRENCY,
+        ENRICH_BATCH_SIZE
+      );
+    }
+
+    return jobs;
+  } finally {
+    if (owned) await browserInstance.close();
+  }
+}

--- a/web/lib/scrapers/phenom-bnc.test.ts
+++ b/web/lib/scrapers/phenom-bnc.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Tests for the pure-logic pieces of the Phenom-BNC scraper.
+ *
+ * The Puppeteer driver (pagination loop, description enrichment with
+ * concurrency=4) requires a real browser. The tests here cover the parts
+ * that don't need a browser: HTML payload extraction, the Phenom-row →
+ * JobData mapper, and the env-var cap resolver.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  decodeHtmlEntities,
+  extractEagerLoadPayload,
+  mapBncJob,
+  resolveJobCap,
+  type PhenomRawJob,
+  type PhenomSearchPayload,
+} from "./phenom-bnc";
+
+const FIXTURE_PATH = resolve(__dirname, "__fixtures__/phenom-bnc-listing.json");
+const FIXTURE: PhenomSearchPayload = JSON.parse(
+  readFileSync(FIXTURE_PATH, "utf8")
+);
+
+describe("extractEagerLoadPayload (BNC)", () => {
+  it("returns null when the marker is missing", () => {
+    expect(extractEagerLoadPayload("<html><body>nothing here</body></html>")).toBeNull();
+  });
+
+  it("returns null when the JSON object is malformed", () => {
+    const html = `<script>var x = "eagerLoadRefineSearch":{"status":200,</script>`;
+    expect(extractEagerLoadPayload(html)).toBeNull();
+  });
+
+  it("extracts the embedded payload from a representative HTML chunk", () => {
+    const wrapped = `<!DOCTYPE html><html><body><script>
+      var phApp = phApp || {};
+      phApp.ddo = { "flashParams": {}, "eagerLoadRefineSearch": ${JSON.stringify(FIXTURE)} };
+    </script></body></html>`;
+
+    const got = extractEagerLoadPayload(wrapped);
+    expect(got).not.toBeNull();
+    expect(got!.totalHits).toBe(FIXTURE.totalHits);
+    expect(got!.data?.jobs?.length).toBe(FIXTURE.data?.jobs?.length);
+  });
+
+  it("does not confuse braces inside string literals for object boundaries", () => {
+    const wrapped = `garbage "eagerLoadRefineSearch":{"trick":"this has a } in it","status":200,"data":{"jobs":[]}}`;
+    const got = extractEagerLoadPayload(wrapped);
+    expect(got).not.toBeNull();
+    expect(got!.data?.jobs).toEqual([]);
+  });
+});
+
+describe("decodeHtmlEntities (BNC re-export)", () => {
+  it("decodes the entity set Phenom uses in JSON-LD descriptions", () => {
+    const encoded =
+      "&lt;div&gt;Hello &amp; goodbye &quot;world&quot; with &nbsp; spaces and &#39;apostrophes&#39;&lt;/div&gt;";
+    const decoded = decodeHtmlEntities(encoded);
+    expect(decoded).toBe(
+      "<div>Hello & goodbye \"world\" with   spaces and 'apostrophes'</div>"
+    );
+  });
+});
+
+describe("mapBncJob", () => {
+  it("maps the principal cloud engineer fixture row to a complete JobData", () => {
+    const cloud = FIXTURE.data!.jobs!.find((j) => j.reqId === "JR-23541");
+    expect(cloud).toBeDefined();
+
+    const job = mapBncJob(cloud as PhenomRawJob);
+    expect(job.external_id).toBe("JR-23541");
+    expect(job.title).toBe("Principal Cloud Engineer");
+    expect(job.department).toBe("Technology | Data | Cyber");
+    expect(job.team).toBe("Cloud Platform Engineering");
+    expect(job.location).toBe("Montréal, Quebec, Canada");
+    expect(job.url).toBe(
+      "https://emplois.bnc.ca/fr_CA/careers/jobdetail/JR-23541/Principal-Cloud-Engineer"
+    );
+    expect(job.description_text).toMatch(/Plateforme Infonuagique/);
+    expect(job.description_html).toBeNull(); // populated by enrichment, not the mapper
+    expect(job.commitment).toBe("full-time");
+    expect(job.posted_date?.toISOString()).toBe("2026-02-28T00:00:00.000Z");
+    // Explicit remote flag from fixture wins over text heuristics.
+    expect(job.location_type).toBe("remote");
+  });
+
+  it("derives team from subCategory, distinct from department", () => {
+    const wealth = FIXTURE.data!.jobs!.find((j) => j.reqId === "JR-23789");
+    const job = mapBncJob(wealth as PhenomRawJob);
+    expect(job.department).toBe("Wealth Management | Private Banking");
+    expect(job.team).toBe("Wealth Management Advisory");
+    expect(job.team).not.toBe(job.department);
+  });
+
+  it("handles missing reqId by falling back to jobUrl/applyUrl", () => {
+    const raw: PhenomRawJob = {
+      title: "Foo",
+      jobUrl: "https://emplois.bnc.ca/fr_CA/careers/jobdetail/FOO-1/Foo",
+    };
+    const job = mapBncJob(raw);
+    expect(job.external_id).toBe("");
+    expect(job.url).toBe("https://emplois.bnc.ca/fr_CA/careers/jobdetail/FOO-1/Foo");
+  });
+
+  it("infers commitment from the type field when present", () => {
+    expect(mapBncJob({ title: "X", type: "Contract" }).commitment).toBe("contract");
+    expect(mapBncJob({ title: "X", type: "Internship" }).commitment).toBe("internship");
+    expect(mapBncJob({ title: "X", type: "Part time" }).commitment).toBe("part-time");
+    expect(mapBncJob({ title: "X", type: "Full time" }).commitment).toBe("full-time");
+    expect(mapBncJob({ title: "X" }).commitment).toBe("full-time"); // default
+
+    // Contract fixture row should land at "contract".
+    const credit = FIXTURE.data!.jobs!.find((j) => j.reqId === "JR-24012");
+    expect(mapBncJob(credit as PhenomRawJob).commitment).toBe("contract");
+  });
+
+  it("respects explicit remote/hybrid flags before falling back to text heuristics", () => {
+    expect(mapBncJob({ title: "X", remote: true }).location_type).toBe("remote");
+    expect(mapBncJob({ title: "X", hybrid: "true" }).location_type).toBe("hybrid");
+
+    // Fixture's wealth advisor sets hybrid: "true" — expect "hybrid".
+    const wealth = FIXTURE.data!.jobs!.find((j) => j.reqId === "JR-23789");
+    expect(mapBncJob(wealth as PhenomRawJob).location_type).toBe("hybrid");
+  });
+
+  it("produces a canonical emplois.bnc.ca URL even when applyUrl routes into Workday", () => {
+    // BNC's applyUrl routes into bnc.wd3.myworkdayjobs.com — we ignore it
+    // and synthesize the Phenom-facing /fr_CA/careers/jobdetail/<id>/<slug> URL.
+    const raw: PhenomRawJob = {
+      reqId: "JR-X",
+      title: "Cloud MLOps & GenAI Lead",
+      applyUrl:
+        "https://bnc.wd3.myworkdayjobs.com/External/job/whatever/apply",
+    };
+    const job = mapBncJob(raw);
+    expect(job.url).toBe(
+      "https://emplois.bnc.ca/fr_CA/careers/jobdetail/JR-X/Cloud-MLOps-GenAI-Lead"
+    );
+    expect(job.url).not.toContain("workday");
+  });
+
+  it("aggregates multi_location into the canonical city/state/country string", () => {
+    const credit = FIXTURE.data!.jobs!.find((j) => j.reqId === "JR-24012");
+    const job = mapBncJob(credit as PhenomRawJob);
+    expect(job.location).toBe("Toronto, Ontario, Canada");
+  });
+
+  it("falls back to city/state/country when multi_location is absent", () => {
+    const raw: PhenomRawJob = {
+      reqId: "JR-Y",
+      title: "Test",
+      city: "Montréal",
+      state: "Quebec",
+      country: "Canada",
+    };
+    const job = mapBncJob(raw);
+    expect(job.location).toBe("Montréal, Quebec, Canada");
+  });
+});
+
+describe("resolveJobCap (BNC)", () => {
+  it("returns null when unset — production default is the FULL corpus", () => {
+    expect(resolveJobCap(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(resolveJobCap("")).toBeNull();
+  });
+
+  it("returns null for a non-numeric value rather than throwing", () => {
+    expect(resolveJobCap("all")).toBeNull();
+    expect(resolveJobCap("50x")).toBeNull();
+  });
+
+  it("parses a positive integer cap (smoke tests / cost ceilings)", () => {
+    expect(resolveJobCap("5")).toBe(5);
+    expect(resolveJobCap("1500")).toBe(1500);
+  });
+
+  it("clamps a zero cap up to 1 — a cap of 0 would be a useless run", () => {
+    expect(resolveJobCap("0")).toBe(1);
+  });
+});
+
+describe("fixture sanity (BNC)", () => {
+  it("contains the three reference jobs the tests depend on", () => {
+    const ids = FIXTURE.data?.jobs?.map((j) => j.reqId);
+    expect(ids).toEqual(
+      expect.arrayContaining(["JR-23541", "JR-23789", "JR-24012"])
+    );
+  });
+
+  it("contains at least 3 jobs from distinct departments", () => {
+    const jobs = FIXTURE.data?.jobs ?? [];
+    expect(jobs.length).toBeGreaterThanOrEqual(3);
+    const departments = new Set(jobs.map((j) => j.multi_category?.[0]));
+    expect(departments.size).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/web/lib/scrapers/phenom-bnc.ts
+++ b/web/lib/scrapers/phenom-bnc.ts
@@ -1,0 +1,475 @@
+/**
+ * BNC (National Bank of Canada / Banque Nationale) — Phenom CareerConnect
+ * scraper on a white-labeled domain.
+ *
+ * Mirrors the proven RBC scraper (`./phenom-rbc.ts`) exactly — BNC runs on
+ * the same Phenom CareerConnect platform behind a white-labeled host
+ * (`emplois.bnc.ca`). The canonical landing is the French URL because BNC
+ * is a Quebec-headquartered bilingual institution; the underlying data
+ * shape is identical to the rest of the Phenom family.
+ *
+ * Two data surfaces:
+ *
+ *   1. Listing pages embed `phApp.eagerLoadRefineSearch.data.jobs[]` with
+ *      ~40 fields per posting (title, reqId, city/state/country,
+ *      multi_category → department, subCategory → team, postedDate,
+ *      descriptionTeaser). Pagination via `?from=<offset>` at 10/page.
+ *
+ *   2. Detail pages embed a `<script type="application/ld+json">`
+ *      JobPosting (schema.org) block with the full HTML description.
+ *      `phApp.ddo.jobDetail.data.job.description` is the fallback.
+ *
+ * Lives in scrape-heavy.yml's offload set (browser-based via puppeteer).
+ *
+ * Cost knob: `PHENOM_BNC_MAX_JOBS` env var is an OPTIONAL cap. Unset (the
+ * production default) means "process the entire BNC corpus." Set it for
+ * smoke tests or to impose a cost ceiling.
+ */
+
+import type { JobData } from "./types";
+import type { Browser, Page } from "puppeteer-core";
+import { decodeHtmlEntities, detectLocationType, htmlToText } from "./utils";
+import { log } from "@/lib/log";
+
+const BNC_LISTING_URL = "https://emplois.bnc.ca/fr_CA/careers/searchjobs";
+const BNC_JOB_BASE_URL = "https://emplois.bnc.ca/fr_CA/careers/jobdetail";
+const DESCRIPTION_CONCURRENCY = 4;
+const ENRICH_BATCH_SIZE = 50;
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+// ---------------------------------------------------------------------------
+// Phenom listing JSON shape (subset)
+// ---------------------------------------------------------------------------
+
+export interface PhenomRawJob {
+  reqId?: string;
+  jobId?: string;
+  title?: string;
+  city?: string;
+  state?: string;
+  country?: string;
+  multi_location?: string[];
+  category?: string;
+  multi_category?: string[];
+  subCategory?: string;
+  postedDate?: string;
+  applyUrl?: string;
+  jobUrl?: string;
+  description?: string;
+  descriptionTeaser?: string;
+  ml_job_parser?: { descriptionTeaser?: string };
+  remote?: boolean | string;
+  hybrid?: boolean | string;
+  type?: string;
+}
+
+export interface PhenomSearchPayload {
+  totalHits?: number;
+  hits?: number;
+  data?: { jobs?: PhenomRawJob[] };
+}
+
+// ---------------------------------------------------------------------------
+// Pure-logic helpers (testable without a browser)
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the rendered HTML, find the `"eagerLoadRefineSearch":` marker, and
+ * return the embedded JSON object via brace-counting. Null on any kind of
+ * failure (marker not found, JSON malformed, etc.) — caller decides how
+ * to react.
+ */
+export function extractEagerLoadPayload(
+  html: string
+): PhenomSearchPayload | null {
+  const marker = '"eagerLoadRefineSearch":';
+  const start = html.indexOf(marker);
+  if (start === -1) return null;
+  const objStart = html.indexOf("{", start + marker.length);
+  if (objStart === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  for (let i = objStart; i < html.length; i++) {
+    const ch = html[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === "\\") {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        try {
+          return JSON.parse(
+            html.substring(objStart, i + 1)
+          ) as PhenomSearchPayload;
+        } catch {
+          return null;
+        }
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Map one Phenom row to the canonical `JobData` shape. Pure transformation
+ * — no I/O, fully unit-testable.
+ *
+ * Phenom splits role taxonomy two ways:
+ *   - `multi_category` (broad pipe-joined family) → `department`
+ *   - `subCategory` (finer-grained) → `team`
+ *
+ * `description_text` is set to the listing-time teaser as a stand-in; the
+ * description-enrichment pass replaces it with the full extracted text.
+ */
+export function mapBncJob(raw: PhenomRawJob): JobData {
+  const externalId = raw.reqId || raw.jobId || "";
+  const locationParts = raw.multi_location?.length
+    ? raw.multi_location.join("; ")
+    : [raw.city, raw.state, raw.country].filter(Boolean).join(", ");
+  const department = raw.multi_category?.[0] || raw.category || null;
+  const team = raw.subCategory || null;
+  const teaser =
+    raw.descriptionTeaser ||
+    raw.ml_job_parser?.descriptionTeaser ||
+    raw.description ||
+    null;
+
+  let locationType: string | null = null;
+  if (raw.remote === true || raw.remote === "true") locationType = "remote";
+  else if (raw.hybrid === true || raw.hybrid === "true")
+    locationType = "hybrid";
+  else locationType = detectLocationType(locationParts, teaser || "");
+
+  let postedDate: Date | null = null;
+  if (raw.postedDate) {
+    const parsed = new Date(raw.postedDate);
+    if (!isNaN(parsed.getTime())) postedDate = parsed;
+  }
+
+  // Canonical Phenom URL — slug is title with non-alnum collapsed.
+  const slug = (raw.title || "")
+    .trim()
+    .replace(/[^a-zA-Z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+  const url = externalId
+    ? `${BNC_JOB_BASE_URL}/${externalId}/${slug}`
+    : raw.jobUrl || raw.applyUrl || "";
+
+  // Phenom occasionally encodes employment type as "Full time" / "Contract".
+  let commitment: string = "full-time";
+  if (raw.type) {
+    const t = raw.type.toLowerCase();
+    if (/contract/.test(t)) commitment = "contract";
+    else if (/intern/.test(t)) commitment = "internship";
+    else if (/part/.test(t)) commitment = "part-time";
+  }
+
+  return {
+    external_id: externalId,
+    title: raw.title || "",
+    department,
+    team,
+    location: locationParts || null,
+    location_type: locationType,
+    description_html: null,
+    description_text: teaser,
+    commitment,
+    posted_date: postedDate,
+    url,
+  };
+}
+
+// Re-exported for the existing test + any external imports.
+export { decodeHtmlEntities } from "./utils";
+
+// ---------------------------------------------------------------------------
+// Browser-side extractor (string-sourced so tsx's `__name` helper can't
+// leak into the page context — see smoke history).
+// ---------------------------------------------------------------------------
+
+export const PHENOM_DETAIL_EXTRACTOR_SRC = `(function () {
+  // Strategy 1: JSON-LD JobPosting (schema.org). Documented + Google-
+  // indexed, so most stable surface available.
+  var ldNodes = document.querySelectorAll('script[type="application/ld+json"]');
+  for (var i = 0; i < ldNodes.length; i++) {
+    var raw = ldNodes[i].textContent || "";
+    if (!raw) continue;
+    try {
+      var parsed = JSON.parse(raw);
+      var candidates = Array.isArray(parsed) ? parsed : [parsed];
+      for (var c = 0; c < candidates.length; c++) {
+        var entry = candidates[c];
+        if (entry && entry["@type"] === "JobPosting" && typeof entry.description === "string" && entry.description.length > 200) {
+          return { html: entry.description, source: "json-ld-JobPosting" };
+        }
+      }
+    } catch (e) {}
+  }
+
+  // Strategy 2: phApp.ddo.jobDetail.data.job.description (Phenom's
+  // internal blob — backup in case schema.org disappears).
+  var html = document.documentElement.innerHTML;
+  var marker = '"jobDetail":';
+  var start = html.indexOf(marker);
+  if (start !== -1) {
+    var objStart = html.indexOf("{", start + marker.length);
+    if (objStart !== -1) {
+      var depth = 0, inStr = false, esc = false;
+      for (var p = objStart; p < html.length; p++) {
+        var ch = html[p];
+        if (esc) { esc = false; continue; }
+        if (ch === '\\\\') { esc = true; continue; }
+        if (ch === '"') { inStr = !inStr; continue; }
+        if (inStr) continue;
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+          depth--;
+          if (depth === 0) {
+            try {
+              var obj = JSON.parse(html.substring(objStart, p + 1));
+              var desc = obj && obj.data && obj.data.job && (obj.data.job.description || obj.data.job.descriptionHtml);
+              if (desc && desc.length > 200) {
+                return { html: desc, source: "phApp-jobDetail" };
+              }
+            } catch (e) {}
+            break;
+          }
+        }
+      }
+    }
+  }
+  return null;
+})()`;
+
+// ---------------------------------------------------------------------------
+// Puppeteer driver
+// ---------------------------------------------------------------------------
+
+interface BrowserHandles {
+  browser: Browser;
+  owned: boolean;
+}
+
+async function acquireBrowser(injected?: Browser): Promise<BrowserHandles> {
+  if (injected) return { browser: injected, owned: false };
+  const puppeteer = await import("puppeteer-core");
+  const chromiumModule = await import("@sparticuz/chromium");
+  type ChromiumLike = {
+    args: string[];
+    defaultViewport?: { width: number; height: number } | null;
+    executablePath: () => Promise<string>;
+  };
+  const chromium = (
+    (chromiumModule as { default?: ChromiumLike }).default ?? chromiumModule
+  ) as unknown as ChromiumLike;
+  const executablePath = await chromium.executablePath();
+  const browser = await puppeteer.default.launch({
+    args: chromium.args,
+    defaultViewport: chromium.defaultViewport,
+    executablePath,
+    headless: true,
+  });
+  return { browser, owned: true };
+}
+
+async function fetchListingPage(
+  page: Page,
+  from: number
+): Promise<PhenomSearchPayload | null> {
+  const url = from === 0 ? BNC_LISTING_URL : `${BNC_LISTING_URL}?from=${from}`;
+  await page.goto(url, { waitUntil: "networkidle2", timeout: 45_000 });
+  await new Promise((r) => setTimeout(r, 2_000));
+  const html = await page.content();
+  return extractEagerLoadPayload(html);
+}
+
+async function enrichOne(page: Page, job: JobData): Promise<void> {
+  if (!job.url) return;
+  await page.goto(job.url, { waitUntil: "networkidle2", timeout: 45_000 });
+  await new Promise((r) => setTimeout(r, 2_500));
+  const result = (await page.evaluate(PHENOM_DETAIL_EXTRACTOR_SRC)) as
+    | { html: string; source: string }
+    | null;
+  if (!result?.html) return;
+  const decoded = decodeHtmlEntities(result.html);
+  job.description_html = decoded;
+  job.description_text = htmlToText(decoded);
+}
+
+/**
+ * Enrich one batch of jobs. Spins up `concurrency` fresh pages, drains a
+ * shared queue, and closes the pages when done — so page memory is
+ * released at the end of every batch rather than accumulating across the
+ * whole corpus.
+ */
+async function enrichBatch(
+  browser: Browser,
+  batch: JobData[],
+  concurrency: number
+): Promise<{ enriched: number; failed: number }> {
+  const queue = [...batch];
+  let enriched = 0;
+  let failed = 0;
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, batch.length) }, async () => {
+      const page = await browser.newPage();
+      try {
+        await page.setUserAgent(USER_AGENT);
+        while (queue.length > 0) {
+          const job = queue.shift();
+          if (!job) break;
+          try {
+            await enrichOne(page, job);
+            enriched++;
+          } catch (e) {
+            failed++;
+            log.warn(
+              {
+                reqId: job.external_id,
+                err: e instanceof Error ? e.message : String(e),
+              },
+              "[phenom-bnc] description enrichment failed"
+            );
+          }
+        }
+      } finally {
+        await page.close();
+      }
+    })
+  );
+  return { enriched, failed };
+}
+
+/**
+ * Enrich every job's description, walking the corpus in chunks of
+ * `batchSize`. Each chunk is a self-contained `enrichBatch` call; progress
+ * is logged after each so a long-running scrape is observable and a crash
+ * leaves a clear high-water mark in the logs.
+ */
+async function enrichDescriptions(
+  browser: Browser,
+  jobs: JobData[],
+  concurrency: number,
+  batchSize: number
+): Promise<void> {
+  const batchCount = Math.ceil(jobs.length / batchSize);
+  let totalEnriched = 0;
+  let totalFailed = 0;
+  for (let i = 0; i < jobs.length; i += batchSize) {
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const batch = jobs.slice(i, i + batchSize);
+    const { enriched, failed } = await enrichBatch(browser, batch, concurrency);
+    totalEnriched += enriched;
+    totalFailed += failed;
+    log.info(
+      {
+        batch: batchNum,
+        batchCount,
+        processed: Math.min(i + batchSize, jobs.length),
+        total: jobs.length,
+        enrichedSoFar: totalEnriched,
+        failedSoFar: totalFailed,
+      },
+      "[phenom-bnc] enrichment batch complete"
+    );
+  }
+  log.info(
+    { enriched: totalEnriched, failed: totalFailed, total: jobs.length },
+    "[phenom-bnc] description enrichment complete"
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the optional per-run cap. `PHENOM_BNC_MAX_JOBS`:
+ *   - unset (production default) → null → process the entire corpus
+ *   - a positive integer → cap the run to that many jobs (smoke tests,
+ *     cost ceilings)
+ * Exported for unit testing.
+ */
+export function resolveJobCap(
+  rawEnv: string | undefined = process.env.PHENOM_BNC_MAX_JOBS
+): number | null {
+  if (rawEnv && /^\d+$/.test(rawEnv)) {
+    return Math.max(1, parseInt(rawEnv, 10));
+  }
+  return null;
+}
+
+export async function fetchPhenomBncJobs(
+  atsIdentifier: string,
+  browser?: Browser
+): Promise<JobData[]> {
+  // `atsIdentifier` is "bnc" today — accepted so the factory can dispatch
+  // by tenant once more Phenom tenants land.
+  void atsIdentifier;
+
+  const cap = resolveJobCap();
+
+  const { browser: browserInstance, owned } = await acquireBrowser(browser);
+
+  try {
+    const listingPage = await browserInstance.newPage();
+    await listingPage.setUserAgent(USER_AGENT);
+
+    const jobs: JobData[] = [];
+    let totalHits: number | null = null;
+    let from = 0;
+
+    // Paginate the FULL listing. Phenom serves 10 per page. Stop when the
+    // corpus is exhausted, a page comes back empty, or the optional cap
+    // is reached.
+    while (true) {
+      const payload = await fetchListingPage(listingPage, from);
+      if (!payload?.data?.jobs?.length) break;
+      totalHits = payload.totalHits ?? totalHits;
+      jobs.push(...payload.data.jobs.map(mapBncJob));
+      from += payload.data.jobs.length;
+      if (cap != null && jobs.length >= cap) break;
+      if (totalHits != null && from >= totalHits) break;
+    }
+
+    if (cap != null && jobs.length > cap) jobs.length = cap;
+    await listingPage.close();
+
+    log.info(
+      {
+        fetched: jobs.length,
+        totalHits,
+        cap: cap ?? "uncapped",
+        batchSize: ENRICH_BATCH_SIZE,
+      },
+      "[phenom-bnc] listings complete; enriching descriptions in batches"
+    );
+
+    if (jobs.length > 0) {
+      await enrichDescriptions(
+        browserInstance,
+        jobs,
+        DESCRIPTION_CONCURRENCY,
+        ENRICH_BATCH_SIZE
+      );
+    }
+
+    return jobs;
+  } finally {
+    if (owned) await browserInstance.close();
+  }
+}

--- a/web/lib/scrapers/phenom-rbc.ts
+++ b/web/lib/scrapers/phenom-rbc.ts
@@ -41,7 +41,7 @@
 
 import type { JobData } from "./types";
 import type { Browser, Page } from "puppeteer-core";
-import { detectLocationType, htmlToText } from "./utils";
+import { decodeHtmlEntities, detectLocationType, htmlToText } from "./utils";
 import { log } from "@/lib/log";
 
 const RBC_LISTING_URL = "https://jobs.rbc.com/ca/en/search-results";
@@ -139,20 +139,10 @@ export function extractEagerLoadPayload(
   return null;
 }
 
-/**
- * Schema.org `description` from JSON-LD arrives HTML-entity-encoded
- * (`&lt;div&gt;…`). Decode so what we store is real HTML.
- */
-export function decodeHtmlEntities(s: string): string {
-  return s
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&apos;/g, "'")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&"); // last — otherwise we re-encode the above
-}
+// `decodeHtmlEntities` moved to `./utils` so the four scrapers that need it
+// (phenom-rbc, scotiabank, workday-td, workday-cibc) share one definition.
+// Re-exported here for the existing test + any external imports.
+export { decodeHtmlEntities } from "./utils";
 
 /**
  * Map one Phenom row to the canonical `JobData` shape. Pure transformation

--- a/web/lib/scrapers/scotiabank.ts
+++ b/web/lib/scrapers/scotiabank.ts
@@ -10,7 +10,7 @@
  */
 
 import type { JobData } from "./types";
-import { htmlToText, detectLocationType } from "./utils";
+import { decodeHtmlEntities, detectLocationType, htmlToText } from "./utils";
 import { log } from "@/lib/log";
 
 const BASE_URL = "https://jobs.scotiabank.com";
@@ -212,17 +212,10 @@ function buildJobData(
   };
 }
 
-/** Decode common HTML entities */
-function decodeHtmlEntities(str: string): string {
-  return str
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#039;/g, "'")
-    .replace(/&#39;/g, "'")
-    .replace(/&apos;/g, "'");
-}
+// `decodeHtmlEntities` moved to `./utils` (had a real bug here — `&amp;`
+// was being decoded FIRST, which meant doubly-encoded sequences like
+// `&amp;lt;` were collapsing to `<` instead of staying as `&lt;`. The
+// canonical version in `./utils` decodes `&amp;` last.).
 
 /** Escape a string for use in a RegExp */
 function escapeRegex(str: string): string {

--- a/web/lib/scrapers/utils.ts
+++ b/web/lib/scrapers/utils.ts
@@ -22,3 +22,24 @@ export function normalizeCommitment(commitment: string): string | null {
   if (/intern/.test(c)) return "internship";
   return commitment;
 }
+
+/**
+ * Decode the common HTML entities that ATS providers double-escape into
+ * embedded JSON (`&lt;div&gt;` style). `&amp;` is decoded LAST — otherwise
+ * a doubly-encoded sequence like `&amp;lt;` would first become `&lt;` then
+ * incorrectly be decoded to `<`. The previous order-sensitive bug existed
+ * in two private copies (phenom-rbc.ts, scotiabank.ts); this is the
+ * canonical implementation — import from here instead of recreating.
+ */
+export function decodeHtmlEntities(s: string): string {
+  if (!s) return s;
+  return s
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&"); // last — see header
+}

--- a/web/lib/scrapers/workday-cibc.test.ts
+++ b/web/lib/scrapers/workday-cibc.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the CIBC Workday scraper.
+ *
+ * Pure-fixture coverage plus the Simplii classifier. Per Farhan's spec,
+ * **no `fetch` allowed inside tests**.
+ *
+ * The Simplii classifier is the load-bearing piece — it's log-only for
+ * Phase 3 but the data shape must be confirmed before Phase 3.5 ships
+ * the actual override mechanism.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkdayUrls,
+  parseWorkdayListingRow,
+  parseWorkdayJobDetail,
+  type WorkdayListingResponse,
+  type WorkdayJobDetailResponse,
+} from "./workday-utils";
+import { isSimpliiPosting } from "./workday-cibc";
+
+const LISTING_FIXTURE: WorkdayListingResponse = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "__fixtures__/workday-cibc-listing.json"),
+    "utf8"
+  )
+);
+const DETAIL_FIXTURE: WorkdayJobDetailResponse = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "__fixtures__/workday-cibc-detail.json"),
+    "utf8"
+  )
+);
+
+const CIBC_URLS = buildWorkdayUrls("cibc", "wd3", "search");
+
+describe("workday-cibc URL builders", () => {
+  it("targets the cibc tenant on wd3 with the search site", () => {
+    expect(CIBC_URLS.listingPostUrl).toBe(
+      "https://cibc.wd3.myworkdayjobs.com/wday/cxs/cibc/search/jobs"
+    );
+  });
+
+  it("builds a public apply URL under /search/...", () => {
+    expect(
+      CIBC_URLS.jobPublicUrl("/job/Toronto-ON/Manager_2521234")
+    ).toBe(
+      "https://cibc.wd3.myworkdayjobs.com/search/job/Toronto-ON/Manager_2521234"
+    );
+  });
+});
+
+describe("workday-cibc listing fixture", () => {
+  it("contains four reference jobs (CIBC, Simplii-title, Simplii-bu, look-alike)", () => {
+    expect(LISTING_FIXTURE.jobPostings).toHaveLength(4);
+  });
+
+  it("maps the Manager row to a complete JobData", () => {
+    const row = LISTING_FIXTURE.jobPostings![0];
+    const job = parseWorkdayListingRow(row, CIBC_URLS.jobPublicUrl);
+    expect(job).not.toBeNull();
+    expect(job!.title).toBe("Manager, Capital Markets Technology");
+    expect(job!.external_id).toBe("Manager--Capital-Markets-Technology_2521234");
+    expect(job!.location).toBe("Toronto, ON");
+    expect(job!.url).toBe(
+      "https://cibc.wd3.myworkdayjobs.com/search/job/Toronto-ON/Manager--Capital-Markets-Technology_2521234"
+    );
+  });
+});
+
+describe("workday-cibc detail fixture", () => {
+  it("decodes the description HTML and produces text", () => {
+    const parsed = parseWorkdayJobDetail(DETAIL_FIXTURE);
+    expect(parsed.description_html).toContain("capital markets technology");
+    expect(parsed.description_text).toContain("capital markets technology");
+  });
+
+  it("surfaces location from the detail response", () => {
+    const parsed = parseWorkdayJobDetail(DETAIL_FIXTURE);
+    expect(parsed.location).toBe("Toronto, ON, Canada");
+  });
+});
+
+describe("isSimpliiPosting (log-only classifier)", () => {
+  it("matches when the title contains 'Simplii'", () => {
+    const row = LISTING_FIXTURE.jobPostings!.find((r) =>
+      r.title?.includes("Simplii")
+    );
+    expect(row).toBeDefined();
+    const result = isSimpliiPosting(row!);
+    expect(result.isMatch).toBe(true);
+    expect(result.marker).toBe("title");
+  });
+
+  it("matches when bulletFields contains the Simplii brand string", () => {
+    const result = isSimpliiPosting({
+      title: "Some role",
+      bulletFields: ["2521456", "Simplii Financial", "Full time"],
+    });
+    expect(result.isMatch).toBe(true);
+    expect(result.marker).toBe("bulletFields");
+  });
+
+  it("matches when an arbitrary brand/business-unit field contains Simplii", () => {
+    const row = LISTING_FIXTURE.jobPostings![2];
+    // Title="Senior Data Engineer", bulletFields all say CIBC,
+    // businessUnit="Simplii Financial Direct Bank" — classifier must
+    // still flag it.
+    const result = isSimpliiPosting(row);
+    expect(result.isMatch).toBe(true);
+    expect(result.marker).toBe("businessUnit");
+  });
+
+  it("does NOT match a CIBC-only row with no Simplii signal", () => {
+    const result = isSimpliiPosting({
+      title: "Manager, Capital Markets Technology",
+      bulletFields: ["2521234", "CIBC", "Regular"],
+    });
+    expect(result.isMatch).toBe(false);
+  });
+
+  it("does NOT match a title with the look-alike word 'Simply'", () => {
+    // "Simply Excellent Service Representative" must not trigger.
+    const lookalike = LISTING_FIXTURE.jobPostings!.find((r) =>
+      r.title?.includes("Simply")
+    );
+    expect(lookalike).toBeDefined();
+    expect(isSimpliiPosting(lookalike!).isMatch).toBe(false);
+  });
+
+  it("does NOT match the substring 'simplistic'", () => {
+    const result = isSimpliiPosting({
+      title: "Build simplistic dashboards",
+      bulletFields: ["just CIBC"],
+    });
+    expect(result.isMatch).toBe(false);
+  });
+
+  it("is case-insensitive ('SIMPLII', 'simplii', 'Simplii' all match)", () => {
+    expect(
+      isSimpliiPosting({ title: "Banking Advisor — SIMPLII Financial" }).isMatch
+    ).toBe(true);
+    expect(isSimpliiPosting({ title: "simplii role" }).isMatch).toBe(true);
+  });
+
+  it("returns isMatch:false (no marker) when nothing matches", () => {
+    const result = isSimpliiPosting({ title: "X", bulletFields: ["Y", "Z"] });
+    expect(result.isMatch).toBe(false);
+    expect(result.marker).toBeUndefined();
+  });
+
+  it("handles a row with neither title nor bulletFields", () => {
+    expect(isSimpliiPosting({}).isMatch).toBe(false);
+  });
+});

--- a/web/lib/scrapers/workday-cibc.ts
+++ b/web/lib/scrapers/workday-cibc.ts
@@ -1,0 +1,204 @@
+/**
+ * CIBC — Workday tenant scraper.
+ *
+ * Tenant: `cibc`. Instance: `wd3`. Site: `search`.
+ *
+ * **Simplii classifier is LOG-ONLY for Phase 3.** Each listing row is
+ * inspected for a Simplii brand marker (in `bulletFields`, title, or any
+ * other visible string). When matched, we log and continue — we do NOT
+ * set a `companySlugOverride` field. Per Farhan: confirm Simplii postings
+ * actually surface from CIBC's Workday in production before adding the
+ * override mechanism + the Simplii companies row (Phase 3.5).
+ *
+ * Cost knob: `WORKDAY_CIBC_MAX_JOBS` env caps the run. Unset → full
+ * corpus.
+ */
+
+import type { JobData } from "./types";
+import { htmlToText } from "./utils";
+import {
+  buildWorkdayUrls,
+  parseWorkdayListingRow,
+  parseWorkdayJobDetail,
+  resolveWorkdayJobCap,
+  type WorkdayListingRow,
+  type WorkdayListingResponse,
+  type WorkdayJobDetailResponse,
+} from "./workday-utils";
+import { log } from "@/lib/log";
+
+const TENANT = "cibc";
+const INSTANCE = "wd3";
+const SITE = "search";
+const PAGE_LIMIT = 20;
+const FETCH_TIMEOUT_MS = 15_000;
+
+/**
+ * Simplii brand classifier. Pure, exported for unit testing.
+ *
+ * Inspects every string-valued field of the raw listing row (title,
+ * bulletFields, and any tenant-emitted brand/business-unit metadata)
+ * for a case-insensitive "simplii" token surrounded by word boundaries.
+ *
+ * Returns `{ isMatch: true, marker }` where `marker` names the field
+ * the match was found in (for log readability), or `{ isMatch: false }`.
+ *
+ * "Simply" or "simplistic" must NOT match — the word boundary regex
+ * (`\bsimplii\b`, case-insensitive) handles this.
+ */
+export function isSimpliiPosting(raw: WorkdayListingRow): {
+  isMatch: boolean;
+  marker?: string;
+} {
+  const pattern = /\bsimplii\b/i;
+
+  // Highest-signal candidates first so the returned `marker` is the most
+  // useful descriptor.
+  if (typeof raw.title === "string" && pattern.test(raw.title)) {
+    return { isMatch: true, marker: "title" };
+  }
+
+  if (Array.isArray(raw.bulletFields)) {
+    for (const b of raw.bulletFields) {
+      if (typeof b === "string" && pattern.test(b)) {
+        return { isMatch: true, marker: "bulletFields" };
+      }
+    }
+  }
+
+  // Walk every other string-valued top-level field. Workday tenants
+  // sometimes surface brand/business-unit metadata under varying keys,
+  // and we don't want a missing key to silently drop the signal.
+  for (const [key, value] of Object.entries(raw)) {
+    if (key === "title" || key === "bulletFields") continue;
+    if (typeof value === "string" && pattern.test(value)) {
+      return { isMatch: true, marker: key };
+    }
+  }
+
+  return { isMatch: false };
+}
+
+export async function fetchWorkdayCibcJobs(): Promise<JobData[]> {
+  const urls = buildWorkdayUrls(TENANT, INSTANCE, SITE);
+  const cap = resolveWorkdayJobCap(process.env.WORKDAY_CIBC_MAX_JOBS);
+
+  const jobs: JobData[] = [];
+  let offset = 0;
+  let total: number | null = null;
+  let simpliiSeen = 0;
+
+  // Step 1: paginate the listing.
+  while (true) {
+    const res = await fetch(urls.listingPostUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        limit: PAGE_LIMIT,
+        offset,
+        searchText: "",
+        appliedFacets: {},
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`Workday CIBC listing error: ${res.status}`);
+    }
+    const data = (await res.json()) as WorkdayListingResponse;
+    const rows = data.jobPostings ?? [];
+    if (rows.length === 0) break;
+    total = data.total ?? total;
+
+    for (const row of rows) {
+      const job = parseWorkdayListingRow(row, urls.jobPublicUrl);
+      if (!job) continue;
+
+      // Simplii classifier — log-only mode for Phase 3. Do NOT mutate
+      // the job; Phase 3.5 wires the override + companies row.
+      const simplii = isSimpliiPosting(row);
+      if (simplii.isMatch) {
+        simpliiSeen++;
+        log.info(
+          {
+            jobReqId: job.external_id,
+            title: job.title,
+            marker: simplii.marker,
+          },
+          "[workday-cibc] would-route-to-simplii (log-only Phase 3)"
+        );
+      }
+
+      jobs.push(job);
+    }
+
+    offset += rows.length;
+    if (cap != null && jobs.length >= cap) break;
+    if (total != null && offset >= total) break;
+  }
+
+  if (cap != null && jobs.length > cap) jobs.length = cap;
+
+  log.info(
+    {
+      fetched: jobs.length,
+      total,
+      cap: cap ?? "uncapped",
+      simpliiSeen,
+    },
+    "[workday-cibc] listings complete; enriching descriptions"
+  );
+
+  // Step 2: enrich each row's description.
+  let enriched = 0;
+  let failed = 0;
+  for (const job of jobs) {
+    if (!job.url) continue;
+    const externalPath = extractExternalPathFromPublicUrl(job.url);
+    if (!externalPath) continue;
+    try {
+      const detailRes = await fetch(urls.jobGetUrl(externalPath), {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!detailRes.ok) {
+        throw new Error(`status ${detailRes.status}`);
+      }
+      const detail = (await detailRes.json()) as WorkdayJobDetailResponse;
+      const parsed = parseWorkdayJobDetail(detail);
+      if (parsed.description_html) {
+        job.description_html = parsed.description_html;
+        job.description_text = parsed.description_text || htmlToText(parsed.description_html);
+      }
+      if (parsed.location && !job.location) job.location = parsed.location;
+      if (parsed.posted_date && !job.posted_date) job.posted_date = parsed.posted_date;
+      enriched++;
+    } catch (e) {
+      failed++;
+      log.warn(
+        {
+          externalId: job.external_id,
+          err: e instanceof Error ? e.message : String(e),
+        },
+        "[workday-cibc] detail enrichment failed"
+      );
+    }
+  }
+
+  log.info(
+    { enriched, failed, total: jobs.length },
+    "[workday-cibc] description enrichment complete"
+  );
+
+  return jobs;
+}
+
+function extractExternalPathFromPublicUrl(publicUrl: string): string | null {
+  const marker = `/${SITE}`;
+  const idx = publicUrl.indexOf(marker);
+  if (idx === -1) return null;
+  const tail = publicUrl.slice(idx + marker.length);
+  return tail.startsWith("/") ? tail : null;
+}

--- a/web/lib/scrapers/workday-td.test.ts
+++ b/web/lib/scrapers/workday-td.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Tests for the TD Bank Workday scraper.
+ *
+ * Pure-fixture coverage. The HTTP-driven driver (`fetchWorkdayTdJobs`)
+ * isn't exercised here — its behavior is the same listing/detail
+ * orchestration covered by the workday-utils tests against the fixtures.
+ * Per Farhan's spec, **no `fetch` allowed inside tests** — we test the
+ * pure mappers against the fixture data.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkdayUrls,
+  parseWorkdayListingRow,
+  parseWorkdayJobDetail,
+  type WorkdayListingResponse,
+  type WorkdayJobDetailResponse,
+} from "./workday-utils";
+
+const LISTING_FIXTURE: WorkdayListingResponse = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "__fixtures__/workday-td-listing.json"),
+    "utf8"
+  )
+);
+const DETAIL_FIXTURE: WorkdayJobDetailResponse = JSON.parse(
+  readFileSync(
+    resolve(__dirname, "__fixtures__/workday-td-detail.json"),
+    "utf8"
+  )
+);
+
+const TD_URLS = buildWorkdayUrls("td", "wd3", "TD_Bank_Careers");
+
+describe("workday-td URL builders", () => {
+  it("targets the TD tenant on wd3 with the TD_Bank_Careers site", () => {
+    expect(TD_URLS.listingPostUrl).toBe(
+      "https://td.wd3.myworkdayjobs.com/wday/cxs/td/TD_Bank_Careers/jobs"
+    );
+  });
+
+  it("builds a public apply URL containing the canonical TD_Bank_Careers segment", () => {
+    expect(
+      TD_URLS.jobPublicUrl("/job/Toronto-Ontario/Senior-Software-Engineer_R-0000123456")
+    ).toBe(
+      "https://td.wd3.myworkdayjobs.com/TD_Bank_Careers/job/Toronto-Ontario/Senior-Software-Engineer_R-0000123456"
+    );
+  });
+});
+
+describe("workday-td listing fixture", () => {
+  it("contains the three reference jobs", () => {
+    expect(LISTING_FIXTURE.jobPostings).toHaveLength(3);
+    expect(LISTING_FIXTURE.total).toBe(3);
+  });
+
+  it("maps the Senior Software Engineer row to a complete JobData", () => {
+    const row = LISTING_FIXTURE.jobPostings![0];
+    const job = parseWorkdayListingRow(row, TD_URLS.jobPublicUrl);
+    expect(job).not.toBeNull();
+    expect(job!.title).toBe("Senior Software Engineer");
+    expect(job!.external_id).toBe("Senior-Software-Engineer_R-0000123456");
+    expect(job!.location).toBe("Toronto, Ontario, Canada");
+    expect(job!.location_type).toBe("onsite");
+    expect(job!.posted_date?.toISOString()).toBe("2026-05-12T00:00:00.000Z");
+    expect(job!.url).toBe(
+      "https://td.wd3.myworkdayjobs.com/TD_Bank_Careers/job/Toronto-Ontario/Senior-Software-Engineer_R-0000123456"
+    );
+    expect(job!.commitment).toBe("full-time");
+  });
+
+  it("infers internship commitment from 'Data Analytics Intern'", () => {
+    const intern = LISTING_FIXTURE.jobPostings![1];
+    const job = parseWorkdayListingRow(intern, TD_URLS.jobPublicUrl);
+    expect(job!.commitment).toBe("internship");
+  });
+
+  it("drops the 'Posted Yesterday' relative date — only ISO/Date-parseable values survive", () => {
+    const intern = LISTING_FIXTURE.jobPostings![1];
+    const job = parseWorkdayListingRow(intern, TD_URLS.jobPublicUrl);
+    expect(job!.posted_date).toBeNull();
+  });
+
+  it("parses an ISO timestamp with time component", () => {
+    const director = LISTING_FIXTURE.jobPostings![2];
+    const job = parseWorkdayListingRow(director, TD_URLS.jobPublicUrl);
+    expect(job!.posted_date?.toISOString()).toBe("2026-05-08T00:00:00.000Z");
+  });
+
+  it("handles a row with no externalPath gracefully (null URL, no external_id)", () => {
+    const partial = parseWorkdayListingRow(
+      { title: "Floating Role", locationsText: "Vancouver, BC" },
+      TD_URLS.jobPublicUrl
+    );
+    expect(partial).not.toBeNull();
+    expect(partial!.url).toBeNull();
+    expect(partial!.external_id).toBe("");
+  });
+});
+
+describe("workday-td detail fixture", () => {
+  it("extracts description_html from jobDescription", () => {
+    const parsed = parseWorkdayJobDetail(DETAIL_FIXTURE);
+    expect(parsed.description_html).toContain("<h2>About this opportunity</h2>");
+    expect(parsed.description_html).toContain("Senior Software Engineer");
+  });
+
+  it("produces a readable description_text via htmlToText", () => {
+    const parsed = parseWorkdayJobDetail(DETAIL_FIXTURE);
+    // html-to-text uppercases h2 headings — match case-insensitively.
+    expect(parsed.description_text.toLowerCase()).toContain("about this opportunity");
+    expect(parsed.description_text).toContain("scalable backend systems");
+    // htmlToText should strip the tags.
+    expect(parsed.description_text).not.toContain("<h2>");
+  });
+
+  it("surfaces location and posted_date from the detail response", () => {
+    const parsed = parseWorkdayJobDetail(DETAIL_FIXTURE);
+    expect(parsed.location).toBe("Toronto, Ontario, Canada");
+    expect(parsed.posted_date?.toISOString()).toBe("2026-05-12T00:00:00.000Z");
+  });
+});

--- a/web/lib/scrapers/workday-td.ts
+++ b/web/lib/scrapers/workday-td.ts
@@ -1,0 +1,150 @@
+/**
+ * TD Bank — Workday tenant scraper.
+ *
+ * Tenant: `td`. Instance: `wd3`. Site: `TD_Bank_Careers`.
+ *
+ * Workday is fetch-based (documented JSON API), but the runtime decides
+ * whether it runs inline on Vercel or offloaded to GitHub Actions via
+ * `scrape-heavy.yml` — the coordinator adds `workday-td` to
+ * `isBrowserScraper`. Either way, no `browser` param needed here.
+ *
+ * Two-step shape:
+ *   1. POST `.../jobs` with `{ limit: 20, offset, searchText: "",
+ *      appliedFacets: {} }` until `offset >= total`.
+ *   2. For each listing row, GET `.../job<externalPath>` and merge the
+ *      `jobDescription` HTML into the JobData.
+ *
+ * Errors bubble up (no in-code retry-with-backoff): the cron retries
+ * tomorrow.
+ *
+ * Cost knob: `WORKDAY_TD_MAX_JOBS` env caps the run. Unset → full corpus.
+ */
+
+import type { JobData } from "./types";
+import { htmlToText } from "./utils";
+import {
+  buildWorkdayUrls,
+  parseWorkdayListingRow,
+  parseWorkdayJobDetail,
+  resolveWorkdayJobCap,
+  type WorkdayListingResponse,
+  type WorkdayJobDetailResponse,
+} from "./workday-utils";
+import { log } from "@/lib/log";
+
+const TENANT = "td";
+const INSTANCE = "wd3";
+const SITE = "TD_Bank_Careers";
+const PAGE_LIMIT = 20;
+const FETCH_TIMEOUT_MS = 15_000;
+
+export async function fetchWorkdayTdJobs(): Promise<JobData[]> {
+  const urls = buildWorkdayUrls(TENANT, INSTANCE, SITE);
+  const cap = resolveWorkdayJobCap(process.env.WORKDAY_TD_MAX_JOBS);
+
+  const jobs: JobData[] = [];
+  let offset = 0;
+  let total: number | null = null;
+
+  // Step 1: paginate the listing.
+  while (true) {
+    const res = await fetch(urls.listingPostUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        limit: PAGE_LIMIT,
+        offset,
+        searchText: "",
+        appliedFacets: {},
+      }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`Workday TD listing error: ${res.status}`);
+    }
+    const data = (await res.json()) as WorkdayListingResponse;
+    const rows = data.jobPostings ?? [];
+    if (rows.length === 0) break;
+    total = data.total ?? total;
+
+    for (const row of rows) {
+      const job = parseWorkdayListingRow(row, urls.jobPublicUrl);
+      if (job) jobs.push(job);
+    }
+
+    offset += rows.length;
+    if (cap != null && jobs.length >= cap) break;
+    if (total != null && offset >= total) break;
+  }
+
+  if (cap != null && jobs.length > cap) jobs.length = cap;
+
+  log.info(
+    { fetched: jobs.length, total, cap: cap ?? "uncapped" },
+    "[workday-td] listings complete; enriching descriptions"
+  );
+
+  // Step 2: enrich each row with the detail response. Sequential because
+  // Workday's surface throttles aggressively on parallel fetches from a
+  // single IP — and the listing alone is enough to populate the dashboard
+  // even if enrichment partially fails.
+  let enriched = 0;
+  let failed = 0;
+  for (const job of jobs) {
+    if (!job.url) continue;
+    // Reconstruct externalPath from the public URL — same as listing row
+    // mapping but in reverse — or fall back to skipping.
+    const externalPath = extractExternalPathFromPublicUrl(job.url);
+    if (!externalPath) continue;
+    try {
+      const detailRes = await fetch(urls.jobGetUrl(externalPath), {
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (!detailRes.ok) {
+        throw new Error(`status ${detailRes.status}`);
+      }
+      const detail = (await detailRes.json()) as WorkdayJobDetailResponse;
+      const parsed = parseWorkdayJobDetail(detail);
+      if (parsed.description_html) {
+        job.description_html = parsed.description_html;
+        job.description_text = parsed.description_text || htmlToText(parsed.description_html);
+      }
+      if (parsed.location && !job.location) job.location = parsed.location;
+      if (parsed.posted_date && !job.posted_date) job.posted_date = parsed.posted_date;
+      enriched++;
+    } catch (e) {
+      failed++;
+      log.warn(
+        {
+          externalId: job.external_id,
+          err: e instanceof Error ? e.message : String(e),
+        },
+        "[workday-td] detail enrichment failed"
+      );
+    }
+  }
+
+  log.info(
+    { enriched, failed, total: jobs.length },
+    "[workday-td] description enrichment complete"
+  );
+
+  return jobs;
+}
+
+/**
+ * Extract the `externalPath` portion from a public Workday URL.
+ * `https://td.wd3.myworkdayjobs.com/TD_Bank_Careers/job/Toronto/X_R-123`
+ *   → `/job/Toronto/X_R-123`
+ */
+function extractExternalPathFromPublicUrl(publicUrl: string): string | null {
+  const marker = `/${SITE}`;
+  const idx = publicUrl.indexOf(marker);
+  if (idx === -1) return null;
+  const tail = publicUrl.slice(idx + marker.length);
+  return tail.startsWith("/") ? tail : null;
+}

--- a/web/lib/scrapers/workday-utils.test.ts
+++ b/web/lib/scrapers/workday-utils.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for the shared Workday helpers.
+ *
+ * Pure-function coverage only — no `fetch` allowed. The HTTP-driven
+ * pieces live in workday-td.ts / workday-cibc.ts and aren't exercised
+ * here.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  buildWorkdayUrls,
+  parseWorkdayListingRow,
+  parseWorkdayJobDetail,
+  resolveWorkdayJobCap,
+  type WorkdayListingRow,
+} from "./workday-utils";
+
+describe("buildWorkdayUrls", () => {
+  it("interpolates tenant, instance, and site into the listing POST URL", () => {
+    const urls = buildWorkdayUrls("td", "wd3", "TD_Bank_Careers");
+    expect(urls.listingPostUrl).toBe(
+      "https://td.wd3.myworkdayjobs.com/wday/cxs/td/TD_Bank_Careers/jobs"
+    );
+  });
+
+  it("produces a detail URL by appending externalPath after the `/job` segment", () => {
+    const urls = buildWorkdayUrls("cibc", "wd3", "search");
+    expect(urls.jobGetUrl("/job/Toronto/Senior-Engineer_R-1")).toBe(
+      "https://cibc.wd3.myworkdayjobs.com/wday/cxs/cibc/search/job/job/Toronto/Senior-Engineer_R-1"
+    );
+  });
+
+  it("produces a public-facing apply URL via jobPublicUrl", () => {
+    const urls = buildWorkdayUrls("td", "wd3", "TD_Bank_Careers");
+    expect(urls.jobPublicUrl("/job/Toronto/X_R-1")).toBe(
+      "https://td.wd3.myworkdayjobs.com/TD_Bank_Careers/job/Toronto/X_R-1"
+    );
+  });
+
+  it("varies by instance (wd1 vs wd3 vs wd5)", () => {
+    expect(buildWorkdayUrls("acme", "wd5", "careers").listingPostUrl).toBe(
+      "https://acme.wd5.myworkdayjobs.com/wday/cxs/acme/careers/jobs"
+    );
+  });
+});
+
+describe("parseWorkdayListingRow", () => {
+  const stubUrl = (p: string) => `https://example.com/site${p}`;
+
+  it("maps a complete row to JobData with title, location, posted_date and URL", () => {
+    const raw: WorkdayListingRow = {
+      title: "Senior Engineer",
+      externalPath: "/job/Toronto/Senior-Engineer_R-123",
+      locationsText: "Toronto, Ontario, Canada",
+      postedOn: "2026-05-12",
+      bulletFields: ["R-123", "Regular"],
+    };
+    const job = parseWorkdayListingRow(raw, stubUrl);
+    expect(job).not.toBeNull();
+    expect(job!.title).toBe("Senior Engineer");
+    expect(job!.external_id).toBe("Senior-Engineer_R-123");
+    expect(job!.location).toBe("Toronto, Ontario, Canada");
+    expect(job!.url).toBe(
+      "https://example.com/site/job/Toronto/Senior-Engineer_R-123"
+    );
+    expect(job!.posted_date?.toISOString()).toBe("2026-05-12T00:00:00.000Z");
+    expect(job!.description_html).toBeNull();
+    expect(job!.description_text).toBeNull();
+  });
+
+  it("synthesizes a URL only when externalPath is present", () => {
+    const job = parseWorkdayListingRow(
+      { title: "X", externalPath: "/job/X_R-1" },
+      stubUrl
+    );
+    expect(job!.url).toBe("https://example.com/site/job/X_R-1");
+
+    const jobNoPath = parseWorkdayListingRow({ title: "Y" }, stubUrl);
+    expect(jobNoPath!.url).toBeNull();
+  });
+
+  it("derives external_id from the last path segment of externalPath", () => {
+    const job = parseWorkdayListingRow(
+      { title: "X", externalPath: "/job/Toronto/Some-Title_R-9999" },
+      stubUrl
+    );
+    expect(job!.external_id).toBe("Some-Title_R-9999");
+  });
+
+  it("returns null when both title and externalPath are missing", () => {
+    expect(parseWorkdayListingRow({}, stubUrl)).toBeNull();
+    expect(parseWorkdayListingRow({ locationsText: "X" }, stubUrl)).toBeNull();
+  });
+
+  it("drops a non-parseable posted_date (e.g. 'Posted Yesterday')", () => {
+    const job = parseWorkdayListingRow(
+      {
+        title: "X",
+        externalPath: "/job/X_R-1",
+        postedOn: "Posted Yesterday",
+      },
+      stubUrl
+    );
+    expect(job!.posted_date).toBeNull();
+  });
+
+  it("infers commitment from title keywords", () => {
+    expect(
+      parseWorkdayListingRow(
+        { title: "Software Intern", externalPath: "/job/X_R-1" },
+        stubUrl
+      )!.commitment
+    ).toBe("internship");
+    expect(
+      parseWorkdayListingRow(
+        { title: "Contract Recruiter", externalPath: "/job/X_R-1" },
+        stubUrl
+      )!.commitment
+    ).toBe("contract");
+    expect(
+      parseWorkdayListingRow(
+        { title: "Part-Time Teller", externalPath: "/job/X_R-1" },
+        stubUrl
+      )!.commitment
+    ).toBe("part-time");
+  });
+
+  it("defaults commitment to full-time when no signal is present", () => {
+    const job = parseWorkdayListingRow(
+      { title: "Senior Engineer", externalPath: "/job/X_R-1" },
+      stubUrl
+    );
+    expect(job!.commitment).toBe("full-time");
+  });
+
+  it("sets location_type from the location string", () => {
+    const remote = parseWorkdayListingRow(
+      { title: "X", externalPath: "/job/X_R-1", locationsText: "Remote, Canada" },
+      stubUrl
+    );
+    expect(remote!.location_type).toBe("remote");
+
+    const onsite = parseWorkdayListingRow(
+      { title: "X", externalPath: "/job/X_R-1", locationsText: "Toronto, ON" },
+      stubUrl
+    );
+    expect(onsite!.location_type).toBe("onsite");
+  });
+});
+
+describe("parseWorkdayJobDetail", () => {
+  it("populates description_html from jobDescription and description_text via htmlToText", () => {
+    const out = parseWorkdayJobDetail({
+      jobPostingInfo: {
+        jobDescription: "<div><p>Hello <strong>world</strong></p></div>",
+      },
+    });
+    expect(out.description_html).toBe("<div><p>Hello <strong>world</strong></p></div>");
+    expect(out.description_text).toMatch(/Hello world/);
+  });
+
+  it("returns empty strings when jobDescription is missing", () => {
+    const out = parseWorkdayJobDetail({ jobPostingInfo: {} });
+    expect(out.description_html).toBe("");
+    expect(out.description_text).toBe("");
+  });
+
+  it("returns empty strings when jobPostingInfo is missing", () => {
+    const out = parseWorkdayJobDetail({});
+    expect(out.description_html).toBe("");
+    expect(out.description_text).toBe("");
+  });
+
+  it("surfaces location when present", () => {
+    const out = parseWorkdayJobDetail({
+      jobPostingInfo: {
+        jobDescription: "<p>x</p>",
+        location: "Toronto, Ontario, Canada",
+      },
+    });
+    expect(out.location).toBe("Toronto, Ontario, Canada");
+  });
+
+  it("parses postedOn into a Date when valid", () => {
+    const out = parseWorkdayJobDetail({
+      jobPostingInfo: { jobDescription: "<p>x</p>", postedOn: "2026-05-12" },
+    });
+    expect(out.posted_date?.toISOString()).toBe("2026-05-12T00:00:00.000Z");
+  });
+});
+
+describe("resolveWorkdayJobCap", () => {
+  it("returns null when unset", () => {
+    expect(resolveWorkdayJobCap(undefined)).toBeNull();
+  });
+
+  it("returns null for an empty string", () => {
+    expect(resolveWorkdayJobCap("")).toBeNull();
+  });
+
+  it("returns null for non-numeric values", () => {
+    expect(resolveWorkdayJobCap("all")).toBeNull();
+    expect(resolveWorkdayJobCap("100x")).toBeNull();
+  });
+
+  it("parses a positive integer", () => {
+    expect(resolveWorkdayJobCap("25")).toBe(25);
+    expect(resolveWorkdayJobCap("1000")).toBe(1000);
+  });
+
+  it("clamps zero up to 1", () => {
+    expect(resolveWorkdayJobCap("0")).toBe(1);
+  });
+});

--- a/web/lib/scrapers/workday-utils.ts
+++ b/web/lib/scrapers/workday-utils.ts
@@ -1,0 +1,225 @@
+/**
+ * Workday-family shared helpers.
+ *
+ * Workday tenants expose a documented JSON API (`/wday/cxs/...`) — no
+ * Puppeteer needed. Two endpoints per tenant:
+ *
+ *   1. Listing (POST `.../jobs`) — paginated by `offset` += 20, returns
+ *      `{ total, jobPostings: [{ title, externalPath, locationsText,
+ *      postedOn, bulletFields }] }`.
+ *
+ *   2. Detail (GET `.../job<externalPath>`) — returns
+ *      `{ jobPostingInfo: { jobDescription /* HTML *\/, location, country,
+ *      postedOn, jobReqId, ... } }`. `externalPath` already starts with `/`.
+ *
+ * Every Workday tenant in the corpus runs on the same surface, so the
+ * three helpers below (URL builder + two pure mappers) are extracted up
+ * front. Per Farhan's call ("guaranteed-shared, duplicating them is
+ * future merge conflict") we do NOT extract a `WorkdayBaseScraper` class
+ * — too premature with two tenants.
+ */
+
+import type { JobData } from "./types";
+import { htmlToText, detectLocationType, normalizeCommitment } from "./utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** One entry from the listing response's `jobPostings[]` array. */
+export interface WorkdayListingRow {
+  title?: string;
+  externalPath?: string;
+  locationsText?: string;
+  postedOn?: string;
+  bulletFields?: string[];
+  // Some tenants surface additional optional metadata (brand, business
+  // unit) inline. We keep the type open via `[k: string]: unknown` so
+  // tenant-specific classifiers (e.g. Simplii) can probe without
+  // re-typing the row.
+  [key: string]: unknown;
+}
+
+export interface WorkdayListingResponse {
+  total?: number;
+  jobPostings?: WorkdayListingRow[];
+}
+
+export interface WorkdayJobDetailResponse {
+  jobPostingInfo?: {
+    jobDescription?: string;
+    location?: string;
+    country?: { descriptor?: string } | string;
+    postedOn?: string;
+    jobReqId?: string;
+    title?: string;
+    externalUrl?: string;
+    timeType?: string;
+    [key: string]: unknown;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the listing POST URL and the per-job detail GET URL builder for a
+ * given Workday tenant. Pure — no HTTP.
+ *
+ * Example: `td` / `wd3` / `TD_Bank_Careers` →
+ *   listingPostUrl = "https://td.wd3.myworkdayjobs.com/wday/cxs/td/TD_Bank_Careers/jobs"
+ *   jobGetUrl("/job/Toronto/Software-Engineer_R-123") =
+ *     "https://td.wd3.myworkdayjobs.com/wday/cxs/td/TD_Bank_Careers/job/Toronto/Software-Engineer_R-123"
+ */
+export function buildWorkdayUrls(
+  tenant: string,
+  instance: string,
+  site: string
+): {
+  listingPostUrl: string;
+  jobGetUrl: (externalPath: string) => string;
+  jobPublicUrl: (externalPath: string) => string;
+} {
+  const base = `https://${tenant}.${instance}.myworkdayjobs.com`;
+  const cxs = `${base}/wday/cxs/${tenant}/${site}`;
+  return {
+    listingPostUrl: `${cxs}/jobs`,
+    jobGetUrl: (externalPath: string) => `${cxs}/job${externalPath}`,
+    // Public-facing apply URL (the one we store on JobData.url).
+    jobPublicUrl: (externalPath: string) => `${base}/${site}${externalPath}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure mappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map one listing row to a `JobData` (without description — the detail
+ * endpoint owns that and the result is merged downstream). Pure.
+ *
+ * `urlBuilder` is passed in so the same mapper works for every Workday
+ * tenant.
+ *
+ * Returns `null` if the row is missing both `externalPath` and `title`
+ * (nothing we can do with it).
+ */
+export function parseWorkdayListingRow(
+  raw: WorkdayListingRow,
+  urlBuilder: (externalPath: string) => string
+): JobData | null {
+  const title = raw.title?.trim() || "";
+  const externalPath = raw.externalPath?.trim() || "";
+  if (!title && !externalPath) return null;
+
+  // `externalPath` is the canonical id we have access to at listing time.
+  // Strip the leading `/job/<tenant>/` if present so the id is stable
+  // across URL-format changes; fall back to the full path otherwise.
+  // Example: "/job/MONTRAL/Senior-Engineer_R-12345" → "Senior-Engineer_R-12345"
+  const externalId = externalPath
+    ? externalPath.split("/").filter(Boolean).pop() || externalPath
+    : "";
+
+  const location = raw.locationsText?.trim() || null;
+
+  let postedDate: Date | null = null;
+  if (raw.postedOn) {
+    // Workday emits a variety of strings here. ISO and "Posted Yesterday"
+    // style both appear. We only parse ISO/Date-parseable values; relative
+    // strings get dropped to null and the detail endpoint can fill in.
+    const parsed = new Date(raw.postedOn);
+    if (!isNaN(parsed.getTime())) postedDate = parsed;
+  }
+
+  // `bulletFields` is Workday's catch-all for unstructured metadata —
+  // often holds the brand name (for CIBC → Simplii). We don't interpret
+  // it here; tenant-specific classifiers do.
+  const bullets = Array.isArray(raw.bulletFields) ? raw.bulletFields : [];
+
+  let commitment: string | null = "full-time";
+  const titleLower = title.toLowerCase();
+  if (/intern/.test(titleLower)) commitment = "internship";
+  else if (/contract/.test(titleLower)) commitment = "contract";
+  else if (/part-time|part time/.test(titleLower)) commitment = "part-time";
+  // Workday sometimes encodes employment type in bulletFields ("Regular",
+  // "Temporary"). Try normalizeCommitment on each as a soft signal.
+  for (const b of bullets) {
+    if (typeof b !== "string") continue;
+    const normalized = normalizeCommitment(b);
+    if (normalized && /contract|part|intern/.test(normalized)) {
+      commitment = normalized;
+      break;
+    }
+  }
+
+  return {
+    external_id: externalId,
+    title,
+    department: null,
+    team: null,
+    location,
+    location_type: location ? detectLocationType(location, "") : null,
+    description_html: null,
+    description_text: null,
+    commitment,
+    posted_date: postedDate,
+    url: externalPath ? urlBuilder(externalPath) : null,
+  };
+}
+
+/**
+ * Map a Workday detail response to the fields the description-enrichment
+ * step needs. Pure.
+ *
+ * `jobDescription` is HTML; we keep both the raw HTML and a text
+ * conversion so downstream consumers (hash gate, AI extractor) can
+ * choose.
+ */
+export function parseWorkdayJobDetail(raw: WorkdayJobDetailResponse): {
+  description_html: string;
+  description_text: string;
+  location?: string;
+  posted_date?: Date | null;
+} {
+  const info = raw.jobPostingInfo ?? {};
+  const descriptionHtml = typeof info.jobDescription === "string" ? info.jobDescription : "";
+
+  let location: string | undefined;
+  if (typeof info.location === "string" && info.location.trim()) {
+    location = info.location.trim();
+  }
+
+  let postedDate: Date | null | undefined;
+  if (info.postedOn) {
+    const parsed = new Date(info.postedOn);
+    if (!isNaN(parsed.getTime())) postedDate = parsed;
+  }
+
+  return {
+    description_html: descriptionHtml,
+    description_text: htmlToText(descriptionHtml),
+    location,
+    posted_date: postedDate,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Job cap
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve an optional per-run cap from an env var. Same semantics as
+ * `resolveJobCap` in phenom-rbc.ts:
+ *   - unset / non-numeric → null → process entire corpus
+ *   - positive integer → cap (smoke tests, cost ceilings)
+ *   - 0 → 1 (a zero cap is a useless run)
+ *
+ * Exported so workday-td/workday-cibc share one definition.
+ */
+export function resolveWorkdayJobCap(rawEnv: string | undefined): number | null {
+  if (rawEnv && /^\d+$/.test(rawEnv)) {
+    return Math.max(1, parseInt(rawEnv, 10));
+  }
+  return null;
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/scripts/calibrate-incumbent-gate.test.ts
+++ b/web/scripts/calibrate-incumbent-gate.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the pure helpers inside `calibrate-incumbent-gate.ts`.
+ *
+ * The script itself is a one-shot read-only audit and is not exercised end-
+ * to-end here (it talks to a live Supabase). What we DO want regression
+ * coverage on:
+ *   - `passesWhitelist` — the simulation primitive. If this drifts from the
+ *     production gate's logic, every reported pass rate is meaningless.
+ *   - `distribute` — the small reduction we use for seniority/function
+ *     percentages. Null bucketing matters because incumbent rows can be
+ *     missing structured extraction.
+ *   - `passRateByKey` — per-bank and per-company breakdowns rely on this.
+ *   - `buildCandidateWhitelists` — verifies the FIRST entry matches the
+ *     live production whitelist exactly, so the report's "current" column
+ *     can never silently drift from reality.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  passesWhitelist,
+  distribute,
+  passRateByKey,
+  buildCandidateWhitelists,
+  type JobRow,
+} from "./calibrate-incumbent-gate";
+import {
+  INCUMBENT_SIGNAL_FUNCTION_CATEGORIES,
+  INCUMBENT_SIGNAL_SENIORITY,
+} from "@/lib/analysis/incumbent-signal";
+
+function job(overrides: Partial<JobRow>): JobRow {
+  return {
+    id: overrides.id ?? "j1",
+    title: overrides.title ?? "Job",
+    seniority_level: overrides.seniority_level ?? null,
+    function_category: overrides.function_category ?? null,
+    company_id: overrides.company_id ?? "c1",
+  };
+}
+
+describe("passesWhitelist", () => {
+  const wl = {
+    name: "test",
+    description: "test",
+    seniorities: ["staff", "principal"] as const,
+    functions: ["engineering-ai-ml", "data-science"] as const,
+  };
+
+  it("passes when both seniority and function are whitelisted", () => {
+    expect(
+      passesWhitelist(
+        job({ seniority_level: "staff", function_category: "engineering-ai-ml" }),
+        wl
+      )
+    ).toBe(true);
+  });
+
+  it("fails when seniority is below the bar even if function matches", () => {
+    expect(
+      passesWhitelist(
+        job({ seniority_level: "senior", function_category: "engineering-ai-ml" }),
+        wl
+      )
+    ).toBe(false);
+  });
+
+  it("fails when function is not whitelisted even if seniority matches", () => {
+    expect(
+      passesWhitelist(
+        job({ seniority_level: "staff", function_category: "engineering-backend" }),
+        wl
+      )
+    ).toBe(false);
+  });
+
+  it("fails when either field is null — mirrors the production gate's missing-structure rule", () => {
+    expect(
+      passesWhitelist(
+        job({ seniority_level: null, function_category: "engineering-ai-ml" }),
+        wl
+      )
+    ).toBe(false);
+    expect(
+      passesWhitelist(
+        job({ seniority_level: "staff", function_category: null }),
+        wl
+      )
+    ).toBe(false);
+  });
+});
+
+describe("distribute", () => {
+  it("counts every value and reports a percent that sums to ~100", () => {
+    const rows = [
+      job({ seniority_level: "senior" }),
+      job({ seniority_level: "senior" }),
+      job({ seniority_level: "staff" }),
+      job({ seniority_level: "junior" }),
+    ];
+    const out = distribute(rows, "seniority_level");
+    const total = out.reduce((s, r) => s + r.percent, 0);
+    expect(total).toBeCloseTo(100, 1);
+    const seniorRow = out.find((r) => r.value === "senior");
+    expect(seniorRow?.count).toBe(2);
+    expect(seniorRow?.percent).toBe(50);
+  });
+
+  it("buckets null values explicitly as '(null)' — needed for unclassified incumbents", () => {
+    const rows = [
+      job({ seniority_level: null }),
+      job({ seniority_level: null }),
+      job({ seniority_level: "staff" }),
+    ];
+    const out = distribute(rows, "seniority_level");
+    const nullRow = out.find((r) => r.value === "(null)");
+    expect(nullRow?.count).toBe(2);
+  });
+
+  it("returns rows sorted descending by count (highest-impact bucket first)", () => {
+    const rows = [
+      job({ function_category: "a" }),
+      job({ function_category: "b" }),
+      job({ function_category: "b" }),
+      job({ function_category: "b" }),
+      job({ function_category: "c" }),
+      job({ function_category: "c" }),
+    ];
+    const out = distribute(rows, "function_category");
+    expect(out.map((r) => r.value)).toEqual(["b", "c", "a"]);
+  });
+
+  it("handles an empty input without dividing by zero", () => {
+    expect(distribute([] as JobRow[], "seniority_level")).toEqual([]);
+  });
+});
+
+describe("passRateByKey", () => {
+  const wl = {
+    name: "test",
+    description: "",
+    seniorities: ["staff"] as const,
+    functions: ["engineering-ai-ml"] as const,
+  };
+
+  it("aggregates total/passed/rate per key with 2-decimal percent", () => {
+    const rows = [
+      job({
+        company_id: "rbc",
+        seniority_level: "staff",
+        function_category: "engineering-ai-ml",
+      }),
+      job({
+        company_id: "rbc",
+        seniority_level: "senior",
+        function_category: "engineering-ai-ml",
+      }),
+      job({
+        company_id: "td",
+        seniority_level: "junior",
+        function_category: "engineering-backend",
+      }),
+    ];
+    const out = passRateByKey(rows, wl, (r) => r.company_id);
+    const rbc = out.find((r) => r.key === "rbc");
+    const td = out.find((r) => r.key === "td");
+    expect(rbc?.total).toBe(2);
+    expect(rbc?.passed).toBe(1);
+    expect(rbc?.rate).toBe(50);
+    expect(td?.total).toBe(1);
+    expect(td?.passed).toBe(0);
+    expect(td?.rate).toBe(0);
+  });
+});
+
+describe("buildCandidateWhitelists", () => {
+  it("first entry is the live production gate — preventing silent drift", () => {
+    const list = buildCandidateWhitelists();
+    expect(list[0].name).toContain("current");
+    expect([...list[0].seniorities]).toEqual([...INCUMBENT_SIGNAL_SENIORITY]);
+    expect([...list[0].functions]).toEqual([
+      ...INCUMBENT_SIGNAL_FUNCTION_CATEGORIES,
+    ]);
+  });
+
+  it("includes a +senior probe so we can quantify the impact of lowering the bar", () => {
+    const list = buildCandidateWhitelists();
+    const plusSenior = list.find((w) => w.name === "+senior");
+    expect(plusSenior).toBeDefined();
+    expect(plusSenior?.seniorities).toContain("senior");
+  });
+
+  it("includes a -aml-financial-crime probe so we can quantify dropping a noisy function", () => {
+    const list = buildCandidateWhitelists();
+    const noAml = list.find((w) => w.name === "-aml-financial-crime");
+    expect(noAml).toBeDefined();
+    expect(noAml?.functions).not.toContain("aml-financial-crime");
+  });
+
+  it("includes a +product-management probe so we can score adding the category at the staff+ bar", () => {
+    const list = buildCandidateWhitelists();
+    const plusPm = list.find((w) => w.name.includes("product-management"));
+    expect(plusPm).toBeDefined();
+    expect(plusPm?.functions).toContain("product-management");
+  });
+});

--- a/web/scripts/calibrate-incumbent-gate.ts
+++ b/web/scripts/calibrate-incumbent-gate.ts
@@ -1,0 +1,448 @@
+/**
+ * Cost-gate calibration: read-only audit of the Phase-3 incumbent ramp.
+ *
+ * After the incumbent ramp we have ~7,500 tier='incumbent' job_postings.
+ * The production gate (web/lib/jobs/incumbent-cost-gate.ts + the shared
+ * web/lib/analysis/incumbent-signal.ts) only sends staff+ in AI/ML / Data /
+ * Risk-AI through the Pro+grounded analyzer. Early RBC numbers showed
+ * ~1/50 = 2% pass rate — likely tighter than ideal because the structured
+ * extraction enum has no "director"/"vp" literal so those titles get
+ * bucketed to other seniority values.
+ *
+ * This script answers, against live data:
+ *   - What fraction of active incumbent rows passes the CURRENT whitelist?
+ *   - How does the pass rate move under reasonable alternative whitelists
+ *     (e.g. +senior, +product-management at staff+, −aml-financial-crime)?
+ *   - Which "near-miss" titles are senior in a whitelisted function — the
+ *     borderline staff-vs-senior calls worth a human review?
+ *   - How does pass rate vary per bank, so a single weak ATS doesn't pull
+ *     the global number down?
+ *
+ * Read-only. No DB writes, no Gemini calls. Outputs a Markdown report to
+ * stdout AND a JSON artifact under `web/scripts/artifacts/`.
+ *
+ * Usage:
+ *   cd web
+ *   npx tsx --env-file=.env.local scripts/calibrate-incumbent-gate.ts
+ */
+
+import { execSync } from "child_process";
+import { mkdir, writeFile } from "fs/promises";
+import { resolve } from "path";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  INCUMBENT_SIGNAL_FUNCTION_CATEGORIES,
+  INCUMBENT_SIGNAL_SENIORITY,
+} from "@/lib/analysis/incumbent-signal";
+
+// ---------------------------------------------------------------------------
+// Pure helpers — extracted so they can be unit-tested without a live DB.
+// ---------------------------------------------------------------------------
+
+export interface JobRow {
+  id: string;
+  title: string | null;
+  seniority_level: string | null;
+  function_category: string | null;
+  company_id: string;
+}
+
+export interface Whitelist {
+  name: string;
+  description: string;
+  seniorities: readonly string[];
+  functions: readonly string[];
+}
+
+/** Does this job pass the given whitelist (both seniority and function)? */
+export function passesWhitelist(job: JobRow, list: Whitelist): boolean {
+  if (!job.seniority_level || !job.function_category) return false;
+  return (
+    list.seniorities.includes(job.seniority_level) &&
+    list.functions.includes(job.function_category)
+  );
+}
+
+/** Distribution: { value -> count, percent } over `rows`, including nulls. */
+export function distribute<T, K extends keyof T>(
+  rows: T[],
+  key: K
+): Array<{ value: string; count: number; percent: number }> {
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    const raw = row[key];
+    const v = raw === null || raw === undefined ? "(null)" : String(raw);
+    counts.set(v, (counts.get(v) ?? 0) + 1);
+  }
+  const total = rows.length || 1;
+  return Array.from(counts.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([value, count]) => ({
+      value,
+      count,
+      percent: Number(((count / total) * 100).toFixed(2)),
+    }));
+}
+
+/** Per-key pass-rate breakdown across a whitelist. */
+export function passRateByKey<T extends JobRow>(
+  rows: T[],
+  list: Whitelist,
+  keyFn: (row: T) => string
+): Array<{ key: string; total: number; passed: number; rate: number }> {
+  const buckets = new Map<string, { total: number; passed: number }>();
+  for (const row of rows) {
+    const k = keyFn(row);
+    const b = buckets.get(k) ?? { total: 0, passed: 0 };
+    b.total += 1;
+    if (passesWhitelist(row, list)) b.passed += 1;
+    buckets.set(k, b);
+  }
+  return Array.from(buckets.entries())
+    .sort((a, b) => b[1].total - a[1].total)
+    .map(([key, v]) => ({
+      key,
+      total: v.total,
+      passed: v.passed,
+      rate: Number(((v.passed / Math.max(v.total, 1)) * 100).toFixed(2)),
+    }));
+}
+
+/**
+ * Define the candidate whitelists we want to compare. The first entry IS
+ * the production gate (mirrors `incumbent-signal.ts`). Subsequent entries
+ * are calibration probes.
+ */
+export function buildCandidateWhitelists(): Whitelist[] {
+  const baseSen = [...INCUMBENT_SIGNAL_SENIORITY];
+  const baseFn = [...INCUMBENT_SIGNAL_FUNCTION_CATEGORIES];
+
+  return [
+    {
+      name: "current (production)",
+      description:
+        "staff+ seniority in AI/ML / Data / Risk-AI — the live cost gate",
+      seniorities: baseSen,
+      functions: baseFn,
+    },
+    {
+      name: "+senior",
+      description:
+        "include `senior` seniority; captures titles that the structured-extraction enum buckets just below staff",
+      seniorities: [...baseSen, "senior"],
+      functions: baseFn,
+    },
+    {
+      name: "-aml-financial-crime",
+      description:
+        "drop the AML/financial-crime function in case it's noisy in incumbents",
+      seniorities: baseSen,
+      functions: baseFn.filter((f) => f !== "aml-financial-crime"),
+    },
+    {
+      name: "+product-management at staff+",
+      description:
+        "add product-management at the current staff+ bar; captures product hires that drive capability roadmaps",
+      seniorities: baseSen,
+      functions: [...baseFn, "product-management"],
+    },
+    {
+      name: "+senior +product-management",
+      description: "combined widening: senior+ AND product-management added",
+      seniorities: [...baseSen, "senior"],
+      functions: [...baseFn, "product-management"],
+    },
+    {
+      name: "+engineering-platform-sre-devops at staff+",
+      description:
+        "include platform/SRE/DevOps staff+ — high-leverage infrastructure hires at incumbents",
+      seniorities: baseSen,
+      functions: [...baseFn, "engineering-platform-sre-devops"],
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// I/O + report — only the main entrypoint touches DB/file system.
+// ---------------------------------------------------------------------------
+
+function gitSha(): string {
+  try {
+    return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
+  } catch {
+    return "unknown";
+  }
+}
+
+interface CompanyRow {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+async function main() {
+  const supabase = createAdminClient();
+
+  // 1. Fetch incumbent companies (live + paused — we want the full universe
+  //    so the per-company breakdown shows zero-volume banks too).
+  const { data: companies, error: companiesError } = await supabase
+    .from("companies")
+    .select("id, name, slug")
+    .eq("tier", "incumbent");
+
+  if (companiesError) {
+    console.error("Failed to fetch companies:", companiesError.message);
+    process.exit(1);
+  }
+
+  const companyMap = new Map<string, CompanyRow>(
+    (companies ?? []).map((c) => [c.id, c as CompanyRow])
+  );
+
+  // 2. Fetch active incumbent job postings. ~7,500 rows at steady state —
+  //    well within a single round-trip (Supabase default page size is 1000,
+  //    so we paginate defensively).
+  const all: JobRow[] = [];
+  const PAGE = 1000;
+  let from = 0;
+  // Hard ceiling guards against an unbounded loop on a misbehaving server.
+  const HARD_CEILING = 50000;
+  while (from < HARD_CEILING) {
+    const { data, error } = await supabase
+      .from("job_postings")
+      .select(
+        "id, title, seniority_level, function_category, company_id, companies!inner(tier)"
+      )
+      .eq("companies.tier", "incumbent")
+      .eq("is_active", true)
+      .range(from, from + PAGE - 1);
+
+    if (error) {
+      console.error("Failed to fetch job_postings:", error.message);
+      process.exit(1);
+    }
+    if (!data || data.length === 0) break;
+    for (const row of data) {
+      all.push({
+        id: row.id,
+        title: row.title ?? null,
+        seniority_level: row.seniority_level ?? null,
+        function_category: row.function_category ?? null,
+        company_id: row.company_id,
+      });
+    }
+    if (data.length < PAGE) break;
+    from += PAGE;
+  }
+
+  // 3. Distributions.
+  const seniorityDist = distribute(all, "seniority_level");
+  const functionDistAll = distribute(all, "function_category");
+
+  const staffPlus = (INCUMBENT_SIGNAL_SENIORITY as readonly string[]);
+  const staffPlusRows = all.filter(
+    (r) => r.seniority_level && staffPlus.includes(r.seniority_level)
+  );
+  const functionDistStaffPlus = distribute(staffPlusRows, "function_category");
+
+  // 4. Per-company corpus counts.
+  const perCompanyCounts = passRateByKey(
+    all,
+    buildCandidateWhitelists()[0],
+    (r) => companyMap.get(r.company_id)?.name ?? "(unknown)"
+  );
+
+  // 5. Pass-rate simulations.
+  const whitelists = buildCandidateWhitelists();
+  const simulations = whitelists.map((wl) => {
+    const passed = all.filter((r) => passesWhitelist(r, wl)).length;
+    return {
+      name: wl.name,
+      description: wl.description,
+      seniorities: [...wl.seniorities],
+      functions: [...wl.functions],
+      total: all.length,
+      passed,
+      rate: Number(((passed / Math.max(all.length, 1)) * 100).toFixed(2)),
+    };
+  });
+
+  // 6. Per-bank pass rate under the CURRENT whitelist (the production gate).
+  const perBank = passRateByKey(
+    all,
+    whitelists[0],
+    (r) => companyMap.get(r.company_id)?.name ?? "(unknown)"
+  );
+
+  // 7. Near-miss titles: senior in a whitelisted function (would pass under
+  //    "+senior"). These are the borderline staff-vs-senior calls.
+  const whitelistedFns = new Set<string>(
+    INCUMBENT_SIGNAL_FUNCTION_CATEGORIES as readonly string[]
+  );
+  const nearMisses = all
+    .filter(
+      (r) =>
+        r.seniority_level === "senior" &&
+        r.function_category != null &&
+        whitelistedFns.has(r.function_category)
+    )
+    .slice() // copy before sort
+    .sort((a, b) => (a.title ?? "").localeCompare(b.title ?? ""))
+    .slice(0, 20)
+    .map((r) => ({
+      title: r.title,
+      company: companyMap.get(r.company_id)?.name ?? "(unknown)",
+      seniority: r.seniority_level,
+      function_category: r.function_category,
+    }));
+
+  // 8. Emit JSON artifact.
+  const sha = gitSha();
+  const artifact = {
+    scenario: "calibrate-incumbent-gate",
+    generatedAt: new Date().toISOString(),
+    gitSha: sha,
+    totals: {
+      incumbentCompanies: companyMap.size,
+      activeIncumbentJobs: all.length,
+    },
+    perCompanyCounts,
+    seniorityDistribution: seniorityDist,
+    functionDistributionAll: functionDistAll,
+    functionDistributionStaffPlus: functionDistStaffPlus,
+    simulations,
+    perBank,
+    nearMisses,
+  };
+
+  const outDir = resolve(process.cwd(), "scripts/artifacts");
+  await mkdir(outDir, { recursive: true });
+  const outPath = resolve(outDir, `calibrate-incumbent-gate-${sha}.json`);
+  await writeFile(outPath, JSON.stringify(artifact, null, 2));
+
+  // 9. Markdown to stdout.
+  const lines: string[] = [];
+  lines.push(`# calibrate-incumbent-gate`);
+  lines.push("");
+  lines.push(`- git sha: \`${sha}\``);
+  lines.push(`- generated at: ${artifact.generatedAt}`);
+  lines.push(`- incumbent companies (any state): ${companyMap.size}`);
+  lines.push(`- active incumbent job_postings: ${all.length}`);
+  lines.push("");
+
+  lines.push(`## Per-company active counts`);
+  lines.push("");
+  lines.push(`| Company | Active jobs | Passing (current gate) | Pass rate |`);
+  lines.push(`|---|---:|---:|---:|`);
+  for (const row of perCompanyCounts) {
+    lines.push(
+      `| ${row.key} | ${row.total} | ${row.passed} | ${row.rate.toFixed(2)}% |`
+    );
+  }
+  lines.push("");
+
+  lines.push(`## Seniority distribution (active incumbents)`);
+  lines.push("");
+  lines.push(`| Seniority | Count | % |`);
+  lines.push(`|---|---:|---:|`);
+  for (const row of seniorityDist) {
+    lines.push(
+      `| \`${row.value}\` | ${row.count} | ${row.percent.toFixed(2)}% |`
+    );
+  }
+  lines.push("");
+
+  lines.push(`## Function-category distribution`);
+  lines.push("");
+  lines.push(`### Across the full corpus`);
+  lines.push("");
+  lines.push(`| Function | Count | % |`);
+  lines.push(`|---|---:|---:|`);
+  for (const row of functionDistAll) {
+    lines.push(
+      `| \`${row.value}\` | ${row.count} | ${row.percent.toFixed(2)}% |`
+    );
+  }
+  lines.push("");
+  lines.push(`### Restricted to staff+ seniority`);
+  lines.push("");
+  lines.push(
+    `Of ${staffPlusRows.length} staff+ incumbent postings (${(
+      (staffPlusRows.length / Math.max(all.length, 1)) *
+      100
+    ).toFixed(2)}% of corpus):`
+  );
+  lines.push("");
+  lines.push(`| Function | Count | % of staff+ |`);
+  lines.push(`|---|---:|---:|`);
+  for (const row of functionDistStaffPlus) {
+    lines.push(
+      `| \`${row.value}\` | ${row.count} | ${row.percent.toFixed(2)}% |`
+    );
+  }
+  lines.push("");
+
+  lines.push(`## Simulated pass rates`);
+  lines.push("");
+  lines.push(
+    `Pass rate = fraction of ${all.length} active incumbent rows that the candidate whitelist would route to \`analyzeJobAdvanced\` (the Pro+grounded call).`
+  );
+  lines.push("");
+  lines.push(`| Whitelist | Description | Passing | Rate |`);
+  lines.push(`|---|---|---:|---:|`);
+  for (const sim of simulations) {
+    lines.push(
+      `| **${sim.name}** | ${sim.description} | ${sim.passed} | ${sim.rate.toFixed(2)}% |`
+    );
+  }
+  lines.push("");
+
+  lines.push(`## Per-bank pass rate (current whitelist)`);
+  lines.push("");
+  lines.push(`| Bank | Active jobs | Passing | Rate |`);
+  lines.push(`|---|---:|---:|---:|`);
+  for (const row of perBank) {
+    lines.push(
+      `| ${row.key} | ${row.total} | ${row.passed} | ${row.rate.toFixed(2)}% |`
+    );
+  }
+  lines.push("");
+
+  lines.push(`## Near-miss titles (senior + whitelisted function)`);
+  lines.push("");
+  lines.push(
+    `Up to 20 jobs where the function IS whitelisted but the seniority is \`senior\` (one notch below the production bar). These are the borderline staff-vs-senior calls — a quick visual scan tells us whether the structured-extraction enum is mis-bucketing director/VP/principal titles.`
+  );
+  lines.push("");
+  lines.push(`| Title | Company | Seniority | Function |`);
+  lines.push(`|---|---|---|---|`);
+  for (const row of nearMisses) {
+    lines.push(
+      `| ${row.title ?? "(no title)"} | ${row.company} | \`${row.seniority}\` | \`${row.function_category}\` |`
+    );
+  }
+  if (nearMisses.length === 0) {
+    lines.push(`| _(no senior + whitelisted-function rows)_ | | | |`);
+  }
+  lines.push("");
+
+  lines.push(`---`);
+  lines.push(`artifact: ${outPath}`);
+
+  console.log(lines.join("\n"));
+}
+
+// Only run when invoked directly via `npx tsx scripts/calibrate-incumbent-gate.ts`.
+// The guard exists so tests can import the pure helpers without spinning
+// up a Supabase client at module-load time.
+const isDirectInvocation =
+  typeof process !== "undefined" &&
+  Array.isArray(process.argv) &&
+  process.argv[1]?.endsWith("calibrate-incumbent-gate.ts");
+
+if (isDirectInvocation) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/web/scripts/seed-phase3-banks.ts
+++ b/web/scripts/seed-phase3-banks.ts
@@ -1,0 +1,139 @@
+/**
+ * One-off Phase 3 seed: insert the 4 new incumbent bank rows into the
+ * `companies` table. The Supabase MCP is currently disconnected, so this
+ * script is the substitute path that runs locally with the service-role
+ * key in .env.local.
+ *
+ * Usage (from `web/`):
+ *   npx tsx --env-file=.env.local scripts/seed-phase3-banks.ts
+ *
+ * Idempotent: each row uses `upsert(..., { onConflict: '...' })` so
+ * re-runs are safe. is_active stays false on first insert — flip it after
+ * smoke + 24h of clean job_runs entries.
+ *
+ * NOTE: There is intentionally NO `simplii` row in this seed. Phase 3
+ * ships the Simplii classifier in LOG-ONLY mode (see workday-cibc.ts).
+ * Once production logs confirm Simplii postings actually surface inside
+ * CIBC's Workday tenant, a follow-up adds the row + flips the classifier
+ * to route via `companySlugOverride`.
+ */
+
+import { createAdminClient } from "@/lib/supabase/admin";
+
+interface IncumbentBankSeed {
+  name: string;
+  slug: string;
+  country: string;
+  ats_type: string;
+  ats_identifier: string;
+  careers_url: string;
+}
+
+const BANKS: IncumbentBankSeed[] = [
+  {
+    name: "BMO",
+    slug: "bmo",
+    country: "CA",
+    ats_type: "phenom",
+    ats_identifier: "bmo",
+    careers_url: "https://jobs.bmo.com/ca/en/search-results",
+  },
+  {
+    name: "TD",
+    slug: "td",
+    country: "CA",
+    ats_type: "workday-td",
+    ats_identifier: "td",
+    careers_url:
+      "https://td.wd3.myworkdayjobs.com/en-US/TD_Bank_Careers",
+  },
+  {
+    name: "CIBC",
+    slug: "cibc",
+    country: "CA",
+    ats_type: "workday-cibc",
+    ats_identifier: "cibc",
+    careers_url: "https://cibc.wd3.myworkdayjobs.com/search",
+  },
+  {
+    name: "National Bank",
+    slug: "bnc",
+    country: "CA",
+    ats_type: "phenom",
+    ats_identifier: "bnc",
+    careers_url: "https://emplois.bnc.ca/fr_CA/careers/searchjobs",
+  },
+];
+
+async function main(): Promise<void> {
+  const supabase = createAdminClient();
+
+  // The companies table is org-scoped. Use the same default org RBC uses.
+  const { data: org, error: orgErr } = await supabase
+    .from("organizations")
+    .select("id")
+    .eq("slug", "default")
+    .single();
+  if (orgErr || !org) {
+    throw new Error(
+      `[seed-phase3] default organization not found: ${orgErr?.message ?? "no row"}`
+    );
+  }
+
+  for (const bank of BANKS) {
+    const row = {
+      organization_id: org.id,
+      name: bank.name,
+      slug: bank.slug,
+      country: bank.country,
+      ats_type: bank.ats_type,
+      ats_identifier: bank.ats_identifier,
+      careers_url: bank.careers_url,
+      is_active: false,
+      tier: "incumbent" as const,
+    };
+
+    const { error: upsertErr } = await supabase
+      .from("companies")
+      .upsert(row, { onConflict: "organization_id,slug" });
+    if (upsertErr) {
+      throw new Error(
+        `[seed-phase3] upsert failed for ${bank.slug}: ${upsertErr.message}`
+      );
+    }
+    console.log(`[seed-phase3] upserted ${bank.slug} (${bank.name})`);
+  }
+
+  // Tier-integrity assert (Luke's blocker #7). If any of the 4 came back
+  // with the default 'fintech' tier — e.g. an older row already existed
+  // with that value and upsert didn't overwrite it — fail loudly. A bank
+  // silently in the fintech tier would leak straight into every aggregator
+  // the Phase 0/Step-1 work was supposed to protect.
+  const { data: verify, error: verifyErr } = await supabase
+    .from("companies")
+    .select("slug, tier, is_active, ats_type")
+    .in(
+      "slug",
+      BANKS.map((b) => b.slug)
+    );
+  if (verifyErr || !verify) {
+    throw new Error(
+      `[seed-phase3] verification query failed: ${verifyErr?.message ?? "no rows"}`
+    );
+  }
+  const mis = verify.filter((r) => r.tier !== "incumbent");
+  if (mis.length > 0) {
+    throw new Error(
+      `[seed-phase3] tier integrity violated — these rows are not 'incumbent': ${mis
+        .map((r) => `${r.slug}=${r.tier}`)
+        .join(", ")}`
+    );
+  }
+  console.log(`[seed-phase3] tier integrity ok — 4/4 rows confirmed 'incumbent'`);
+  console.log(`[seed-phase3] all is_active=false; flip after smoke.`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/web/supabase/migrations/20260522000000_phase3_indexes.sql
+++ b/web/supabase/migrations/20260522000000_phase3_indexes.sql
@@ -1,0 +1,31 @@
+-- Phase 3 indexes — pre-empt the query-plan degradation Luke flagged
+-- ahead of the Big-6 bank ramp (~7,500 active job_postings rows + the new
+-- "Incumbent Bets" dashboard rail that calls getIncumbentBets() on every
+-- page load).
+--
+-- 1. Composite, partial index on the per-company windowed query shape.
+--    Covers getIncumbentBets (both the signal-window query and the
+--    company-detail panel scope) plus the per-company sparkline / hiring-
+--    delta / pivot-classification queries that all share the same access
+--    pattern: WHERE company_id = ? AND is_active = TRUE AND first_seen_date
+--    >= ?. DESC matches the read order — newest first.
+--
+-- 2. Partial, single-column index on companies.tier among active rows.
+--    Every tier-aware aggregator (dashboard KPIs, competitive matrix, hot
+--    roles, weekly digest, themes) joins companies!inner with
+--    .eq("companies.is_active", true) and .in/eq("companies.tier", ...).
+--    A partial index keyed on tier among the active-only set lets the
+--    planner skip the redundant filter step.
+
+CREATE INDEX IF NOT EXISTS idx_job_postings_company_active_first_seen
+  ON job_postings (company_id, first_seen_date DESC)
+  WHERE is_active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_companies_tier_active
+  ON companies (tier)
+  WHERE is_active = TRUE;
+
+COMMENT ON INDEX idx_job_postings_company_active_first_seen IS
+  'Per-company windowed query path: getIncumbentBets, getCompanyHiringSparkline, getCompanyHiringDelta, classifyCompanyPivot.';
+COMMENT ON INDEX idx_companies_tier_active IS
+  'Phase 0 tier filter on active companies — joined by every cross-company aggregator.';


### PR DESCRIPTION
## Summary
Phase 3 — scales the incumbent lens from RBC alone to all five Big-6 Canadian banks; adds the cost-gate calibration script and the partial-corpus scraper-break canary. Plan reviewed by **Luke** (architecture/perf) and **Farhan** (code quality) before build; all their blockers landed.

### Streams
- **Stream P** (Phenom-family, mirrors the proven `phenom-rbc.ts` pattern):
  - `web/lib/scrapers/phenom-bmo.ts` — BMO
  - `web/lib/scrapers/phenom-bnc.ts` — National Bank (white-labelled `emplois.bnc.ca`)
- **Stream W** (Workday-family, HTTP-based but **offloaded to GH Actions** per Luke):
  - `web/lib/scrapers/workday-utils.ts` — pure shared helpers from day one (no base class — fork-per-tenant)
  - `web/lib/scrapers/workday-td.ts` — TD
  - `web/lib/scrapers/workday-cibc.ts` — CIBC, with `isSimpliiPosting` classifier in **log-only mode** (no `companySlugOverride` until production logs confirm Simplii postings actually surface — dodges the `closed_date` flap risk Farhan flagged)
- **Stream O** — observability:
  - `web/scripts/calibrate-incumbent-gate.ts` — read-only report on the incumbent corpus + simulated pass rates under candidate whitelists
  - Extended `web/lib/email/scraper-health.ts` with `evaluateCanary` + a "Scraper-break canary" section in the alert email (fires on >50% day-over-day drops, not just outages)

### Performance work baked in (Luke's blockers)
- New partial indexes — `idx_job_postings_company_active_first_seen` + `idx_companies_tier_active` (migration `20260522000000_phase3_indexes.sql`). **Apply via Supabase dashboard / psql before flipping is_active=true on the new banks.**
- `getJobsListData` hard-capped at 500 rows (was unbounded — would have shipped ~22 MB JSON per `?tier=incumbent` page render at 5× scale).
- Workday scrapers offloaded to GH Actions despite being API-based — a cold ~1,500-job scrape with description enrichment can't fit in Vercel's 300s function budget.
- Tier-integrity assert in the seed script — fails loud if any of the 4 new rows ends up `tier='fintech'`.

### Code-quality work baked in (Farhan's blockers)
- `decodeHtmlEntities` consolidated into `web/lib/scrapers/utils.ts` (was duplicated twice; scotiabank's copy had a subtle `&amp;`-first ordering bug — see pre-work commit message).
- Workday scrapers built around `workday-utils.ts` from day one — but pure helpers, not a base class.
- Test floor honored per scraper: fixtures under `__fixtures__/`, pure parser + mapper + cap-resolver tests, no `fetch` / `puppeteer` in tests.
- `companySlugOverride` deferred to Phase 3.5 — keeps Phase 3 free of an under-spec'd contract.
- CLAUDE.md + CRON_TOPOLOGY.md + OBSERVABILITY.md updated.

### Verification
- `npm test` — **233/233 pass** (88 new across the three streams)
- `npm run build` — clean
- `npm run lint` — clean (pre-existing unrelated warning only)

### Phase 3.5 follow-ups (out of scope here)
1. Apply migration `20260522000000_phase3_indexes.sql` to the Supabase project (MCP currently disconnected, so via dashboard/psql).
2. Run `npx tsx --env-file=.env.local scripts/seed-phase3-banks.ts` to insert the 4 new company rows.
3. Smoke each bank by flipping `is_active=true` one at a time + manually triggering `scrape-heavy.yml`.
4. Run `npx tsx --env-file=.env.local scripts/calibrate-incumbent-gate.ts` once the full multi-bank corpus is in; recalibrate the seniority whitelist if the data supports it.
5. Flip the Simplii classifier on (add the `simplii` companies row, route via `companySlugOverride`) if production logs show Simplii postings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)