### PR TITLE
fix(workday): URL builder doubled `/job` segment, causing all 406s (v2.2.2)

### DIFF
--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.2.2",
+    "date": "2026-05-23",
+    "changes": [
+      { "type": "fix", "description": "Workday detail-page URLs were doubled (`/job/job/...`), causing every TD and CIBC detail enrichment to return 406. Root cause: Workday's `externalPath` already starts with `/job/...`, but `buildWorkdayUrls.jobGetUrl` was prepending another `/job`. Verified against the live API: corrected URLs return 200 even without browser-like headers. The browser-header machinery added earlier in v2.2.0 was a red herring caused by misdiagnosis." }
+    ]
+  },
+  {
     "version": "2.2.1",
     "date": "2026-05-23",
     "changes": [

--- a/web/lib/scrapers/workday-utils.test.ts
+++ b/web/lib/scrapers/workday-utils.test.ts
@@ -23,10 +23,10 @@ describe("buildWorkdayUrls", () => {
     );
   });
 
-  it("produces a detail URL by appending externalPath after the `/job` segment", () => {
+  it("produces a detail URL by appending externalPath verbatim (Workday's externalPath already starts with `/job/...`)", () => {
     const urls = buildWorkdayUrls("cibc", "wd3", "search");
     expect(urls.jobGetUrl("/job/Toronto/Senior-Engineer_R-1")).toBe(
-      "https://cibc.wd3.myworkdayjobs.com/wday/cxs/cibc/search/job/job/Toronto/Senior-Engineer_R-1"
+      "https://cibc.wd3.myworkdayjobs.com/wday/cxs/cibc/search/job/Toronto/Senior-Engineer_R-1"
     );
   });
 

--- a/web/lib/scrapers/workday-utils.ts
+++ b/web/lib/scrapers/workday-utils.ts
@@ -67,10 +67,14 @@ export interface WorkdayJobDetailResponse {
  * Build the listing POST URL and the per-job detail GET URL builder for a
  * given Workday tenant. Pure — no HTTP.
  *
- * Example: `td` / `wd3` / `TD_Bank_Careers` →
+ * Workday returns `externalPath` already prefixed with `/job/...`, so the
+ * detail URL builder appends it verbatim — DO NOT prepend an extra `/job`
+ * or the call returns 406 from the Akamai edge (May 2026 incident).
+ *
+ * Example: `td` / `wd3` / `TD_Bank_Careers` with externalPath `/job/Toronto/X_R-1` →
  *   listingPostUrl = "https://td.wd3.myworkdayjobs.com/wday/cxs/td/TD_Bank_Careers/jobs"
- *   jobGetUrl("/job/Toronto/Software-Engineer_R-123") =
- *     "https://td.wd3.myworkdayjobs.com/wday/cxs/td/TD_Bank_Careers/job/Toronto/Software-Engineer_R-123"
+ *   jobGetUrl      = "https://td.wd3.myworkdayjobs.com/wday/cxs/td/TD_Bank_Careers/job/Toronto/X_R-1"
+ *   jobPublicUrl   = "https://td.wd3.myworkdayjobs.com/TD_Bank_Careers/job/Toronto/X_R-1"
  */
 export function buildWorkdayUrls(
   tenant: string,
@@ -85,7 +89,7 @@ export function buildWorkdayUrls(
   const cxs = `${base}/wday/cxs/${tenant}/${site}`;
   return {
     listingPostUrl: `${cxs}/jobs`,
-    jobGetUrl: (externalPath: string) => `${cxs}/job${externalPath}`,
+    jobGetUrl: (externalPath: string) => `${cxs}${externalPath}`,
     // Public-facing apply URL (the one we store on JobData.url).
     jobPublicUrl: (externalPath: string) => `${base}/${site}${externalPath}`,
   };

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## TL;DR

The Workday 406s I "fixed" in PR #81 were never an Akamai bot-detection issue — they were a URL bug, and that misdiagnosis cost a 60-line cookie/header machine that wasn't needed.

## Root cause

[workday-utils.ts:88](web/lib/scrapers/workday-utils.ts#L88):

```ts
jobGetUrl: (externalPath: string) => `${cxs}/job${externalPath}`,
```

Workday's `externalPath` is **already prefixed with `/job/...`** (verified against the live TD API). So the builder produced `/job/job/Toronto/...` — a 404 path that Akamai surfaces as 406. Even the existing unit test pinned the buggy URL, so nothing caught it.

## Verification (live curl against TD's API)

```
curl '.../wday/cxs/td/TD_Bank_Careers/job/job/Toronto/X_R-1'  → HTTP 406
curl '.../wday/cxs/td/TD_Bank_Careers/job/Toronto/X_R-1'      → HTTP 200
```

Bare `Accept: application/json` against the correct URL returns 200 — no User-Agent, no Referer, no cookies needed.

## What changed

- `workday-utils.ts:88` — `${cxs}/job${externalPath}` → `${cxs}${externalPath}`
- Updated JSDoc with a clearer example + a note for whoever adds the next Workday tenant
- `workday-utils.test.ts:28-30` — the test had pinned the buggy doubled URL
- v2.2.1 → v2.2.2 + changelog `fix` entry

## What I'm NOT removing

The `buildWorkdayHeaders` + `extractCookieJar` helpers from PR #81 stay in. They're now defensive — not required, but harmless and may help if Akamai posture tightens. Removing them would be diff churn without value.

## Verification

- `cd web && ./node_modules/.bin/vitest run lib/scrapers` — **115/115 pass**
- Will trigger live TD + CIBC smokes after merge to confirm zero 406s

🤖 Generated with [Claude Code](https://claude.com/claude-code)