### PR TITLE
docs: encode session learnings into CLAUDE.md + seed agent memory

### DIFF
--- a/.claude/agent-memory/senior-architect/MEMORY.md
+++ b/.claude/agent-memory/senior-architect/MEMORY.md
@@ -1,0 +1,78 @@
+# Senior Architect -- Memory
+
+## Project: Fintech Talent Brief
+
+### Diagnostic discipline (May 2026 lessons)
+
+- **Confirm symptoms with `curl` before designing a remediation.** The May 2026 Workday 406 was diagnosed as Akamai bot-detection and "fixed" with a 60-line cookie/header machine. The actual cause was a one-character URL bug (`/job` prepended to a path that already started with `/job/...`). A `curl` against the constructed URL would have caught it in 30 seconds. When recommending a fix, demand to see the wire-level repro first.
+- **Unit tests can pin a buggy assumption.** The Workday URL test asserted the doubled `/job/job/...` output — so vitest stayed green for weeks while production 100% failed. Pure-fixture tests don't catch URL-shape, header, or content-negotiation bugs. For scrapers, recommend a smoke step that hits the real endpoint (e.g. `WORKDAY_*_MAX_JOBS=2`) before merging.
+- **Gemini 2.5 reasoning tokens are billed at the output rate.** Returned in `usageMetadata.thoughtsTokenCount` or as the residual of `totalTokenCount - input - output - cached`. The May 2026 cost audit found our formula had been dropping them, undercounting Flash extract spend ~3x. When reviewing a Gemini call site, check that `recordUsage` propagates thoughts to `estimateUsd`.
+- **Vercel webhook hiccup signature:** GitHub status `Vercel - Deployment failed.` with no target URL AND no Deployments-tab entry = webhook rejected upstream of any build. Recipe: `git commit --allow-empty -m "chore: retrigger Vercel" && git push origin main`. Don't chase a phantom build error.
+
+### Gemini cost-reduction playbook (April 2026)
+
+Started at ~$1.50–$1.90/day Gemini spend (forecast $51/month, +23.5% vs March). Shipped as a phased, measurement-first effort across PRs #55–#60. Future work in this area should follow the same discipline: measure first, ship one change per PR, attach the comparison report.
+
+**Phase 0 (#55) — `-latest` alias migration.** Swapped every pinned preview ID to the floating alias convention. Rationale: model rotations land without code changes; `-latest` may point to preview/experimental, detected by Phase-1 harness and Phase-5 telemetry.
+
+**Phase 1 (#56) — meter + compare harness + committed baselines.** Non-optional prerequisite: never optimize without a baseline. Built `web/lib/ai/gemini-meter.ts` (`recordUsage`, `UsageRecord`), `web/scripts/gemini-compare.ts`, and the seeded 20-job fixture. Baselines committed in `web/scripts/artifacts/`. Two headline numbers worth remembering:
+- `extract-structure` per-job: ~$0.0015 (Flash), ~9s latency, 13% retry rate.
+- `analyze-advanced` per-job: ~$0.089 (2 Pro+grounded calls), ~30s latency.
+
+**Phase 2 (#57) — description-hash gate on re-extraction.** Migration adds `job_postings.description_hash` with in-migration pgcrypto backfill. `processor.ts` skips `extractAndUpdateStructure` on unchanged descriptions. Null hash = treat as changed (safe first-scrape behavior). This is the dominant Flash-tier saving in production — every daily scrape that repeats unchanged descriptions becomes free.
+
+**Phase 3 (#58) — drop duplicate Pro+grounded pre-fetch.** One-line change: `advanced-strategic.ts` no longer calls `performWebSearch` by default; the main analysis call already has `googleSearch` tool enabled and grounds in-flight. Measured −51% analyze cost with 100% agreement on `is_new_direction` / `is_executive_movement` / `confidence` / `novelty_score`. `category` dropped to 70% — accepted as defensible reclassifications rather than gamed with a lowered threshold.
+
+**Phase 4 (#59) — Flash-Lite routing evaluation.** Negative result: 78% cheaper, 83% faster, 0 retries, but L1 agreement 80% on `function_category` and `seniority_level` vs the 95% bar. One hard error (`Senior Backend Engineer → fraud-trust-safety`) disqualified the swap. Tooling + enum entry shipped so this is easy to re-evaluate after Google rotates the alias or the prompt changes.
+
+**Phase 5 (#60) — production telemetry.** `gemini_usage_events` table + `writeUsageEvent` fire-and-forget sink + 15 production call-sites wired. Captures `model_served` distinct from `model_requested` so the silent Pro→Flash fallback is observable.
+
+**Phase 6 — explicitly optional.** Novelty-gated Pro routing, company-insight content-hash cache, extract-prompt trim. The user's stance (2026-04-19): *"we may never do phase 6."* Pursue ONLY if Phase-5 telemetry shows residual waste after Phase 2 and Phase 3 land in production.
+
+### Architectural patterns worth preserving
+
+- **Fire-and-forget telemetry.** `gemini-telemetry.ts` never awaits and swallows errors. A flaky DB insert does not block a user request. Apply this pattern whenever observability is added to a hot path.
+- **Content-hash gate.** Phase 2 pattern applies broadly: when re-work is cheap to detect (hash the input, compare to stored), always gate on it. Candidates for the same pattern: company-insight regeneration, weekly digest commentary per company.
+- **Negative-result PRs.** Phase 4 shipped measurement tooling + committed evidence without changing production. Preserves the work and documents the "we tried, here's why not" for future reviewers.
+- **Measure at the boundary.** `recordUsage` + `writeUsageEvent` at every call-site, not a central interceptor. Each site knows its call-site label and `extra` context better than a global hook could.
+
+### Live ingestion path (sacred)
+```
+processor.ts → [description_hash gate] → extractAndUpdateStructure → extractJobStructure (Flash)
+analyzer.ts → analyzeJobAdvanced (Pro+grounded, in-flight grounding, no pre-fetch)
+```
+Two Gemini calls per new job (not three, not one). Protect this shape — the history of miscounting call-sites was the origin of the April cost debugging round.
+
+### Cost drivers and their levers
+
+| call-site | per-call cost (2026-04 measured) | primary lever |
+|---|---|---|
+| `analyzeJobAdvanced` (Pro+grounded) | ~$0.043 | novelty-gated routing (Phase 6 candidate) |
+| `performWebSearch` (pre-fetch) | ~$0.043 | dropped in Phase 3 |
+| `extractJobStructure` (Flash) | ~$0.0015 | hash gate (Phase 2) |
+| `generateCompanyInsight` | ~$0.01–0.02 | content-hash cache (Phase 6 candidate) |
+| Grounding surcharge | $0.035/request flat | remove grounding where prompt doesn't need fresh news |
+
+Any grounded call is ~$0.035 even at zero tokens — scrutinize it before merge.
+
+### Known dead code on the ingestion path
+- `strategic.ts#analyzeJob` — exported only.
+- `categorizer.ts#categorizePosting` — backfill script only.
+- The 8000-char description cap in `strategic.ts` — on the dead branch; the live `advanced-strategic.ts` has no cap.
+
+If a future change needs to wire these in, that's an explicit architectural decision, not a drive-by.
+
+### Silent Pro→Flash fallback
+Lives at `advanced-strategic.ts:467-485`. Now observable via `gemini_usage_events.model_served`. Any new Pro call that doesn't capture `modelServed` distinctly is a regression.
+
+### Measurement infrastructure
+- Fixture: `web/scripts/fixtures/gemini-sample-jobs.json` (20 seeded jobs across 5 companies, min 500 description chars).
+- Runner: `web/scripts/gemini-compare.ts` with `--scenario`, `--mode`, `--variant`, `--model`, `--limit`, `--dry-run`.
+- Diff tools: `diff-analyze-artifacts.ts`, `diff-extract-artifacts.ts`, `project-hash-gate-savings.ts`.
+- Baselines committed in `web/scripts/artifacts/` at specific git SHAs — reference them before any new optimization instead of regenerating.
+
+### Pricing table caveat
+`web/lib/ai/gemini-pricing.ts` is hand-maintained from Google's public pricing page and intended for relative trending only. Reconcile `estimated_usd` totals to Google Cloud billing monthly; expect drift. Update the constants when observed drift exceeds ~10%.
+
+### Cron constraint
+Max 2 Vercel crons per CLAUDE.md. Currently daily `/api/cron/collect` at 06:00 UTC and weekly `/api/cron/report` Mon 05:00 UTC. Any future scheduled quality-suite run must fold into one of these or replace the oldest entry.

--- a/.claude/agent-memory/senior-staff-code-reviewer/MEMORY.md
+++ b/.claude/agent-memory/senior-staff-code-reviewer/MEMORY.md
@@ -1,0 +1,87 @@
+# Senior Staff Code Reviewer -- Memory
+
+## Project: Fintech Talent Brief
+
+### Review-blocking patterns from May 2026 incidents
+
+- **Unit tests that pin buggy assumptions.** The Workday URL builder shipped with a `/job`-doubling bug because `workday-utils.test.ts` *asserted* the buggy output — vitest stayed 100% green while every production detail call returned 406 for weeks. When reviewing a fixture-based test for a scraper / parser / URL builder, ask: "does this just lock in whatever the implementation currently does, or does it cross-check against an independent source of truth?" If only the former, push back.
+- **"It's bot detection" without wire-level evidence.** Three hours and a 60-line cookie/header machine in PR #81 were spent on a misdiagnosed Workday 406 that was a one-character URL bug. Rule of thumb: if the proposed fix is "add more headers to defeat bot detection," demand a `curl` against the failing URL with the simplest possible headers first. If bare `Accept: application/json` works, it's not bot detection.
+- **Gemini call site missing thoughts-token billing.** Gemini 2.5 returns reasoning tokens billed at the output rate. `gemini-meter.ts#recordUsage` infers them from the `totalTokenCount` residual if the SDK doesn't surface the named field. Any new Gemini call site that constructs its own usage record (not going through `recordUsage`) is undercounting cost — block the PR.
+- **Tier/role page variants that drop blocks silently.** When `{isIncumbent ? <Variant /> : <Original />}` ships, the new branch often skips conditional render blocks from the original by oversight, not design. Phase 2's incumbent variant of `companies/[slug]/page.tsx` dropped the `latestInsight` rendering entirely — RBC insights silently went nowhere. When reviewing a branched render, list every conditional block in the original and verify each is keep/drop/replace **explicitly**.
+
+### AI Model Convention (updated 2026-04-19)
+- All Gemini calls MUST use floating `-latest` aliases: `gemini-flash-latest`, `gemini-flash-lite-latest`, `gemini-pro-latest`.
+- Never pin a versioned or preview ID (`gemini-3-flash-preview`, `gemini-2.0-flash`, etc.).
+- Model strings must resolve through `AI_MODEL_OPTIONS` in `web/lib/ai/prompt-config.ts` — anything outside that Zod enum fails validation. Flag hardcoded strings that bypass it.
+- Pro model is used only when web-search grounding is load-bearing.
+
+### Mandatory Gemini telemetry (Phase 5, 2026-04-19)
+- Every new Gemini call-site MUST build a `UsageRecord` via `recordUsage` from `web/lib/ai/gemini-meter.ts` and pass it to `writeUsageEvent` from `web/lib/ai/gemini-telemetry.ts`. Writes are fire-and-forget into `gemini_usage_events`.
+- Propagate an optional `onUsage` observer alongside the DB write for scripts that run the same function in a `gemini-compare.ts` scenario.
+- Flag any `generateContent` call without these two alongside. Reference implementations: `structure.ts#extractJobStructure`, `advanced-strategic.ts#analyzeJobAdvanced`, `advanced-strategic.ts#performWebSearch` (they also pull `usageMetadata` from `stream.response` in the streaming chat path).
+
+### Grounding discipline (Phase 3 lesson, 2026-04-19)
+- Before approving a new `googleSearch`-enabled call, confirm the upstream caller is not already grounding. The Apr 2026 incident was `analyzeJobAdvanced` firing a pre-fetch grounded call PLUS the main grounded call — duplicate work, doubled per-job cost.
+- Grounding surcharge is ~$0.035/request regardless of token count. Two grounded calls per logical operation is nearly always a smell.
+
+### Live ingestion path (sacred)
+```
+processor.ts → [description_hash gate] → extractAndUpdateStructure → extractJobStructure (Flash)
+analyzer.ts → analyzeJobAdvanced (Pro+grounded; in-flight grounding, no pre-fetch)
+```
+Do NOT add wiring into `analyzeJob` in `strategic.ts` or `categorizePosting` in `categorizer.ts` — both are dead code on the live ingestion path (legacy/backfill only). Anyone wiring them in needs to justify it explicitly.
+
+### Dead code to beware of
+- `strategic.ts#analyzeJob` — exported, never called in production
+- `categorizer.ts#categorizePosting` — only in `scripts/backfill-function-category.ts`
+- The 8000-char description cap in `strategic.ts` DOES NOT apply to the live `advanced-strategic.ts#analyzeJobAdvanced` path. Flag anyone citing it as a production constraint.
+
+### Silent Pro→Flash fallback
+- `advanced-strategic.ts:467-485` silently swaps Pro→Flash on quota errors. `gemini_usage_events.model_served` exposes when this fires — `WHERE model_requested <> model_served` surfaces it. Flag any new analysis function that logs only `modelRequested` without also recording `modelServed`.
+
+### Quality testing thresholds (Phase 3 & 4 plan-of-record)
+- For `analyze-advanced` optimizations: L1 agreement on `is_new_direction`, `is_executive_movement` must be ≥90%. `category` is a soft taxonomy field and below-threshold shifts (70% on Phase 3) can be accepted with explicit documentation of the reclassifications.
+- For `extract-structure` optimizations: L1 agreement on `function_category`, `seniority_level`, `standardized_department` must be ≥95%. Phase 4 Flash-Lite evaluation failed this bar (80%) and was NOT routed — hard "no" precedent for blind-swapping extract models.
+- L2 voice-validator delta must not regress by >2pp.
+- Voice warnings are post-hoc regex checks from `lib/ai/voice-validator.ts` — not a substitute for human judgment on `insight_summary` tone.
+
+### Cache-key invariant
+- Any response cache (present or future, e.g. company-insight cache envisioned in the plan) MUST include `prompt_config_version` in the key. Otherwise a prompt tweak silently serves stale outputs forever. Flag cache keys that only hash inputs.
+
+### Voice-directive placement
+- The ~140-token voice block from `web/lib/ai/voice.ts` is mandatory on user-facing surfaces (digest, company insight, chat, narrative) and forbidden on internal extraction/classification prompts (extraction output is never shown to users). Flag voice blocks leaking into extraction prompts.
+
+### Measurement-first convention
+- PRs touching `web/lib/ai/**` or `web/lib/analysis/**` must run `gemini-compare.ts` and attach the markdown report. Reference diff tools: `diff-analyze-artifacts.ts` (L1+L2+cost), `diff-extract-artifacts.ts` (L1+partial-extraction), `project-hash-gate-savings.ts` (projection vs baseline).
+- Committed baselines in `web/scripts/artifacts/` are the reference points. Do not regenerate the fixture casually — it's seeded annually.
+
+### Silver Layer Pattern
+- Per-job `tech_stack: string[]` is extracted during ingestion via `lib/analysis/structure.ts`.
+- Stored in `job_postings.tech_stack` (JSONB with GIN index).
+- Aggregated in `lib/analysis/digest.ts:getTopTech()` for weekly digests.
+- Company-level tech stack in `lib/ai/tech-stack-extraction.ts` duplicates this work with a separate Gemini call.
+
+### Error Handling Anti-Pattern
+- `tech-stack-extraction.ts` catches all batch errors and continues, returning empty results on total failure.
+- API route returns 201 for empty results, making failures look like success.
+- Flag the `try { ... } catch { continue; }` pattern wherever it appears without an accompanying null-rate counter or status propagation.
+
+### Job System -- Stuck Jobs (diagnosed 2026-03-06)
+- See `job-system-issues.md` for detailed findings.
+- Root cause: no guaranteed-terminal-status invariant in runner/processor.
+- `executeCollectionJob` and `executeAnalysisJob` throw after setting `running` without catch to set `failed`.
+- Cron resume logic picks up stale `running` jobs, creating infinite loop.
+- `processCollectionTask` catch block re-throws without defensive task status update.
+- GitHub Actions offload leaves tasks `running`; cleanup cron NOT in vercel.json.
+- Final status logic deliberately sets job to `running` for offloaded tasks.
+- `triggerAnalysisJobIfNeeded` fires executeAnalysisJob with `.catch(console.error)` -- no status cleanup.
+
+### Job Tracking
+- All cron/manual jobs tracked in `job_runs` table (not deprecated `cron_logs`).
+- Valid job_types: collect, analyze, report, company-insights, insight-generation.
+
+### Cron Constraint
+- Max 2 cron jobs per CLAUDE.md; currently at: daily collect (6 AM), weekly report (Mon 6 AM).
+- `cleanup-jobs` cron exists at `/api/cron/cleanup-jobs/route.ts` but is NOT in vercel.json.
+- `company-insights` cron exists but is NOT in vercel.json.
+- Cleanup logic should be folded into collect cron to respect 2-cron limit.

--- a/.claude/agent-memory/senior-staff-code-reviewer/job-system-issues.md
+++ b/.claude/agent-memory/senior-staff-code-reviewer/job-system-issues.md
@@ -1,0 +1,31 @@
+# Job System -- Stuck Jobs Analysis (2026-03-06)
+
+## Files Reviewed
+- `web/lib/jobs/runner.ts` -- job creation and execution
+- `web/lib/jobs/processor.ts` -- collection task processing (scrape + ingest)
+- `web/lib/jobs/analyzer.ts` -- analysis task processing
+- `web/lib/jobs/progress.ts` -- progress tracking
+- `web/lib/jobs/types.ts` -- type definitions
+- `web/app/api/cron/collect/route.ts` -- cron entry point
+- `web/app/api/cron/cleanup-jobs/route.ts` -- stale job cleanup (not deployed)
+- `web/app/api/admin/trigger/route.ts` -- admin manual trigger
+- `web/vercel.json` -- cron and function config
+
+## Root Causes (ranked by impact)
+
+1. **runner.ts:99,142** -- `executeCollectionJob` throws after setting `running`, no catch sets `failed`
+2. **collect/route.ts:45-52** -- Cron resume picks up stale `running` jobs, creating infinite loop
+3. **processor.ts:473-476** -- catch block re-throws without defensive task status update
+4. **processor.ts:401-426 + vercel.json** -- GitHub Actions offload + cleanup cron not deployed
+5. **runner.ts:146-150** -- Final status logic deliberately sets job to `running` for offloaded tasks
+
+## Key Invariant Missing
+Every function that sets `status: 'running'` MUST guarantee a terminal status on ALL exit paths.
+Neither runner.ts nor processor.ts nor analyzer.ts enforce this.
+
+## Fix Strategy
+1. Add try/catch with `status: 'failed'` to executeCollectionJob, executeAnalysisJob
+2. Add defensive catch to processCollectionTask, processAnalysisTask
+3. Fold cleanup logic into collect cron as first step (respects 2-cron limit)
+4. Fix resume query to exclude jobs older than maxDuration
+5. Handle "no resumable tasks but offloaded tasks exist" gracefully

--- a/.claude/agent-memory/ux-design-advisor/MEMORY.md
+++ b/.claude/agent-memory/ux-design-advisor/MEMORY.md
@@ -1,0 +1,13 @@
+# UX Design Advisor — Memory Index
+
+## Patterns & Conventions
+- [dashboard-patterns.md](./dashboard-patterns.md) — Established UI patterns, component conventions, layout decisions
+
+## Design Decisions
+- [design-decisions.md](./design-decisions.md) — Rationale behind key design choices
+
+## Tier/role variant rendering audit (May 2026 lesson)
+
+Phase 2's incumbent integration shipped `{isIncumbent ? <IncumbentBranch /> : <FintechBranch />}` on `companies/[slug]/page.tsx`. The new incumbent branch was clean visually — `TierBadge` pill, context callout, "Senior hiring signal" panel — but silently **dropped** the `latestInsight` rendering block that the fintech branch had. The page query still loaded `latestInsight` for both branches, so admin-generated insights for incumbents went nowhere on the page even when the data existed.
+
+**Design-review rule:** when reviewing a "lens / variant" rendering of an existing page, ask explicitly what happens to every block on the original. Tier-variant audits should produce a kept / dropped / replaced row for every conditional render block in the source. Don't approve a "minimal variant" without that audit.

--- a/.claude/agent-memory/ux-design-advisor/dashboard-patterns.md
+++ b/.claude/agent-memory/ux-design-advisor/dashboard-patterns.md
@@ -1,0 +1,49 @@
+# Dashboard UI Patterns & Conventions
+
+## Segmented Pill Control (TimeRangeSelector pattern)
+- Used for small sets of mutually exclusive options (2–6 items)
+- Markup: `inline-flex items-center rounded-lg border bg-muted p-0.5 text-muted-foreground`
+- Active state: `bg-background text-foreground shadow-sm`
+- Inactive hover: `hover:bg-background/50 hover:text-foreground`
+- Text: `text-xs font-medium` for compact controls, `text-sm font-medium` for page-level controls
+- Padding: `px-2.5 py-1` (compact) or `px-3 py-1` (page-level)
+- Defined in: `components/dashboard/TimeRangeSelector.tsx`
+- Also used in: `components/dashboard/CompaniesOverview.tsx` (MatrixControls)
+
+## Dashboard Page Layout (app/(dashboard)/page.tsx)
+- ROW 0: Time Range Selector (right-aligned, controls charts/sparklines/flow chart)
+- ROW 1: Stat Cards with sparklines
+- ROW 2: Weekly Intel Banner (AI digest narrative)
+- ROW 3: Net Hiring Flow Chart (full width)
+- ROW 4: Competitive Matrix (lg:col-span-2) + Function Mix donut (1/3)
+- ROW 5: Hot Roles Feed (1/2) + Strategy Signals (1/2)
+- Page-level time range param: `range` (2w/1m/3m/6m, default 3m)
+- Matrix-specific params: `matrixWindow` (current/30/60/90/180/360) + `matrixScope` (active/all)
+
+## Competitive Matrix (CompaniesOverview.tsx)
+- 7 function group columns (Engineering, Product & Design, Data & Analytics, Risk/Legal/Compliance, GTM, Finance & Strategy, Ops & People) — "Other" excluded
+- Short labels map: Eng, Prod, Data, Risk, GTM, Fin, Ops
+- Company column sticky left (bg-card z-10)
+- Zero-count cells: `—` with `text-muted-foreground/40`
+- Zero-total rows: should use `opacity-50` on TableRow (recommended, not yet implemented)
+- 7d Net column: shown in Current mode only (hidden for historical windows)
+- Cell color highlighting (green/red bg): Current mode only
+- Controls live in CardHeader with responsive stacking: `flex-col gap-3 sm:flex-row sm:items-start sm:justify-between`
+
+## Table Conventions
+- Horizontal rules only (no vertical borders) — shadcn Table default
+- Row hover via TableRow default hover state
+- Sticky first column uses `sticky left-0 bg-card z-10` (must match card background)
+- Horizontal scroll wrapper: `overflow-x-auto -mx-6` with inner `min-w-[600px] px-6`
+- Numeric cells: `tabular-nums text-center`
+
+## Two-Control Disambiguation Problem (identified)
+- Dashboard has two visually identical segmented pills: page-level TimeRangeSelector and matrix MatrixControls
+- These control different things (charts vs. matrix data)
+- Recommended fix: add a small "Charts" label before the page-level control
+- Without labeling, users have no way to know which control affects what
+
+## Known Design Debt
+- Page-level TimeRangeSelector has no label — floats unlabeled above dashboard
+- Scope toggle labels "Active only" / "Include closed" are asymmetric; recommended: "Open roles" / "All roles"
+- `getDescription()` produces awkward copy for active+historical combination: "currently active during the last N days"

--- a/.claude/agent-memory/ux-design-advisor/design-decisions.md
+++ b/.claude/agent-memory/ux-design-advisor/design-decisions.md
@@ -1,0 +1,21 @@
+# Design Decisions & Rationale
+
+## Matrix time window independent of page time range (2026-03)
+- Decision: CompetitiveMatrix has its own time window controls, independent of the page-level chart range
+- Rationale: The matrix serves a different analytical purpose than the trend charts. The chart range affects sparklines and the net hiring flow chart; the matrix window affects the competitive snapshot.
+- Implementation: Separate URL params (`matrixWindow`, `matrixScope`) vs. page-level `range`
+- Trade-off: Two controls on same page creates disambiguation burden — must label the page-level control
+
+## Always show all tracked companies in matrix (2026-03)
+- Decision: Removed filter on `row.total > 0` — companies with zero active jobs (e.g. Wealthsimple) now appear
+- Rationale: Absence of hiring is itself a signal. Hiding a company because they have 0 jobs removes competitive intelligence.
+- Trade-off: Rows with all-zero data add visual weight with no informational density; mitigated by reduced opacity treatment
+
+## 7d Net column hidden in historical mode (2026-03)
+- Decision: 7d Net column is only rendered in "Current" mode
+- Rationale: Weekly net change over a multi-week lookback window is semantically meaningless
+- No trade-off — this is unambiguously correct
+
+## Cell color highlighting (green/red) Current mode only (2026-03)
+- Decision: bg-green-50/bg-red-50 cell highlights only shown in Current mode
+- Rationale: Same as 7d Net — weekly change signals don't apply to historical windows

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,12 +113,15 @@ Compact rules; long-form rationale + April 2026 cost-incident context in [`docs/
 - **Build before push:** `cd web && npm run build` is the contract. Vercel will fail the deploy on a TS error that local dev tolerates.
 - **Changelog discipline:** every user-facing change gets an entry in `web/data/releases.json`. Types: `feature` | `fix` | `improvement`. Bump `web/package.json` version per semver: patch (1.0.x) bug fixes, minor (1.x.0) features, major (x.0.0) breaking changes.
 - **Tests:** Vitest for unit (pure functions only), Playwright for one smoke (`e2e/smoke.spec.ts`); see `docs/AGENTS.md`#Tests.
+- **Vercel webhook hiccup recipe:** if a merge to `main` shows GitHub status `Vercel - Deployment failed.` with **no** target URL and **no** entry in Vercel's Deployments tab, the webhook was rejected upstream of any build — there's no log to read because no build happened. Push an empty commit to retrigger: `git commit --allow-empty -m "chore: retrigger Vercel" && git push origin main`. Don't chase a phantom build error; verify a deployment record exists before debugging code.
+- **Tier-/role-variant rendering:** when adding a tier or role variant of an existing page (`{isIncumbent ? <IncumbentBranch /> : <FintechBranch />}`), walk every conditional render block from the original (`{insight && ...}`, `{coreFunctions.length && ...}`) and decide explicitly: keep / drop / replace. The May 2026 incumbent-variant work loaded `latestInsight` for the page but had no code to render it, so admin-generated insights silently went nowhere.
 
 ## 8. Anti-patterns
 
 Things that will get a PR rejected:
 
 - Adding a third Vercel cron. The cap is two — route long-running work through GitHub Actions instead.
+- Pinning `node-version: '20'` (or older) in a `.github/workflows/*.yml` file. Node 20 is deprecated for GitHub Actions runners (forced to 24 by default starting June 2026, removed September 2026). Use `'22'` or newer.
 - Hardcoding a model string outside `web/lib/ai/prompt-config.ts`.
 - Hardcoding a color outside `web/app/globals.css` (raw hex, rgb, hsl, oklch, or `bg-[#…]`). Add a token instead. Lint rule: `design-system/no-raw-color`.
 - Using Fraunces (`font-display`) outside the four approved editorial surfaces (digest hero, marketing hero, login hero, company stated-strategy callout).

--- a/web/lib/ai/CLAUDE.md
+++ b/web/lib/ai/CLAUDE.md
@@ -16,9 +16,11 @@ Every Gemini call site writes to `gemini_usage_events`:
 
 If your call is wrapped by an existing helper that already meters, do not meter again. Double-counting is as misleading as missing data.
 
+**Gemini 2.5 reasoning tokens.** The 2.5 series (Pro AND Flash with structured-output prompts) returns reasoning/"thinking" tokens in `usageMetadata.thoughtsTokenCount`, and folds them into `totalTokenCount`. They are billed at the **output** rate. `recordUsage` reads the named field OR infers from the `totalTokenCount` residual when the SDK omits it (Flash 2.5 does this in practice). If a future SDK version exposes more named fields, update `gemini-meter.ts` AND backfill historical rows. The May 2026 audit found we'd been silently undercounting Flash extract spend ~3x by ignoring this; see v2.2.1 changelog.
+
 ## Pricing & cost math
 
-- **`gemini-pricing.ts`** — Per-model token pricing used by the meter and the comparison harness. Update when Google's price list changes.
+- **`gemini-pricing.ts`** — Per-model token pricing used by the meter and the comparison harness. Update when Google's price list changes. **`estimateUsd` bills reasoning tokens at the output rate** — don't add a separate "thoughts" price column unless Google starts charging differently.
 
 ## Voice directive
 

--- a/web/lib/scrapers/CLAUDE.md
+++ b/web/lib/scrapers/CLAUDE.md
@@ -33,9 +33,13 @@ Avature CRM is a different vendor from Phenom; the white-labelled pages render p
 
 Workday exposes a documented JSON POST endpoint (`/wday/cxs/<tenant>/<site>/jobs`) so these are HTTP fetch-based, not Puppeteer. They are nonetheless **offloaded to GitHub Actions** (see `isBrowserScraper` in `index.ts`) because a cold ~1,500-job scrape with per-job description GETs exceeds Vercel's 300s function budget. `AbortSignal.timeout(15_000)` on every fetch; non-2xx throws (no in-code retry — the daily cron is the retry).
 
-- **`workday-utils.ts`** — pure shared helpers: `buildWorkdayUrls`, `parseWorkdayListingRow`, `parseWorkdayJobDetail`, `resolveWorkdayJobCap`. Used by every tenant-specific Workday scraper. Intentionally NOT a base class — fork-per-tenant.
+- **`workday-utils.ts`** — pure shared helpers: `buildWorkdayUrls`, `parseWorkdayListingRow`, `parseWorkdayJobDetail`, `resolveWorkdayJobCap`. Also exports `buildWorkdayHeaders` + `extractCookieJar` (defensive — not required for current tenants but harmless if Akamai posture tightens). Used by every tenant-specific Workday scraper. Intentionally NOT a base class — fork-per-tenant.
 - **`workday-td.ts`** — TD Bank (`td.wd3.myworkdayjobs.com/en-US/TD_Bank_Careers`).
 - **`workday-cibc.ts`** — CIBC (`cibc.wd3.myworkdayjobs.com/search`). Also exports `isSimpliiPosting` — a Simplii-Financial classifier currently running in **log-only mode**. The companies row for Simplii and the `companySlugOverride` routing land in a follow-up after production logs confirm Simplii postings actually surface in CIBC's Workday.
+
+### Workday URL gotcha (read this before changing `buildWorkdayUrls`)
+
+Workday returns `externalPath` already prefixed with `/job/...`. The detail URL builder MUST append it verbatim — do NOT prepend another `/job` or every detail GET returns 406. The May 2026 incident shipped that bug for a week and the misdiagnosis ("Akamai bot-detection") cost a 60-line cookie/header machine that was never the fix. **When debugging a Workday detail 406, the first move is `curl` against the constructed URL — not adding headers.**
 
 ### `browser.ts` is 1131 LOC — leave it alone pre-launch
 
@@ -53,9 +57,11 @@ Resist the urge to refactor `browser.ts` before launch. It works. The complexity
 
 ## Adding a new ATS
 
+0. **Verify the ATS against live HTML before assuming.** Don't trust pattern-matching from a sibling brand — `curl` the careers URL, grep for known markers: `phApp` / `eagerLoadRefineSearch` → Phenom, `data-avaturetemplate` / `avacdn.net` → Avature, `wd[0-9]+.myworkdayjobs.com` → Workday, `boards.greenhouse.io` → Greenhouse, etc. The parent corporate brand tells you nothing — BNC was on Avature while its sibling RBC was on Phenom (May 2026).
 1. Decide: API or browser-based?
-2. Create the file (`web/lib/scrapers/<name>.ts`) implementing the shared `JobData` shape.
-3. Add a `case "<name>":` to `fetchJobs` in `index.ts`.
-4. If browser-based, route through `scrape-heavy.yml` — do **not** add a new browser scrape on the Vercel hot path.
-5. Add the company config (see `config/companies.yaml` for the Python side; `web/lib/scrapers/detect-ats.ts` for the web side).
-6. Update this file with a one-line description of the new scraper.
+2. **Probe the documented endpoint with `curl` before writing parser code.** Confirm the response shape, status codes, and any required headers. If something looks like bot-detection (406/403), `curl` with the *simplest possible* headers FIRST — if it works, it's not bot-detection. Unit tests on fixtures don't catch URL-shape bugs (the May 2026 Workday `/job/job/` doubling shipped because the test pinned the buggy URL).
+3. Create the file (`web/lib/scrapers/<name>.ts`) implementing the shared `JobData` shape.
+4. Add a `case "<name>":` to `fetchJobs` in `index.ts`.
+5. If browser-based, route through `scrape-heavy.yml` — do **not** add a new browser scrape on the Vercel hot path.
+6. Add the company config (see `config/companies.yaml` for the Python side; `web/lib/scrapers/detect-ats.ts` for the web side).
+7. Update this file with a one-line description of the new scraper.


### PR DESCRIPTION
## Summary

Documenting six lessons from the May 23 incident session into the relevant `CLAUDE.md` files, plus seeding `MEMORY.md` for luke / farhan / meredith so the next session inherits the diagnostic discipline.

## CLAUDE.md edits

| File | Lesson |
|---|---|
| [`CLAUDE.md`](CLAUDE.md) §7 | Vercel webhook hiccup recipe (empty-commit retrigger) |
| [`CLAUDE.md`](CLAUDE.md) §7 | Tier/role variant rendering audit (Phase 2 dropped `latestInsight`) |
| [`CLAUDE.md`](CLAUDE.md) §8 | Anti-pattern: pinning Node 20 in workflow YAMLs |
| [`web/lib/scrapers/CLAUDE.md`](web/lib/scrapers/CLAUDE.md) Workday section | URL gotcha — `externalPath` already starts with `/job/...`, don't double it |
| [`web/lib/scrapers/CLAUDE.md`](web/lib/scrapers/CLAUDE.md) "Adding a new ATS" | Verify ATS against live HTML; probe with curl before writing parser |
| [`web/lib/ai/CLAUDE.md`](web/lib/ai/CLAUDE.md) Telemetry/Pricing | Gemini 2.5 reasoning tokens are billed at the output rate |

## Agent memory seeded

| Agent | Section added |
|---|---|
| **luke** (senior-architect) | "Diagnostic discipline (May 2026 lessons)" — curl-first, unit tests can pin bugs, thinking tokens, Vercel webhook signature |
| **farhan** (senior-staff-code-reviewer) | "Review-blocking patterns from May 2026 incidents" — fixture tests that pin buggy assumptions, cookie/header machines on misdiagnosed 406s, tier-variant audits, missing thoughts-token billing |
| **meredith** (ux-design-advisor) | "Tier/role variant rendering audit" appended to the index |

The PR also includes the supporting memory files (`dashboard-patterns.md`, `design-decisions.md`, `job-system-issues.md`) at the new `.claude/agent-memory/` location — they were already in the working tree from an in-flight `web/.claude/` → `.claude/` migration the user has been doing, and the seeded MEMORY indexes link to them.

## Out of scope

- Agent definition files (`.claude/agents/*.md`) — the user is mid-migration of these; left for them to commit separately.
- The deletions in `web/.claude/agents/` and `web/.claude/agent-memory/` — same.

## Verification

- No code touched, no tests affected (docs-only).
- No version bump (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)