### PR TITLE
feat(scotiabank): 5th Big-6 incumbent + workday pagination + insight resilience (v2.3.1)

### DIFF
--- a/config/companies.yaml
+++ b/config/companies.yaml
@@ -122,3 +122,16 @@ companies:
     careers_url: https://emplois.bnc.ca/en_CA/careers/searchjobs
     tier: incumbent
     is_active: false
+
+  # Scotiabank (parent brand). Shares jobs.scotiabank.com with Tangerine but
+  # under a different brand path. The same `scotiabank.ts` SuccessFactors
+  # scraper handles both — Tangerine's hrefs include the `/Tangerine/` brand
+  # prefix, Scotia parent omits it, so the parser matches both shapes.
+  - name: Scotiabank
+    slug: scotiabank
+    country: CA
+    ats_type: scotiabank
+    ats_identifier: Scotiabank
+    careers_url: https://jobs.scotiabank.com/Scotiabank/search/
+    tier: incumbent
+    is_active: false

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.3.1",
+    "date": "2026-05-23",
+    "changes": [
+      { "type": "fix", "description": "Incumbent insight generation no longer dies on truncated JSON. `maxOutputTokens` for `generateInsightWithLLM` raised from 4096 to 8192 — incumbent banks with rich grounded-research context routinely overran the old cap mid-string, producing \"Unterminated string in JSON\" parse failures that killed the call. Also added empty-response and parse-failure retries (up to 2 attempts each, with backoff) matching the pattern already used in `detectCompanyType`, so a single transient bad response no longer aborts the whole backfill." }
+    ]
+  },
+  {
     "version": "2.3.0",
     "date": "2026-05-23",
     "changes": [

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "2.3.0",
+    "date": "2026-05-23",
+    "changes": [
+      { "type": "feature", "description": "Scotiabank — 5th and final Big-6 incumbent — joins the lens. The parent brand shares Scotia's `jobs.scotiabank.com` SuccessFactors portal with Tangerine (already tracked as a fintech subsidiary), so a single `scotiabank.ts` parser drives both: the brand-path prefix in job hrefs is matched as an optional regex group (Tangerine includes `/Tangerine/`, Scotia parent omits it). Wires the new `scotiabank` ATS through detect-ats, the GitHub-Actions offload list (1,900 jobs × per-detail enrichment doesn't fit in Vercel's 300s budget), and the Phase-3 seed. 19 unit tests cover total-count parsing (handles SuccessFactors's `<b>`-wrapped count), row parsing for both brand-path shapes, postal-code-strip, dedupe, entity decode, description extraction, and the new `SCOTIABANK_MAX_PAGES` env cap." },
+      { "type": "fix", "description": "Scotiabank scraper's hardcoded 20-page cap (~500 jobs) silently truncated any brand larger than ~500 — fine for Tangerine, broken for Scotia parent (~1,900). Default raised to 200 (5,000-job ceiling, ~2.5× headroom); `SCOTIABANK_MAX_PAGES` env overrides for smoke runs." }
+    ]
+  },
+  {
+    "version": "2.2.4",
+    "date": "2026-05-23",
+    "changes": [
+      { "type": "fix", "description": "TD and CIBC Workday scrapers were stopping at 40 jobs (2 pages × 20) instead of pulling the full corpus (~1,531 and ~535 respectively). Root cause: Workday returns the real `total` only on the first page; subsequent pages echo `total: 0` while still returning real `jobPostings`. The loop used `data.total ?? total`, which doesn't fall back on `0`, so `total` got clobbered to `0` and the next `offset >= total` check exited immediately. Now we only update `total` when the value is positive." }
+    ]
+  },
+  {
     "version": "2.2.3",
     "date": "2026-05-23",
     "changes": [

--- a/web/lib/analysis/company-insights.ts
+++ b/web/lib/analysis/company-insights.ts
@@ -534,7 +534,8 @@ async function generateInsightWithLLM(
     headline: string | null;
     key_signal: string | null;
     executive_summary: string | null;
-  } | null
+  } | null,
+  retryCount = 0
 ): Promise<GeneratedInsightContent> {
   const key = process.env.GEMINI_API_KEY;
   if (!key) {
@@ -546,7 +547,10 @@ async function generateInsightWithLLM(
     model: "gemini-flash-latest",
     generationConfig: {
       temperature: 0.25,
-      maxOutputTokens: 4096,
+      // 8192 was 4096 — incumbent banks (BMO/RBC/Scotia) with grounded
+      // research context routinely truncated mid-JSON, producing
+      // "Unterminated string" parse failures that killed the whole call.
+      maxOutputTokens: 8192,
       responseMimeType: "application/json",
     },
   });
@@ -584,9 +588,16 @@ async function generateInsightWithLLM(
 
     const text = result.response.text()?.trim() ?? "";
 
-    // Handle empty response
+    // Handle empty response — Gemini sometimes returns nothing on first
+    // call, especially when context is large; retry once or twice before
+    // failing so the whole bank isn't lost on a transient hiccup.
     if (!text || text.length === 0) {
       log.warn(`Empty response from Gemini for company insight generation: ${companyName}`);
+      if (retryCount < 2) {
+        log.info(`Retrying company insight for "${companyName}" due to empty response (attempt ${retryCount + 2}/3)`);
+        await new Promise((r) => setTimeout(r, 1000 * (retryCount + 1)));
+        return generateInsightWithLLM(companyName, context, research, _companyType, previousInsight, retryCount + 1);
+      }
       throw new Error("Empty response from LLM");
     }
 
@@ -624,21 +635,28 @@ async function generateInsightWithLLM(
             log.info(`Successfully parsed JSON after fixing trailing commas for company insight "${companyName}"`);
           } catch (fixError) {
             log.error(`Failed to parse JSON for company insight "${companyName}" after extraction attempts. Error: ${fixError instanceof Error ? fixError.message : String(fixError)}`);
-            // Log the problematic JSON snippet for debugging
             if (jsonMatch[0].length < 500) {
               log.error(`Problematic JSON snippet: ${jsonMatch[0]}`);
             }
-            // Log full response if it's short enough to be useful
             if (text.length < 1000) {
               log.error(`Full response: ${text}`);
+            }
+            if (retryCount < 2) {
+              log.info(`Retrying company insight for "${companyName}" due to JSON parse failure (attempt ${retryCount + 2}/3)`);
+              await new Promise((r) => setTimeout(r, 1000 * (retryCount + 1)));
+              return generateInsightWithLLM(companyName, context, research, _companyType, previousInsight, retryCount + 1);
             }
             throw new Error(`Failed to parse JSON response: ${fixError instanceof Error ? fixError.message : String(fixError)}`);
           }
         } else {
           log.error(`No JSON found in response for company insight "${companyName}". Response length: ${text.length}, Preview: ${responsePreview}`);
-          // Log full response if it's short enough to be useful
           if (text.length < 1000) {
             log.error(`Full response: ${text}`);
+          }
+          if (retryCount < 2) {
+            log.info(`Retrying company insight for "${companyName}" due to no-JSON response (attempt ${retryCount + 2}/3)`);
+            await new Promise((r) => setTimeout(r, 1000 * (retryCount + 1)));
+            return generateInsightWithLLM(companyName, context, research, _companyType, previousInsight, retryCount + 1);
           }
           throw new Error("No JSON found in LLM response");
         }

--- a/web/lib/scrapers/CLAUDE.md
+++ b/web/lib/scrapers/CLAUDE.md
@@ -18,7 +18,7 @@ These hit the ATS provider's JSON endpoint. They run inside Vercel functions and
 These need Puppeteer because the ATS doesn't expose a clean JSON feed. They are too long-running / memory-heavy to run reliably inside a Vercel cron, so the live flow offloads them via `triggerScrapeWorkflow` in `web/lib/github.ts`, which `workflow_dispatch`-es `.github/workflows/scrape-heavy.yml`.
 
 - **`dayforce.ts`** — Dayforce boards.
-- **`scotiabank.ts`** — Scotiabank custom careers site.
+- **`scotiabank.ts`** — Scotiabank SuccessFactors portal (`jobs.scotiabank.com`). One parser drives every Scotia-family brand: the parent **Scotiabank** brand (incumbent, ~1,900 jobs, hrefs omit the brand prefix) and **Tangerine** (fintech subsidiary, ~30 jobs, hrefs include `/Tangerine/`). The brand-path prefix in hrefs is matched as an optional regex group so both shapes work. `SCOTIABANK_MAX_PAGES` env caps per-run pagination (default 200 = 5,000-job ceiling). Offloaded to `scrape-heavy.yml` for the parent — 1,900 jobs × per-page + per-detail fetches don't fit in Vercel's 300s budget.
 - **`phenom-rbc.ts`** — RBC's Phenom CareerConnect tenant (`jobs.rbc.com`). Reads server-rendered `phApp.eagerLoadRefineSearch` + JSON-LD `JobPosting` per detail page. Chunked enrichment (50/batch, concurrency=4).
 - **`phenom-bmo.ts`** — BMO's Phenom tenant (`jobs.bmo.com`). Same shape as phenom-rbc.
 - **`browser.ts`** — Generic Puppeteer helpers (`scrapeJobsWithBrowser`, `scrapeGenericJobBoard`, `scrapeSuccessFactors`).

--- a/web/lib/scrapers/__fixtures__/scotiabank-detail.html
+++ b/web/lib/scrapers/__fixtures__/scotiabank-detail.html
@@ -1,0 +1,659 @@
+<!DOCTYPE html>
+<html class="html5" xml:lang="en-US" lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+
+        <head>
+            <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+            <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+            <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                        <link type="text/css" class="keepscript" rel="stylesheet" href="https://jobs.scotiabank.com/platform/bootstrap/3.4.8_NES/css/bootstrap.min.css" />
+                            <link type="text/css" rel="stylesheet" href="/platform/css/j2w/min/bootstrapV3.global.responsive.min.css?h=c4edfb0a" />
+                
+                <script type="text/javascript" src="/platform/js/j2w/j2w.fallbacks.js"></script>
+                
+                
+                <script type="text/javascript" src="https://hcm17.sapsf.com/verp/vmod_v1/ui/extlib/jquery_3.5.1/jquery.js" onerror="loadFallbacks('/platform/js/jquery/jquery-3.5.1.min.js', '/platform/js/jquery/jquery-migrate-3.1.0.min.js')"></script>
+                <script type="text/javascript" src="https://hcm17.sapsf.com/verp/vmod_v1/ui/extlib/jquery_3.5.1/jquery-migrate.js"></script>
+            <script type="text/javascript" src="/platform/js/jquery/jquery-migrate-1.4.1.js"></script>
+                <title>Technical Delivery Lead (Governance) 1 Job Details | Scotiabank</title>
+
+        <meta name="keywords" content="Toronto Technical Delivery Lead (Governance) 1 - ON, M5H 1H1" />
+        <meta name="description" content="Toronto Technical Delivery Lead (Governance) 1 - ON, M5H 1H1" />
+        <link rel="canonical" href="https://jobs.scotiabank.com/job/Toronto-Technical-Delivery-Lead-%28Governance%29-1-ON-M5H-1H1/599350817/" />
+            <meta name="robots" content="index" />
+        <meta name="twitter:card" content="summary" />
+                <meta property="og:title" content="Technical Delivery Lead (Governance) 1" />
+                <meta property="og:description" content="Technical Delivery Lead (Governance) 1" />
+                <meta name="twitter:title" content="Technical Delivery Lead (Governance) 1" />
+                <meta name="twitter:description" content="Technical Delivery Lead (Governance) 1" />
+                <link type="text/css" rel="stylesheet" href="//rmkcdn.successfactors.com/c37ab1bb/cc0aafda-cf6f-41a8-9c11-7.css" />
+                            <link type="text/css" rel="stylesheet" href="/platform/csb/css/header1.css?h=c4edfb0a" />
+                            <link type="text/css" rel="stylesheet" href="/platform/css/j2w/min/sitebuilderframework.min.css?h=c4edfb0a" />
+                            <link type="text/css" rel="stylesheet" href="/platform/css/j2w/min/BS3ColumnizedSearch.min.css?h=c4edfb0a" />
+                            <link type="text/css" rel="stylesheet" href="/platform/fontawesome4.7/css/font-awesome-4.7.0.min.css?h=c4edfb0a" /><script src="//assets.adobedtm.com/27c34d6e7144/279cc12b6e9b/launch-509289b4ee23.min.js" async></script>
+
+<meta name="google-site-verification" content="2H4BkrMPOG4Y4N-NxFjKNBodJBFNsrsUOl8W-482hzM" />
+<script type="text/javascript">
+</script>
+
+        
+        <link rel="shortcut icon" href="//rmkcdn.successfactors.com/c37ab1bb/1fff5394-e827-446e-a18a-4.jpg" type="image/x-icon" />
+            <style id="antiClickjack" type="text/css">body{display:none !important;}</style>
+            <script type="text/javascript" id="antiClickJackScript">
+                if (self === top) {
+                    var antiClickjack = document.getElementById("antiClickjack");
+                    antiClickjack.parentNode.removeChild(antiClickjack);
+                } else {
+                    top.location = self.location;
+                }
+            </script>
+        </head>
+
+        <body class="coreCSB job-page body   body" id="body">
+
+        <div id="outershell" class="outershell">
+
+    <div id="header" class="header headermain " role="banner">
+            <div id="headerbordertop" class="headerbordertop"></div>
+        <script type="text/javascript">
+            //<![CDATA[
+            $(function()
+            {
+                /* Using 'skipLinkSafari' to include CSS styles specific to Safari. */
+                if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+                    $("#skipLink").attr('class', 'skipLinkSafari');
+                }
+            });
+            //]]>
+        </script>
+        <div id="skip">
+            <a href="#content" id="skipLink" class="skipLink" title="Skip to main content"><span>Skip to main content</span></a>
+        </div>
+
+        <div class="limitwidth">
+            <div class="menu desktop upper">
+                <div class="inner" role="navigation" aria-label="Header Menu">
+                        <a href="https://jobs.scotiabank.com/" title="Scotiabank" style="display:inline-block">
+                            <img class="logo" src="//rmkcdn.successfactors.com/c37ab1bb/9fe76e4f-e61e-4096-89f7-5.png" alt="Scotiabank" />
+                        </a>
+                    <ul class="nav nav-pills" role="list">
+        <li class="dropdown">
+            <a id="header1top0MenuButton" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false" title="Featured Jobs" aria-controls="header1top0">
+                Featured Jobs <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu company-dropdown headerdropdown" id="header1top0" role="menu" aria-labelledby="header1top0MenuButton">
+                        <li role="none"><a role="menuitem" href="/go/AML/2574017/" title="AML">AML</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Commercial-Banking/2573917/" title="Commercial Banking ">Commercial Banking </a></li>
+                        <li role="none"><a role="menuitem" href="/go/Student-&amp;-New-Grad-Jobs/2298417/" title="Student &amp; New Grad">Student &amp; New Grad</a></li>
+                        <li role="none"><a role="menuitem" href="/go/IT-&amp;-Digital-Banking-Jobs/2298017/" title="Technology">Technology</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Finance-Jobs/2297817/" title="Finance">Finance</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Operations-Jobs/2298117/" title="Global Operations">Global Operations</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Retail-Banking-Jobs/2298217/" title="Retail Banking">Retail Banking</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Financial-Planner-Jobs/2371217/" title="Financial Planner">Financial Planner</a></li>
+            </ul>
+        </li>
+        <li><a href="/content/location/?locale=en_US" title="Locations">Locations</a></li>
+        <li><a href="/talentcommunity/subscribe/?locale=en_US" title="Join our Talent Community">Join our Talent Community</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="menu mobile upper">
+                <a href="https://jobs.scotiabank.com/" title="Scotiabank">
+                    <img class="logo" src="//rmkcdn.successfactors.com/c37ab1bb/9fe76e4f-e61e-4096-89f7-5.png" alt="Scotiabank" />
+                </a>
+            <div class="nav">
+                    <div class="dropdown mobile-search">
+                        <button id="searchToggleBtn" type="button" title="Search" aria-label="Search" class="dropdown-toggle" data-toggle="collapse" data-target="#searchSlideNav"><span class="mobilelink fa fa-search"></span></button>
+                        <div id="searchSlideNav" class="dropdown-menu search-collapse">
+
+        <div class="well well-small searchwell">
+            <form class="form-inline jobAlertsSearchForm" name="keywordsearch" method="get" action="/search/" xml:lang="en-US" lang="en-US" style="margin: 0;" role="search">
+                <input name="createNewAlert" type="hidden" value="false" />
+                <div class="container-fluid">
+                    <div class="row columnizedSearchForm">
+                        <div class="column col-md-9">
+                            <div class="fieldContainer row">
+                                    <div class="col-md-6 rd-keywordsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Keyword</span>
+
+                                        <i class="keywordsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-q columnized-search" name="q" maxlength="50" aria-label="Search by Keyword" />
+
+                                    </div>
+                                    <div class="col-md-6 rd-locationsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Location</span>
+
+                                        <i class="locationsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-locationsearch columnized-search" name="locationsearch" maxlength="50" aria-label="Search by Location" />
+                                    </div>
+                            </div>
+                        </div>
+                        <div class="rd-searchbutton col-md-2">
+                            <div class="row emptylabelsearchspace labelrow">
+                                 
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12 col-sm-12 col-xs-12 search-submit">
+                                            <input type="submit" class="btn keywordsearch-button" value="Search Jobs" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </form>
+        </div>
+                        </div>
+                    </div>
+                <div class="dropdown mobile-nav">
+                    <a id="hamburgerToggleBtn" href="#" title="Menu" aria-label="Menu" class="dropdown-toggle" aria-controls="nav-collapse-design1" aria-expanded="false" role="button" data-toggle="collapse" data-target="#nav-collapse-design1"><span class="mobilelink fa fa-bars"></span></a>
+                    <ul id="nav-collapse-design1" class="dropdown-menu nav-collapse">
+        <li class="dropdown">
+            <a id="header1bot0MenuButton" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false" title="Featured Jobs" aria-controls="header1bot0">
+                Featured Jobs <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu company-dropdown headerdropdown" id="header1bot0" role="menu" aria-labelledby="header1bot0MenuButton">
+                        <li role="none"><a role="menuitem" href="/go/AML/2574017/" title="AML">AML</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Commercial-Banking/2573917/" title="Commercial Banking ">Commercial Banking </a></li>
+                        <li role="none"><a role="menuitem" href="/go/Student-&amp;-New-Grad-Jobs/2298417/" title="Student &amp; New Grad">Student &amp; New Grad</a></li>
+                        <li role="none"><a role="menuitem" href="/go/IT-&amp;-Digital-Banking-Jobs/2298017/" title="Technology">Technology</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Finance-Jobs/2297817/" title="Finance">Finance</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Operations-Jobs/2298117/" title="Global Operations">Global Operations</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Retail-Banking-Jobs/2298217/" title="Retail Banking">Retail Banking</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Financial-Planner-Jobs/2371217/" title="Financial Planner">Financial Planner</a></li>
+            </ul>
+        </li>
+        <li><a href="/content/location/?locale=en_US" title="Locations">Locations</a></li>
+        <li><a href="/talentcommunity/subscribe/?locale=en_US" title="Join our Talent Community">Join our Talent Community</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="lower headersubmenu">
+            <div class="inner limitwidth">
+                <div class="links">
+                        <div id="langListContainer" class="language node dropdown header-one headerlocaleselector">
+        <a id="langDropDownToggleBtn" class="dropdown-toggle languageselector" role="button" aria-expanded="false" data-toggle="dropdown" href="#" aria-controls="langListDropDown">Language <span class="caret"></span></a>
+        <ul id="langListDropDown" role="menu" aria-labelledby="langDropDownToggleBtn" class="dropdown-menu company-dropdown headerdropdown">
+                <li role="none">
+                    <a role="menuItem" href="https://jobs.scotiabank.com?locale=en_US" lang="en-US">English (United States)</a>
+                </li>
+                <li role="none">
+                    <a role="menuItem" href="https://jobs.scotiabank.com?locale=es_ES" lang="es-ES">Español (España)</a>
+                </li>
+                <li role="none">
+                    <a role="menuItem" href="https://jobs.scotiabank.com?locale=fr_CA" lang="fr-CA">Français (Canada)</a>
+                </li>
+        </ul>
+                        </div>
+                        <div class="profile node">
+			<div class="profileWidget">
+					<a href="#" onclick="j2w.TC.handleViewProfileAction(event)" xml:lang="en-US" lang="en-US" style=" ">View Profile</a>
+			</div>
+                        </div>
+
+
+
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+    <style type="text/css">
+        #content {
+            padding-top: 0px;
+        }
+    </style>
+
+    <script type="text/javascript" classhtmlattribute="keepscript" src="/platform/js/j2w/j2w.bootstrap.collapse.js"></script>
+    <script type="text/javascript" classhtmlattribute="keepscript" src="/platform/js/j2w/j2w.bootstrap.dropdown.js"></script>
+            <div id="innershell" class="innershell">
+                <div id="content" tabindex="-1" class="content" role="main">
+                    <div class="inner">
+
+                <div id="search-wrapper">
+
+        <div class="well well-small searchwell">
+            <form class="form-inline jobAlertsSearchForm" name="keywordsearch" method="get" action="/search/" xml:lang="en-US" lang="en-US" style="margin: 0;" role="search">
+                <input name="createNewAlert" type="hidden" value="false" />
+                <div class="container-fluid">
+                    <div class="row columnizedSearchForm">
+                        <div class="column col-md-9">
+                            <div class="fieldContainer row">
+                                    <div class="col-md-6 rd-keywordsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Keyword</span>
+
+                                        <i class="keywordsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-q columnized-search" name="q" maxlength="50" aria-label="Search by Keyword" />
+
+                                    </div>
+                                    <div class="col-md-6 rd-locationsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Location</span>
+
+                                        <i class="locationsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-locationsearch columnized-search" name="locationsearch" maxlength="50" aria-label="Search by Location" />
+                                    </div>
+                            </div>
+                                <div class="row optionsLink optionsLink-padding">
+                                </div>
+                        </div>
+                        <div class="rd-searchbutton col-md-2">
+                            <div class="row emptylabelsearchspace labelrow">
+                                 
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12 col-sm-12 col-xs-12 search-submit">
+                                            <input type="submit" class="btn keywordsearch-button" value="Search Jobs" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </form>
+        </div>
+                        <div class="row clearfix">
+                <div class="span6 col-sm-6">
+                    <div class="savesearch-wrapper" id="savesearch-wrapper">
+                <div class="well well-small well-sm">
+                    <div class="savesearch" id="savesearch" xml:lang="en-US" lang="en-US">
+                        <div class="alert alert-error alert-danger invalid-feedback frequency-error" tabindex="-1">
+                            <span class="alert-icon-frequency-error fa fa-exclamation-circle"></span><div class="frequency-error-message" aria-live="polite" id="frequency-error-feedback"></div>
+                        </div>
+        <span class="subscribe-frequency-label">
+            <label id="labelFrequencySpinBtn" for="j_idt271" aria-hidden="true">Select how often (in days) to receive an alert:</label>
+            <input id="j_idt271" type="number" class="form-control subscribe-frequency frequencySpinBtn" name="frequency" required="required" min="1" max="99" maxlength="2" value="7" oninput="j2w.Agent.setValidFrequency(this)" aria-labelledby="labelFrequencySpinBtn" />
+        </span>
+                        <div class="savesearch-buttons-wrapper">
+                                <button class="btn savesearch-link" id="savesearch-link" tabindex="0"><i class="icon-envelope glyphicon-envelope" aria-hidden="true"></i> Create Alert</button>
+                        </div>
+                    </div>
+                </div>
+            <style type="text/css">
+                form.emailsubscribe-form {
+                    display: none;
+                }
+            </style>
+
+        <form id="emailsubscribe" class="emailsubscribe-form form-inline" name="emailsubscribe" method="POST" action="/talentcommunity/subscribe/?locale=en_US&amp;jobid=599350817" xml:lang="en-US" lang="en-US" novalidate="novalidate">
+                <div class="well well-small well-sm">
+                    <div class="alert alert-error alert-danger hidden frequency-error" tabindex="-1">
+                        <button tabindex="0" type="button" class="close" onclick="$('.frequency-error').addClass('hidden'); return false;" title="Close"><span aria-hidden="true">×</span></button>
+                        <div class="frequency-error-message" aria-live="polite"></div>
+                    </div>
+        <span class="subscribe-frequency-label">
+            <label id="labelFrequencySpinBtn" for="j_idt282" aria-hidden="true">Select how often (in days) to receive an alert:</label>
+            <input id="j_idt282" type="number" class="form-control subscribe-frequency frequencySpinBtn" name="frequency" required="required" min="1" max="99" maxlength="2" value="7" oninput="j2w.Agent.setValidFrequency(this)" aria-labelledby="labelFrequencySpinBtn" />
+        </span>
+                    <input id="emailsubscribe-button" class="btn emailsubscribe-button" title="Create Alert" value="Create Alert" type="submit" style="float: none" />
+                </div>
+        </form>
+                    </div>
+                </div>
+                        </div>
+                </div>
+
+                <div class="jobDisplayShell" itemscope="itemscope" itemtype="http://schema.org/JobPosting"><span itemprop="jobLocation" itemscope itemtype="http://schema.org/Place"><span itemprop="address" itemscope itemtype="http://schema.org/PostalAddress"><meta itemprop="addressLocality" content="Toronto"><meta itemprop="addressRegion" content="ON"><meta itemprop="postalCode" content="M5H 1H1"><meta itemprop="addressCountry" content="CA"></span></span><meta itemprop="datePosted" content="Sun May 24 02:00:00 UTC 2026"><meta itemprop="hiringOrganization" content="Scotiabank">
+                    <div class="jobDisplay">
+                            <div class="content">
+                                <div class="jobTitle">
+                    <div class="applylink pull-right">
+                <a xml:lang="en-US" lang="en-US" class="btn btn-primary btn-large btn-lg apply dialogApplyBtn " href="/talentcommunity/apply/599350817/?locale=en_US">Apply now »</a>
+                    </div>
+                                </div>
+                                <div class="job">
+    <style type="text/css">
+        .buttontext3af2b517d67c87d3 a{
+            border: 1px solid transparent;
+        }
+        .buttontext3af2b517d67c87d3 a:focus{
+            border: 1px dashed #7849b8 !important;
+            outline: none !important;
+        }
+    </style>
+    <div dir="auto" style="    " class="buttontext buttontext3af2b517d67c87d3 rtltextaligneligible center unmodified backgroundimage backgroundcolorb6a533a1 linkcolor7e1f44b4a96faebb linkhovercolor7e23a4baa17a2110       display marginTopNone marginBottomNone marginRightNone marginLeftNone customSpacingEnabled">
+        <div class="inner " style="font-family:Arial, Helvetica, sans-serif; font-size:16px;"><span class="fontcolor098bfe3a142e91e6"><h4>Please be advised that our Careers site will be <strong>unavailable </strong>from November 28 at 12am ET to November 29 12am ET for scheduled system maintenance.</h4>
+</span>
+        </div>
+    </div>
+    <div class="joblayouttoken rtltextaligneligible displayDTM ">
+        <div class="inner fontcolorb6a533a1" style="font-family:Arial, Helvetica, sans-serif; font-size:16px;">
+            <div class="row">
+                <div class="col-xs-12 fontalign-left">
+                        <h1>
+        <span class="joblayouttoken-label">Title: 
+        </span>
+
+    <span xml:lang="en-US" lang="en-US" itemprop="title" data-careersite-propertyid="title" class="rtltextaligneligible">Technical Delivery Lead (Governance) 1
+    </span>
+                        </h1>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="joblayouttoken rtltextaligneligible displayDTM ">
+        <div class="inner fontcolorb6a533a1" style="font-family:Arial, Helvetica, sans-serif; font-size:16px;">
+            <div class="row">
+                <div class="col-xs-12 fontalign-left">
+
+    <span xml:lang="en-US" lang="en-US" itemprop="description" data-careersite-propertyid="description" class="rtltextaligneligible">
+                <span class="jobdescription"><p><span style="font-size:16.0px"><span style="font-family:Arial, Helvetica, sans-serif"><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQMAAABICAYAAADyOZDQAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAABxuSURBVHhe7Z0HmBRF2sf/0z1xZ5ddktnPnM5TkBM5URARA2Ii6JlQVIwgJgRRznDqiadySBADqBg4VMSsKIIgICbO7OmJOZ0IsrC7k7vne/8107s9YZcFdhd8qN/zNDtdXf1WdYW33qp6u/GkBWg0ms0eI/tXo9Fs5mhloNFoFFoZaDQahVYGGo1GoZWBRqNRaGWg0WgUWhloNBqFVgYajUahlYFGo1FoZaDRaBRaGWg0GoVWBhqNRqGVgUajUWhloNFoFFoZaDQahVYGGo1GoZWBRqNRaGWg0WgUWhloNBpFy38DcU0V7K+/hv3zL0hHo4DPC6NNW3i23grG9tsCXm824uaNHYkiveQtGFJG9r5/hPl/22evaDTNQ4spg5Q0bGvqNCQWLoZnxUoE4VFmic1rSCNqmvBKg/cf2AXeASfAPKSbum9zJLX0PVgXDIPvq29UGcVCQdgjLkPJsIsyEVoI68efUHPmufBYFqxsGPNjSt0FJ98Jc8/dM4GbOdZn/0X8wktUO2Z7Jh45SuRfzz9ugrfznzKBmzjNrgzS0pBi11wP474HEJDCqZLkklJo7kRZcGxkfo9HFWBSfltdu8C4dAj8hx3KKJsN6crVqOxyCFqLwlyZzjQtlluplE3yXw/Cd8RhKqwlsJZ9hUSX7vDxdyZI1ZNX8pN6+Rn49u+UCdzMSb2zFN6jTlDt2q0M2J4T0x+A/4hemcBNHNZt85FKoebUQQhNmYaoKIEV0rgTeYqA8JyNzYmzRo7gkncQf2i6ur45kZgzVykCloNDLFti0QcfVn9bDMNAVI5qqZf8wyOWnCaLlEWxMkrI4fkdTXubVRlUjbgGpXMXYKWdMTOpLdcG47CZVXnSKBk9UoX9nkm88irsvqegql/dUd33ZKz5y0CkV/6WjVWH/euK7K86WCa0lrCqkv9qNM1CsymD5OIlCE2bjlWiCPLhOMeEaf4GxZRy605eq/DI1f7Hw9xt10zg75j0t9/DWPgGQgsW1R6lry+GMee1zAJqHr4D9pe5J03xOlgmPiknU5vlmmak2ZRBdOwENcLnqwI27FZUAJwDt2+LxFZbIhUISJiB1nJwYbHaNFAy/NLMDb93/D6kxeRfnXckAn5lhufjlQ4fPfVEVBgmyqSMSuRoJ7+rttsGoYsvyMbSaJqeZlEG9s//Q2rxG2ru754aOIogKaNf6IVZqHh3EVovXYzW8hfT7kX8hGMQkOv2cX1g7rpL5qbNkLIJYxG/4RrYnToivdceSJxxCkpefArGFltkY2g0TU+zKIPUx5+iLGkpc9dNSDp6fMcdUPLUDHj/fAA8ZWVAMAhj223gO6Y3QlMnwzPvBZRef03mhs2YwJDzEZzzPEoWzYV/7K0wt9k6e0WjaR6aRRmkf/o5Z87rEBY7wdO1CzyiAOrD22FfGNttmz37/eMJ86mLIIrRU1GePdFoNj7N4mcQu/d+BEddV7tP7sC98piYvuUy4jU11tvvwpo3H6kPPob1009Ix+LwlITg3X47eLt0hnnU4TB22Tkbu2HsL7+CNXsOUm+9g9R33yMdjcETCiqnqMbIsr79Dp4lbyHpMZBatBjm9MdR4ypmamDb60XJ30bDW9Eatt8Hf5/e8AT8alEx8fxLMCy7ds+ayBXYMr0yd94pG1IcW/JrvzAbicVLYH33A9KJOMyKCvj26wCz3/Ewsw4wyQWLYP78M5IuVcU0rN13hbfTfurc+uobrO7SXfKS63REP4PQvBfh7bgv7NVrYM18CtZrC5D85jukUymYbVrDt8/eMI88HGbPQzI3rgfW64uRmv0KUh9Kna5YqbYzfVIHZo9uMAf0hdG2DdJVVUi+8LKK75Qwn4iH98he8LSuUGGJua/B/HWFWKt1z+vj8267LXzduqpzS6a31kOPIrXwDaQkricQkDrfTq4fBI9MYc0tt1Tx8kn9+33Eeh1T4GfA9u554hH4evbIBLpIPP0cIO0qLXEcuOkeTIlFvdsuqp21NM2iDBIvvQLz9HNQmacMCAsofelQBP96VTZkw0jOmQdr7ATg7XfU4iMbrePUxGL2yb9cyKz2eeGTzuAdNRymKIhisONbt9yOxKxnUCaV0qCsvsfBFFlUEPnE//UEAhcPhy3PH5e7uefsNsEceeWiLNixVqYttFn2MTzSiWyxqiJ/7CzlZEjDqqsaQ85jY25AcPCgbEgudnU1UmPuQHLaowhHojl5Z579ko7yVzipPwJjx6Bq0HloNfd1lUcHplFz2okI33m7Oq9PGZgSL/zvxbA+/QzWyNEI/fhz0fQ4TUx1EiV0zUj4pAM3luSbbyP1tzHwvvW2KnP6pjjpU64phRdt3w7GzdfDd2AXpKW8mKbzJJmylvTnPCuKraM6W939cJR/+rk8b26Zrul+IFrNmoHYM88hfcXVCFVWIilR6E3orvOoKBWP1HfwnDPVvW7WVRlEJt6Nkuv/Dna9utwwP9J+Jcye/TR8G8Fr0d1Gmwxf505YLaMcPdfc8ME5QvrHTULkiGORfHQG0qKN14e0bSM6/GoYJ58Jr1gFEZFLRx0qIKbBc/7lOcOtRAKBx55E4tDeiL+YGUncxGU0Tcq1wOOzYCeTa5cl8VI9j1b3FSAjvSXxVsnBe/MLmQ2FcFehSg41XXBGCMNAPBhQi6+83zm4IwHuQBQh9cUyxI88Dv67p8KqiRTknV6fDKNTV/CJWVhz7InKxyEiSsidhhQqEAplpRaHdZgSZRi5/mbETzsbnh9/qjc9Pp/33x8g3f8URG+/MyNgLcQm34tUn37wi1XmyOFfyuWh6kDqPr38V9jnDkH1VX9FpZSX+zl4qMVrl8MP16eSeXGoCM3ttxcraSHMsy8EVq1Ssnkv03LXuS3XgiP/ippbbstKXD9o5UAU3RpJ5zeR6+SF6UglIznu1o2iCEizKANPu3bwi1nF7UK35mNz5zkf3rv0PXiHXYmqA7ojcuLpSM2YCVtMvkYhBVkz8ByEHnxEVRwLknKdTpYPwzlKsVI9UqmBgYORktHHISaWAM4YDMiowDiM2xhZaZHF+2JPPauubQysb75F/LgTEfzsC2nIlhqdiuWdYRy12Nj9770PQzopG/y6wjvSogz9z74go3XG6qkvPcK6oRIKidVSc/Ot2dDiRMbfheDoG9XIzDZSX50yjHmPyRGQKRX4Mlfm0joRkRRS73+A6vOGSrllBqr60uMzrJbyDd8+HomXX81cWEdYbpHzL4ZfLC1aOw781Ub6StWxvREceGomcCPQLMqAlIySji5zdjUtyIa5obanZkzX1CAwbwG8Qy5DrOthSIjVYMdi2VjFqRp1LUpfnqs8G9kIilVgsQdjPE4lInRo+sOeKoya2r5gmOrg9TWG+mQxPu+zpYKtjz5R4S1KIqleJCpZvkKtz9SXd5q5zjX+ZUdiYywWv7FQCdB0d2QwDXc6DjxnR6tkRxo7EfFniq8XJebNh/+GW5RyL5Y3njtpEJ6z7pmP9YXKxPPRpzB/XanKhDLz03VgOJ9DKY1rb1RrI+tKzegb0Oq/y5SCdNJh7tlHqrbaEuFxG2Z1bCjNpgwMmZf7p9wlP0zlW1BflbFIWThqsfGnn+C/aQziYn4nxfQvBt9+DE55UDUuN5TPh6HjEp11ONdzHJmch2wrJnjNiX1Rcu9EeFq1UhZG9bArELQyo5e7ghxZzHtGlqdWlvMsjK9Mb7m/SuRQniKeUPPqtnKE5b78Ucu5P5NXA57K1RJYXwnVT3TiZLT65LMCRUBJ9NfgaMNwyzTVtm5+/jcUyqFTFOXyGZkOn5drIc51wjywnrlmER1xDdJrci3AtCj/yOVXiQwqqboO6dxPeewwlM9ap4cq09nQ52A6tKSofFi/TIflxr9sQ/nyGZ/KqnTZV9IO6yzLBsnWa3z2HASnPqQsHuf5CCcyPA/cNQ7GRt5dcvpJsxA4sheMWf+CvcMOaCcdkQXdEOxYNGN9n3+BlJi+HC3yqbn1DhkdMotTDixujviUHzupH/DwVARffR7ph+5DXDo/w9uKUooM6Ivw3eMzNwmJ519EhYwM7gqiLLpJ842zmNxbJ2uKOqcsXncaCu/j/RUffqLkEbXKfvlQRK68BMnDe6otVTdqdPOaiJ5/NuLDhyEweiQ8a5mr55NevQaxiXeLdVKoCMpZzlu0R/z6q1G24BVUvL0Q3qdmIHbKAOX+7c7/+sL7qQSsXXZG8o5bUP7GPFS89TqM6Q8i0ftw1aHY0N3lxFG8YsVviOW9cJWY8QQqvv9ROlquQmY5seMnuCMh5U/5FW/OR2r8bUjttadSdhv6HITPkezSGdbkcQjMfgbWPTIVOLCLCs+H6XEtLPnaAnW+VsJhZf0mZLCg4nEPYZTF50tefCH8hxycCdyItMj3DCxuP0nDTT48HWExydiR2YhpcuV2kwzMEDVzvLQUpVL5xtZbqXCublcd0E2NwO5CZeV4/X54p06Gv89RmUAXiRkzYS1cjNCkf2ZDMlT1PxUl8xfmKAM2YK/PB//9k+Hr0zsT6IIdPnnORUglk7UKifllw6zu0Q2tnsx90zLx5NPwn3dxzjYr07CCQbT5SqYWeT4X9v9+wapOXeGLxVXjcaD8+Lhba+eUasdi6OWZdRAVksmH8vDcY3eEZj4Ko4ijEvNjnT8McbGscm0rsZwkjZpzByE85kZ1Xmw3gTAddpRY964oEWXpkXrKJz5hMozr/y7Twczc34EjfHT33VCxeK4MRZnOtrrXMSh57wM16rpRHWX4JQiOGp4NqSMdjyN6zoUIvjRHTTfd7YhSOWCE58+Gue8fVdiaPv0QevNtpXAcnOeg52uJtJ18OL8PzHy6YDRnviJHHoYyUXykvt0EWmO+l59FbOqDKH38qYK6Yto1HfZBKxlsirmmtzQtkgOzvBX814xAaIlo9Yl3IHGodOhAAO2kMFhg7sZCWGBcU2hVHUF0vEw1siSXvIkKiZzfiLkNBxldiykC4j95QIEiSK+qROKdpbVzRQdltousYoqA+I85Gh55Fk5BHHi/Wj94d6n6HoGbdHV1wfMpJL7926rsybqTFKuJct15p5JJiVIMiCIrpgiIv/8JsIeer0bu9YWWRaRta4Tuv6eoIiABGe1ix/YuSIfWH/77hSiar9U5t1Ktjz+ReshVBLwvcmj3ooqA0AcgdN8kVG+zlWpD6wOfo0ZM8+DY4gubIbF4qttUqHhuuHDK9rM2+MGe6G3/hP3YkzlTOdYbLdlYMICwTFk3BUVAWjQXRusKeE85CSUzp6NsyWtIXDcK9vbbFTX3WHAR0bOJ58T0ljk44Rdl8uG+82qpsFCR/d+GsL7+GgEx39yjb2NlhQYPQmXrchXfgXL81TW1jby5saRD0YfBDRVZ6rAe8O65RzakOKELBmNNUCyp7Pm6QqvNOKm/qs+GCA29AAkpIndXoiIvlRBLpoLqfNmXCIuV5VbwjE97Ijjk/ExAPXBq5RVLqR4fz7WilEinjjBksCoGFZ2n85/Uukg+/GhPQ7BmGMd49TVlQbpritK45mHccgPMXRvnCNcSbDSVZOy4A/zDLkJ44RzEj+c2ZGGB8+MQ4Mjx3XfqnFt5uc1fNKzcZ0rjX9c5N0fl/F37gGTBEBPWU1KSDSkOr5tiijO+G8qzfyv8RkGTk7JgiwWSO5Zm5tjejh0yJw1gbLWlKOHt1brI+sB0HWeehuAr6JHSsCid3HSYT3tF5rsN9HfgdXe98voarxfevRpWasTXqYOabq4PzBW9VBuC7Wr9SkmQ9ssdCz6bWwanGVUDTkDojNOyIZsGG90+oTMIv6cX3WILtTjnho2Onb32gx9FGi8Len22eYrJUqxF4zvUl6anpUy+Dcx/o+PVR2Pu5+6Kna++M9SWUz3PQfWwttFXYeXO59cZZweoPtZ2fS0Uaw2cZng2wQ/VNGvLTUciSIsJuDbok29t2b7AY5EorZptMEa7dgUVH5O5WPo/n6vV9XWBsuIi3C2PWhwyFcmf9+djS0WmJZ6Kn4VyKI9ymx2vCaNNazWCulH74C5nqvqwv/kW3u9/kPzW5X9d4LMml7yVOWmA5EefoFSmYnTtdUM16sm+jm20b6emWO564PXylI3k+x9mAhogIflY3+lOsyMKj0/Odu0uAS5ils2dr/wONiWaVRlUXXIlEj2PRkrmTQ3BF3v8X36V07kIG4j6jlx2bkpHofzmy9WE8qpqRMZNzAQ0EnPnHZGUeT99CBwoq1UjZEXlenl1jYrvQDkJkWeI3JaAZZG/sFUtitG/8A3VQRoiMnaCzNNTtbsh6wp3CDDzafUuR0PEx/EDN4VTgGrDA2/2y8rG7jKV4AtB6qwO5XNw56TsWXGs5b8i/ehjarF5U4M1ww/4BEdcBiscztnO5TXuUIQmT6nXCSuf9C/LC/wzmppmUwbcbvHNegbmp5/B/stARI7pj+SMmbnvIoipbXFb5sxz4YtEC+Z+/NSX3a4tjOzLQL6DDkSljIruhsOCpQ+8Mf4uxKdktnryif9zAmL9T4Udi2dD5D6Znvi6/jnHeYWy6ABlTJiM+H0PZALzSEi4MfHuAi8yyqG8+lbXmxp+cTe/CyijWvKVHHwRUh98pMLyiUve/Y/OyMn/ukIlyMXXxOnnwCqmEKRzxkZdi/CCxapu3JTIfNnYZ28YO/yfOjfat4d3//2k/HKbIkfP8NL3Eb1kuFiXhWrLls4RH3gOgr+tKlhI3VQIyRQjcMzRCI/7R2bRNRtOWFdRyXfq4ivUV6jrg58PjJ59AZK33Ibk8FGIjRwtJmzDHrrrS7Mpg+qrr1Or7Wx0dDbxLXkb5pDLUNm5Gyq79sTqw45GZZfuqO7VB14xJ6nd3Y2T1ctVZ/8h3WoX9LhdxtdSue3krn42FVoQxsi/ovq4E9Ur1PQHiN4zFdXHDoBx060ILliE6GmDlH+4Q+CsgUpOfiVRlnnVtTmy+JfnhoTzuns2y/spJ3T2Geq8JfAd3hOVMrVyr3TzF7c4zf/9gmjvExCVhpN8Za6aOsT5GnW/k2Fed7PaTt2QmTDTWS0yfJ/8BxGx/KI3jlFOOPQOjU2dpurUf+8Dqu7dsIy4yBrMWzgLDhpYMOVhGhw9A488hpqevRGTuky+8SaS8xciOuZ21PQ4Ev5339sgpdYScKGU27lV/Y/P2TVjnpX3ak0EkbPOl0bntjMzcECNXHeTeg2cC8OefsfDI8qz6oJh6kW9pqZZnI7iYhEEzh2a42jjQHPaJyXBDsQOxXkr/+ZXKEd/Wgb+12bDm3UcIZY0wFi3w+Ue/v8LdfAhKMNxRaZMNjDOR6loeJ1+DTU9DkbJ9GlqnYKsPv4klC9aUuAQsjZZ7riUW3nwgah45vFMoIv4tEfgv3yUcoxx4LNZYhpXLF1c4A/QWKcjEnvgYQSHX11QzryL81T6QlAGlSXNVMaiY487/24a63TkQDmUS0ci5zVj7p875eROg3HpGVmz4w4oXzwPnmAgc4GI/Erp3GWffl7g4MP7KJ/p0J2Z1/ibSs85z4dtqzFOR8p56OgjUPbw1GxIIVXSUcPPvqjy5cB2Ef3Tfih/5Tl13phXmPmdiupDeyP0xZcFViXbT9XJ/VE2aVwmMEu1WHjBi85DYv7rats6KlPpkquvROyu++A/tjd8vXpmYzYNTW4Z2L/+itjoG5QJVFfsdbDAODLRWqBmZOHlVyjPyw0T9hXDchQBMffeC5ACaSXXGc9Jw5HBRsiOR/OUf3lOeJ0dPjx/ESInnY708uUqvPTO21BTVqoqeF1kEZ7xPt7fanzmGwAtSVAsmzXduqpO7OSdMH9UAMwzy5lrMWyAjoefk/8NhXKoBJiO6pxysNMwTXcazJujjPithBxFQEwTpePvQFzKkht5+c9C2UyD7YVth785NWiq52gJuEUZevAeJOTZqTCdZ+Qz8HnKZjyJyAMPZQKJPKctUzFu4XpkCu2JJzKvZFs2vH/ujFQzvBjX9MpARhOfzOc4ReCDuit2bTAuR+I20tH5QlHp1SMyF/IID78ENWecquIxnXVJg53Es+gNWN//qM5NGal8MjLYwaAaKRori/FUfKlk38NTaufALU3Z/XejZs/d1OhSDObT/Uz8zRGL1kljn7UAuV+tkbjKPj8dB4bRuYdp2rfdDJ9YUMXw7tcBxqSxanuZU5/6ZDnh/MtnoFzm5/eAd889YIwdo8rOPS2iklQDzchrkRQrQyFxuP3K7zbw/x9N/vCjtNkf1MIxvzHquOg3JU2uDPi5Jt/cF5AQ7UXTlv7X+fPBYrBTs0F7/T7ERlyG8OSGP4YRlkKNiYXglYJS92XD64ONjJ8cT+66M3xznoNXzDwHv4yu3mefQHKXnVScfH+HfGplSXxTpgb+bgdlrxSH0vIPav56kWtF7ykCv44UfPpxRLsfpN7KrM81l6mx8zLfid5HwHPQgRkzVsIbkp+fFzYYw+eDde5ZsGWq47zMk/80PGe9s24MUbSJCXcgdHbDnp3BvwxAasoktQjL+3h/faWk1o3keVODB6lvajKuO588cqivTBuqB9LI+4rF4ZEPn7HmrNNry41x+IsWlk+mSzGZltChjPj7HY/qy0bA2GM3+KU/BC8Zguidk2Sq/Gm9rvcbQpMrA+Lr2EF9Ct2adq96D8GQRkPFQHOWoynnsqxMFgjD+NvTtrX6JLhf5nncjmkMwcsvhv/V59WLJmxwlOXIYxpMi+dM29iiPRISPyCKypf9xp8bnyiHwLwXkbhsKDzt2xXk1y2L1xmP8XlfQyg/C+l0HO3ch8kFo2INkY0vHi+ITxn1+WyYkp/QUzOQuPFaeLbdtjbvTjmwnPnWqFkSQvzSISh75H54ZGoTlPCCNLKu3wrbRlDy447DUa08mULownNR+uIsJDvuk5EvR056cvA17nifI+GTOgqcelJWaMME+x4H37yXEOt7bK2i5/M4bcapA0tGyLAo8JBYiSWxmMqXO5883A5DfLGJW33u6/zMmHtBuRi8Tj8X931cy6K8WiQd93V3vGLOWaVjbkRVpw7qTVonLvNPf4yyH39G9ZmD1Y5BoP8J6j9t5bsNqTEyvXp9EewFC1Hy979lvizexLTIW4v2N9/BeusdWB9+pHwK7KpqNf/hBy1NGV29+3WEsX8nNcqtLzblivmfeu9DpMSc4oKNEQ7Du/OOyloxuh/c6K8R0+nIkkJnnlNff6ucp5QL8k47ZD6Iyh2ORsrigqCx7Ev19R4HjgbSEjP/O68/1ymajY//kadh5674c9HV3nUX5UrcEHxd1pq3ANbiJUjKlI2r1GbbtmIJSRnLaGJmpzM0Nc3KSqRc+WIa1jZb1350ld8ZsN59T37Urf8w7zwMUQJskGw+1itzMx+j/fLrzAdRRTl5O+wDo2eP2o/IrA/2F8tg0bf//Q9hLV8uZrMJ7047wuzRHeZRvVQbYt1YSzOmdUEe99u3dquXW61mVVXO83r5vG3awNtAHq3PPoe5YmVO/an7RC5fVSdpac+25JFR3Hngtxqx9x9q/WTc0HHNkBHeLdfBI+Xu7dpFzN+wOrdkigBuFYsCN2mFUsk0Ay2iDDQazaZPs0wTNBrN7w+tDDQajUIrA41Go9DKQKPRKLQy0Gg0Cq0MNBqNQisDjUaj0MpAo9EotDLQaDQKrQw0Go1CKwONRqPQykCj0Si0MtBoNAqtDDQajUIrA41Go9DKQKPRKLQy0Gg0Cq0MNBqNQisDjUYjAP8PkYd8GPWUPd4AAAAASUVORK5CYII=" style="float:right"></span></span></p>
+
+<p> </p>
+
+<p> </p>
+
+<p> </p>
+
+<p><span style="font-size:16.0px"><span style="font-family:Arial, Helvetica, sans-serif">Requisition ID: 249373<br>
+<br>
+Join a purpose driven winning team, committed to results, in an inclusive and high-performing culture.</span></span></p>
+
+<p> </p>
+<p><span style="font-family:arial, helvetica, sans-serif">We are looking for a motivated and adaptable Technology Lead to join our growing team. This role is ideal for someone with intermediate experience who is ready to grow into a leadership path while playing a key role in how we govern, deliver, and scale technology across the organization. </span><br><span style="font-family:arial, helvetica, sans-serif">As a tech lead, you’ll work horizontally across multiple platforms and teams — helping to shape technology governance, vendor/contract management, technology spend analysis, delivery planning, and cross-team coordination. You’ll be a connector between engineering teams, business stakeholders, and leadership, ensuring that initiatives move forward efficiently and with the right guardrails in place. </span></p>
+<p><br><strong><span style="font-family:arial, helvetica, sans-serif">Is this role right for you? In this role, you will:</span></strong></p>
+<p> </p>
+<p><span style="font-family:arial, helvetica, sans-serif">Technology Governance &amp; Standards </span><br><span style="font-family:arial, helvetica, sans-serif">•    Contribute to defining and maintaining technology standards, architecture guardrails, and best practices. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Support review processes for new tools, platforms, and integrations. </span><br><span style="font-family:arial, helvetica, sans-serif">Vendor &amp; Contract Management </span><br><span style="font-family:arial, helvetica, sans-serif">•    Assist in evaluating technology vendors, contracts, and SaaS platforms. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Support procurement, licensing, and vendor relationship management. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Track contract renewals and support cost optimization efforts. </span><br><span style="font-family:arial, helvetica, sans-serif">Technology Spend &amp; Analysis </span><br><span style="font-family:arial, helvetica, sans-serif">•    Partner with finance and procurement to analyze tech spend and provide insights on optimization opportunities. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Build dashboards or reports to improve visibility into technology costs and utilization. </span><br><span style="font-family:arial, helvetica, sans-serif">Delivery &amp; Planning Support </span><br><span style="font-family:arial, helvetica, sans-serif">•    Coordinate with engineering, product, and operations teams to align delivery timelines. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Help track dependencies, risks, and resource allocation across initiatives. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Support sprint/quarterly planning cycles with data and insights. </span><br><span style="font-family:arial, helvetica, sans-serif">Cross-Team Collaboration </span><br><span style="font-family:arial, helvetica, sans-serif">•    Serve as a bridge between different engineering and business teams. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Help resolve blockers and ensure alignment across projects. </span></p>
+<p> </p>
+<p><strong><span style="font-family:arial, helvetica, sans-serif">Do you have the skills that will enable you to succeed in this role? We'd love to work with you if you have:</span></strong></p>
+<p><br><span style="font-family:arial, helvetica, sans-serif">•    4-6 years of experience in a technology, engineering, or IT-focused role with exposure to multiple tech stacks. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Strong analytical skills with the ability to interpret financial/operational data and present insights. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Experience working with technology contracts, vendors, or procurement. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Familiarity with project delivery frameworks (Agile, Scrum, or hybrid). </span><br><span style="font-family:arial, helvetica, sans-serif">•    Strong organizational and coordination skills; able to manage dependencies across multiple teams. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Solid communication skills and ability to work with both technical and non-technical stakeholders. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Exposure to cloud platforms (GCP, AWS, or Azure). </span><br><span style="font-family:arial, helvetica, sans-serif">•    Prior experience in technology governance or enterprise architecture functions. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Hands-on familiarity with collaboration and planning tools (Jira, Confluence, Smartsheet, PowerBI, etc.). </span><br><span style="font-family:arial, helvetica, sans-serif">•    Experience in financial services or other highly regulated industries. </span></p>
+<p> </p>
+<p> </p>
+<p><strong><span style="font-family:arial, helvetica, sans-serif">What's in it for you?</span></strong><br><span style="font-family:arial, helvetica, sans-serif"> </span><br><span style="font-family:arial, helvetica, sans-serif">•    Diversity, Equity, Inclusion &amp; Allyship - We strive to create an inclusive culture where every employee is empowered to reach their fullest potential, respected for who they are, and are embraced through bias-free practices and inclusive values across Scotiabank. We embrace diversity and provide opportunities for all employee to learn, grow &amp; participate through our various Employee Resource Groups (ERGs) that span across diverse gender identities, ethnicity, race, age, ability &amp; veterans.</span><br><span style="font-family:arial, helvetica, sans-serif">•    Accessibility and Workplace Accommodations - We value the unique skills and experiences each individual brings to the Bank and are committed to creating and maintaining an inclusive and accessible environment for everyone. Scotiabank continues to locate, remove, and prevent barriers so that we can build a diverse and inclusive environment while meeting accessibility requirements. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Upskilling through online courses, cross-functional development opportunities, and tuition assistance. </span><br><span style="font-family:arial, helvetica, sans-serif">•    Competitive Rewards program including bonus, flexible vacation, personal, sick days, and benefits will start on day one.</span><br><span style="font-family:arial, helvetica, sans-serif">•    Community Engagement - no matter where you choose to work from; we offer opportunities for community engagement &amp; belonging with our various programs.</span></p>
+<p> </p>
+<p> </p>
+<p> </p>
+<p><span style="font-family:arial, helvetica, sans-serif"><span>#BFUTR </span> </span></p><p> </p>
+
+<p><span style="font-size:16.0px"><span style="font-family:Arial, Helvetica, sans-serif">Location(s):  Canada : Ontario : Toronto <br>
+<br>
+<span style="color:#444444">Scotiabank is a leading bank in the Americas. Guided by our purpose: "for every future", we help our customers, their families and their communities achieve success through a broad range of advice, products and services, including personal and commercial banking, wealth management and private banking, corporate and investment banking, and capital markets.  </span><br>
+<br>
+<span style="color:#444444">At Scotiabank, we value the unique skills and experiences each individual brings to the Bank, and are committed to creating and maintaining an inclusive and accessible environment for everyone. If you require accommodation (including, but not limited to, an accessible interview site, alternate format documents, ASL Interpreter, or Assistive Technology) during the recruitment and selection process, please let our Recruitment team know. If you require technical assistance, please <a href="https://www.scotiabank.com/careers/en/careers/technical-support-for-applicants.html" target="_blank">click here</a>. Candidates must apply directly online to be considered for this role. We thank all applicants for their interest in a career at Scotiabank; however, only those candidates who are selected for an interview will be contacted.</span></span></span></p>
+                </span>
+    </span>
+                </div>
+            </div>
+        </div>
+    </div>         
+            <p class="job-location">
+                <span class="jobmarkets">
+                </span>
+                    <span class="jobsegments">
+                    <br /><strong>Job Segment: </strong>
+                    <span itemprop="industry">Information Technology, IT Architecture, Investment Banking, Contract Manager, Engineer, Technology, Finance, Legal, Engineering
+                    </span>
+                    </span>
+            </p>
+
+                                </div>
+                                <div class="clear clearfix"></div>
+                    <div class="applylink pull-right">
+                <a xml:lang="en-US" lang="en-US" class="btn btn-primary btn-large btn-lg apply dialogApplyBtn " href="/talentcommunity/apply/599350817/?locale=en_US">Apply now »</a>
+                    </div>
+                            </div>
+                        <div class="clear clearfix"></div>
+                    </div>
+                </div>
+                <aside id="similar-jobs" title="Find similar jobs">
+                    <div xml:lang="en-US" lang="en-US" id="similar-jobs-label">Find similar jobs: </div>
+                    <div id="similar-jobs-links">     
+                        <a title="IT &amp; Digital Banking Jobs" href="/go/IT-&amp;-Digital-Banking-Jobs/2298017/">IT &amp; Digital Banking Jobs</a>
+                    </div>
+                </aside>
+                    </div>
+                </div>
+            </div>
+
+    <div id="footer" role="contentinfo">
+        <div id="footerRowTop" class="footer footerRow">
+            <div class="container  footer-fullwidth">
+
+    <div id="footerInnerLinksSocial" class="row">
+        <ul class="inner links" role="list">
+        </ul>
+        </div>
+            </div>
+        </div>
+            <div id="footerColumnsShell" class="footerRow footerColumnsShell">
+                <div class="container  footer-fullwidth">
+
+    
+
+    <footer id="footerColumns" class="row footerColumns">
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label=" ">
+                <h2 class="footerMenuTitle"> </h2>
+
+                <ul>
+                                <li><a href="/" title=" "> </a></li>
+                </ul>
+            </nav>
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label="Careers">
+                <h2 class="footerMenuTitle">Careers</h2>
+
+                <ul>
+                                <li><a href="https://www.scotiabank.com/ca/en/about/contact-us/privacy.html" title="Privacy Policy" target="_blank">Privacy Policy</a></li>
+                                <li><a href="https://www.scotiabank.com/careers/en/careers/technical-support-for-applicants.html" title="Required Technical Support" target="_blank">Required Technical Support</a></li>
+                                <li><a href="https://www.scotiabank.com/content/dam/scotiabank/canada/en/documents/E-Verify-ParticipationPoster.pdf" title="E-Verify Participation (U.S.)" target="_blank">E-Verify Participation (U.S.)</a></li>
+                                <li><a href="https://www.scotiabank.com/content/dam/scotiabank/canada/en/documents/E-Verify-RightToWorkPoster.pdf" title="E-Verify Right to Work (U.S.)" target="_blank">E-Verify Right to Work (U.S.)</a></li>
+                </ul>
+            </nav>
+                <div class="clearfix visible-xs-block"></div>
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label="Related Sites">
+                <h2 class="footerMenuTitle">Related Sites</h2>
+
+                <ul>
+                                <li><a href="https://www.scotiabank.com/careers/en/careers.html" title="Global" target="_blank">Global</a></li>
+                                <li><a href="http://www.scotiabank.com/careers/en/careers/careers-students-and-new-grads.html" title="Students &amp; New Grads" target="_blank">Students &amp; New Grads</a></li>
+                                <li><a href="https://www.scotiabank.com/ca/en/about/contact-us/privacy/privacy-cookies.html" title="Cookie Settings">Cookie Settings</a></li>
+                </ul>
+            </nav>
+                <div class="clearfix visible-sm-block"></div>
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label="Connect">
+                <h2 class="footerMenuTitle">Connect</h2>
+
+                <ul>
+                                <li><a href="https://www.facebook.com/scotiabank/" title="Facebook" target="_blank">Facebook</a></li>
+                                <li><a href="https://twitter.com/scotiabank" title="Twitter" target="_blank">Twitter</a></li>
+                                <li><a href="https://www.linkedin.com/company/scotiabank" title="LinkedIn" target="_blank">LinkedIn</a></li>
+                                <li><a href="https://www.youtube.com/user/Scotiabank" title="YouTube" target="_blank">YouTube</a></li>
+                                <li><a href="https://www.instagram.com/explore/tags/lifeatscotiabank/" title="Instagram" target="_blank">Instagram</a></li>
+                </ul>
+            </nav>
+                <div class="clearfix visible-md-block"></div>
+                <div class="clearfix visible-xs-block"></div>
+    </footer>
+                </div>
+            </div>
+
+        <div id="footerRowBottom" class="footer footerRow">
+            <div class="container  footer-fullwidth">
+                    <p>© 2021 Scotiabank.com All Rights Reserved</p>
+            </div>
+        </div>
+    </div>
+        </div>
+            <script class="keepscript" src="https://jobs.scotiabank.com/platform/bootstrap/3.4.8_NES/js/lib/dompurify/purify.min.js" type="text/javascript"></script>
+            <script class="keepscript" src="https://jobs.scotiabank.com/platform/bootstrap/3.4.8_NES/js/bootstrap.min.js" type="text/javascript"></script><script type="text/javascript"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.core.min.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.tc.min.js?h=c4edfb0a"></script>
+
+		<script type="text/javascript">
+			//<![CDATA[
+				j2w.init({
+					"cookiepolicy"   : 1,
+					"useSSL"         : true,
+					"isUsingSSL"     : true,
+					"isResponsive"   : true,
+					"categoryId"     : 0,
+					"siteTypeId"     : 1,
+					"ssoCompanyId"   : 'scotiabank',
+					"ssoUrl"         : 'https://career17.sapsf.com',
+					"passwordRegEx"  : '^(?=.{6,20}$)(?!.*(.)\\1{3})(?=.*([\\d]|[^\\w\\d\\s]))(?=.*[A-Za-z])(?!.*[\\u007F-\\uFFFF\\s])',
+					"emailRegEx"     : '^(?![+])(?=([a-zA-Z0-9\\\'.+!_-])+[@]([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9])[.]([a-zA-Z]){1,63}$)(?!.*[\\u007F-\\uFFFF\\s,])(?!.*[.]{2})',
+					"hasATSUserID"	 : false,
+					"useCASWorkflow" : true,
+					"brand"          : "",
+					"dpcsStateValid" : true
+					
+				});
+
+				j2w.TC.init({
+					"seekConfig" : {
+						"url" : 'https\x3A\x2F\x2Fwww.seek.com.au\x2Fapi\x2Fiam\x2Foauth2\x2Fauthorize',
+						"id"  : 'successfactors12',
+						"advertiserid" : ''
+					}
+				});
+
+				$.ajaxSetup({
+					cache   : false,
+					headers : {
+						"X-CSRF-Token" : "10b39261-d489-47d8-9372-63feddcb8f88"
+					}
+				});
+			//]]>
+		</script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.apply.min.js?h=c4edfb0a"></script>
+            <script type="text/javascript">
+                //<![CDATA[
+                j2w.Apply.init({
+                    jobID                    : 599350817,
+                    locale                   : 'en_US',
+                    relocateApplyURL         : '',
+                    subscribeAtApply         : true,
+                    useOnPageBusinessCard    : true,
+                    applyWithLinkedIn2Config : {"enabled":false,"companyId":null,"integrationContext":null,"internalId":"249373-en_US","email":""}
+                });
+                //]]>
+            </script>
+		<script type="text/javascript">
+		//<![CDATA[
+			$(function() 
+			{
+				var ctid = '86a03340-5c4e-49ea-b8ab-372813593c4e';
+				var referrer = '';
+				var landing = document.location.href;
+				var brand = '';
+				$.ajax({ url: '/services/t/l'
+						,data: 'referrer='+ encodeURIComponent(referrer)
+								+ '&ctid=' + ctid 
+								+ '&landing=' + encodeURIComponent(landing)
+								+ '&brand=' + brand
+						,dataType: 'json'
+						,cache: false
+						,success: function(){}
+				});
+			});
+		//]]>
+		</script>
+        <script type="text/javascript">
+            //<![CDATA[
+            $(function() {
+                $('input:submit,button:submit').each(function(){
+                    var submitButton = $(this);
+                    if(submitButton.val() == '') submitButton.val('');
+                });
+
+                $('input, textarea').placeholder();
+            });
+            //]]>
+        </script>
+					<script type="text/javascript" src="/platform/js/localized/strings_en_US.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/search/search.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.user.min.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.agent.min.js?h=c4edfb0a"></script>
+        
+        <script type="text/javascript" src="/platform/js/jquery/js.cookie-2.2.1.min.js"></script>
+        <script type="text/javascript" src="/platform/js/jquery/jquery.lightbox_me.js"></script>
+        <script type="text/javascript" src="/platform/js/jquery/jquery.placeholder.2.0.7.min.js"></script>
+        <script type="text/javascript" src="/js/override.js?locale=en_US&amp;i=315305498"></script>
+        <script type="text/javascript">
+            const jobAlertSpans = document.querySelectorAll("[data-testid=jobAlertSpanText]");
+            jobAlertSpans?.forEach((jobEl) => {
+              jobEl.textContent = window?.jsStr?.tcjobresultscreatejobalertsdetailstext || "";
+            });
+        </script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.sso.min.js?h=c4edfb0a"></script>
+            <script type="text/javascript">
+                //<![CDATA[
+                j2w.SSO.init({
+                    email    : '',
+                    enabled  : false,
+                    jobID    : '599350817',
+                    locale   : 'en_US',
+                    tcaction : 'job',
+                    logoutDefaultPath : 'jobs.scotiabank.com',
+                    usingRD  : true
+                });
+
+                // This code is to deal with empty e-mail strings on back button clicks to the page when first logging in.
+                $(window).on( "load", function () {
+                    if (''.length && !j2w.SSO.getEmail().length) {
+                        $.ajax({
+                            type    : 'GET',
+                            url     : '/services/security/email',
+                            success : function (data) {
+                                if (data.email.length) {
+                                    j2w.SSO.setEmail(data.email);
+                                }
+                            }
+                        });
+                    }
+                });
+                //]]>
+            </script>
+            <script type="text/javascript">
+                //<![CDATA[
+                    var subscribeWidgetSetup = {
+                        action                : 'subscribe',
+                        usingJobAlertsManager : false
+                    };
+                //]]>
+            </script>
+					<script type="text/javascript" src="/platform/js/tc/subscribeWidget.js?h=c4edfb0a"></script>
+                        <script type="text/javascript">
+                            //<![CDATA[
+                            $(function() {
+                                $('.emailsubscribe-button').click(function (e) {
+                                    e.preventDefault();
+                                    var $frequency = $('.subscribe-frequency').val();
+                                    var rcmLoggedIn = false;
+                                    var action = rcmLoggedIn ? 'alertCreate' : 'subscribe';
+                                    var result = j2w.Agent.validateFrequency($frequency);
+                                    if (!result.length) {
+                                        j2w.TC.collectForCASWorkflow({
+                                            "emailAddress": '',
+                                            "action": action,
+                                            "socialSrc": '',
+                                            "frequency": parseFloat($frequency)
+                                        });
+                                    } else {
+                                        if (j2w.Args.get('isResponsive')) {
+                                            $('.frequency-error-message').html(result.concat('<br/>'));
+                                            $('.frequency-error').removeClass('hidden');
+                                        } else {
+                                            alert(result.join('\n'));
+                                        }
+                                    }
+                                });
+                            });
+                            //]]>
+                        </script>
+					<script type="text/javascript" src="/platform/js/j2w/min/options-search.min.js?h=c4edfb0a"></script>
+            <script type="application/javascript">
+                //<![CDATA[
+                var j2w = j2w || {};
+                j2w.search = j2w.search || {};
+                j2w.search.options = {
+                    isOpen: false,
+                    facets: [],
+                    showPicklistAllLocales : false
+                };
+                //]]>
+            </script>
+		</body>
+    </html>

--- a/web/lib/scrapers/__fixtures__/scotiabank-listing.html
+++ b/web/lib/scrapers/__fixtures__/scotiabank-listing.html
@@ -1,0 +1,1359 @@
+<!DOCTYPE html>
+<html class="html5" xml:lang="en-US" lang="en-US" xmlns="http://www.w3.org/1999/xhtml">
+
+        <head>
+            <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+            <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
+            <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+                <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                        <link type="text/css" class="keepscript" rel="stylesheet" href="https://jobs.scotiabank.com/platform/bootstrap/3.4.8_NES/css/bootstrap.min.css" />
+                            <link type="text/css" rel="stylesheet" href="/platform/css/j2w/min/bootstrapV3.global.responsive.min.css?h=c4edfb0a" />
+                
+                <script type="text/javascript" src="/platform/js/j2w/j2w.fallbacks.js"></script>
+                
+                
+                <script type="text/javascript" src="https://hcm17.sapsf.com/verp/vmod_v1/ui/extlib/jquery_3.5.1/jquery.js" onerror="loadFallbacks('/platform/js/jquery/jquery-3.5.1.min.js', '/platform/js/jquery/jquery-migrate-3.1.0.min.js')"></script>
+                <script type="text/javascript" src="https://hcm17.sapsf.com/verp/vmod_v1/ui/extlib/jquery_3.5.1/jquery-migrate.js"></script>
+            <script type="text/javascript" src="/platform/js/jquery/jquery-migrate-1.4.1.js"></script>
+                    <title>Scotiabank Jobs</title>
+
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <meta name="keywords" content=", Scotiabank Jobs" />
+        <meta name="description" content="Find  at Scotiabank" />
+        <link rel="canonical" href="https://jobs.scotiabank.com/search/" />
+            <meta name="robots" content="noindex" />
+                <link type="text/css" rel="stylesheet" href="//rmkcdn.successfactors.com/c37ab1bb/cc0aafda-cf6f-41a8-9c11-7.css" />
+                            <link type="text/css" rel="stylesheet" href="/platform/csb/css/header1.css?h=c4edfb0a" />
+                            <link type="text/css" rel="stylesheet" href="/platform/css/j2w/min/sitebuilderframework.min.css?h=c4edfb0a" />
+                            <link type="text/css" rel="stylesheet" href="/platform/css/j2w/min/BS3ColumnizedSearch.min.css?h=c4edfb0a" />
+                            <link type="text/css" rel="stylesheet" href="/platform/fontawesome4.7/css/font-awesome-4.7.0.min.css?h=c4edfb0a" /><script src="//assets.adobedtm.com/27c34d6e7144/279cc12b6e9b/launch-509289b4ee23.min.js" async></script>
+
+<meta name="google-site-verification" content="2H4BkrMPOG4Y4N-NxFjKNBodJBFNsrsUOl8W-482hzM" />
+<script type="text/javascript">
+</script>
+
+        
+        <link rel="shortcut icon" href="//rmkcdn.successfactors.com/c37ab1bb/1fff5394-e827-446e-a18a-4.jpg" type="image/x-icon" />
+            <style id="antiClickjack" type="text/css">body{display:none !important;}</style>
+            <script type="text/javascript" id="antiClickJackScript">
+                if (self === top) {
+                    var antiClickjack = document.getElementById("antiClickjack");
+                    antiClickjack.parentNode.removeChild(antiClickjack);
+                } else {
+                    top.location = self.location;
+                }
+            </script>
+        </head>
+
+        <body class="coreCSB search-page body   body" id="body">
+
+        <div id="outershell" class="outershell">
+
+    <div id="header" class="header headermain " role="banner">
+            <div id="headerbordertop" class="headerbordertop"></div>
+        <script type="text/javascript">
+            //<![CDATA[
+            $(function()
+            {
+                /* Using 'skipLinkSafari' to include CSS styles specific to Safari. */
+                if (navigator.userAgent.indexOf('Safari') != -1 && navigator.userAgent.indexOf('Chrome') == -1) {
+                    $("#skipLink").attr('class', 'skipLinkSafari');
+                }
+            });
+            //]]>
+        </script>
+        <div id="skip">
+            <a href="#content" id="skipLink" class="skipLink" title="Skip to main content"><span>Skip to main content</span></a>
+        </div>
+
+        <div class="limitwidth">
+            <div class="menu desktop upper">
+                <div class="inner" role="navigation" aria-label="Header Menu">
+                        <a href="https://jobs.scotiabank.com/" title="Scotiabank" style="display:inline-block">
+                            <img class="logo" src="//rmkcdn.successfactors.com/c37ab1bb/9fe76e4f-e61e-4096-89f7-5.png" alt="Scotiabank" />
+                        </a>
+                    <ul class="nav nav-pills" role="list">
+        <li class="dropdown">
+            <a id="header1top0MenuButton" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false" title="Featured Jobs" aria-controls="header1top0">
+                Featured Jobs <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu company-dropdown headerdropdown" id="header1top0" role="menu" aria-labelledby="header1top0MenuButton">
+                        <li role="none"><a role="menuitem" href="/go/AML/2574017/" title="AML">AML</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Commercial-Banking/2573917/" title="Commercial Banking ">Commercial Banking </a></li>
+                        <li role="none"><a role="menuitem" href="/go/Student-&amp;-New-Grad-Jobs/2298417/" title="Student &amp; New Grad">Student &amp; New Grad</a></li>
+                        <li role="none"><a role="menuitem" href="/go/IT-&amp;-Digital-Banking-Jobs/2298017/" title="Technology">Technology</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Finance-Jobs/2297817/" title="Finance">Finance</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Operations-Jobs/2298117/" title="Global Operations">Global Operations</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Retail-Banking-Jobs/2298217/" title="Retail Banking">Retail Banking</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Financial-Planner-Jobs/2371217/" title="Financial Planner">Financial Planner</a></li>
+            </ul>
+        </li>
+        <li><a href="/content/location/?locale=en_US" title="Locations">Locations</a></li>
+        <li><a href="/talentcommunity/subscribe/?locale=en_US" title="Join our Talent Community">Join our Talent Community</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+
+        <div class="menu mobile upper">
+                <a href="https://jobs.scotiabank.com/" title="Scotiabank">
+                    <img class="logo" src="//rmkcdn.successfactors.com/c37ab1bb/9fe76e4f-e61e-4096-89f7-5.png" alt="Scotiabank" />
+                </a>
+            <div class="nav">
+                    <div class="dropdown mobile-search">
+                        <button id="searchToggleBtn" type="button" title="Search" aria-label="Search" class="dropdown-toggle" data-toggle="collapse" data-target="#searchSlideNav"><span class="mobilelink fa fa-search"></span></button>
+                        <div id="searchSlideNav" class="dropdown-menu search-collapse">
+
+        <div class="well well-small searchwell">
+            <form class="form-inline jobAlertsSearchForm" name="keywordsearch" method="get" action="/search/" xml:lang="en-US" lang="en-US" style="margin: 0;" role="search">
+                <input name="createNewAlert" type="hidden" value="false" />
+                <div class="container-fluid">
+                    <div class="row columnizedSearchForm">
+                        <div class="column col-md-9">
+                            <div class="fieldContainer row">
+                                    <div class="col-md-6 rd-keywordsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Keyword</span>
+
+                                        <i class="keywordsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-q columnized-search" name="q" maxlength="50" aria-label="Search by Keyword" />
+
+                                    </div>
+                                    <div class="col-md-6 rd-locationsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Location</span>
+
+                                        <i class="locationsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-locationsearch columnized-search" name="locationsearch" maxlength="50" aria-label="Search by Location" />
+                                    </div>
+                            </div>
+                        </div>
+                        <div class="rd-searchbutton col-md-2">
+                            <div class="row emptylabelsearchspace labelrow">
+                                 
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12 col-sm-12 col-xs-12 search-submit">
+                                            <input type="submit" class="btn keywordsearch-button" value="Search Jobs" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </form>
+        </div>
+                        </div>
+                    </div>
+                <div class="dropdown mobile-nav">
+                    <a id="hamburgerToggleBtn" href="#" title="Menu" aria-label="Menu" class="dropdown-toggle" aria-controls="nav-collapse-design1" aria-expanded="false" role="button" data-toggle="collapse" data-target="#nav-collapse-design1"><span class="mobilelink fa fa-bars"></span></a>
+                    <ul id="nav-collapse-design1" class="dropdown-menu nav-collapse">
+        <li class="dropdown">
+            <a id="header1bot0MenuButton" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button" aria-expanded="false" title="Featured Jobs" aria-controls="header1bot0">
+                Featured Jobs <b class="caret"></b>
+            </a>
+            <ul class="dropdown-menu company-dropdown headerdropdown" id="header1bot0" role="menu" aria-labelledby="header1bot0MenuButton">
+                        <li role="none"><a role="menuitem" href="/go/AML/2574017/" title="AML">AML</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Commercial-Banking/2573917/" title="Commercial Banking ">Commercial Banking </a></li>
+                        <li role="none"><a role="menuitem" href="/go/Student-&amp;-New-Grad-Jobs/2298417/" title="Student &amp; New Grad">Student &amp; New Grad</a></li>
+                        <li role="none"><a role="menuitem" href="/go/IT-&amp;-Digital-Banking-Jobs/2298017/" title="Technology">Technology</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Finance-Jobs/2297817/" title="Finance">Finance</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Operations-Jobs/2298117/" title="Global Operations">Global Operations</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Retail-Banking-Jobs/2298217/" title="Retail Banking">Retail Banking</a></li>
+                        <li role="none"><a role="menuitem" href="/go/Financial-Planner-Jobs/2371217/" title="Financial Planner">Financial Planner</a></li>
+            </ul>
+        </li>
+        <li><a href="/content/location/?locale=en_US" title="Locations">Locations</a></li>
+        <li><a href="/talentcommunity/subscribe/?locale=en_US" title="Join our Talent Community">Join our Talent Community</a></li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+        <div class="lower headersubmenu">
+            <div class="inner limitwidth">
+                <div class="links">
+                        <div id="langListContainer" class="language node dropdown header-one headerlocaleselector">
+        <a id="langDropDownToggleBtn" class="dropdown-toggle languageselector" role="button" aria-expanded="false" data-toggle="dropdown" href="#" aria-controls="langListDropDown">Language <span class="caret"></span></a>
+        <ul id="langListDropDown" role="menu" aria-labelledby="langDropDownToggleBtn" class="dropdown-menu company-dropdown headerdropdown">
+                <li role="none">
+                    <a role="menuItem" href="https://jobs.scotiabank.com/Scotiabank/search/?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=0&amp;locale=en_US" lang="en-US">English (United States)</a>
+                </li>
+                <li role="none">
+                    <a role="menuItem" href="https://jobs.scotiabank.com/Scotiabank/search/?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=0&amp;locale=es_ES" lang="es-ES">Español (España)</a>
+                </li>
+                <li role="none">
+                    <a role="menuItem" href="https://jobs.scotiabank.com/Scotiabank/search/?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=0&amp;locale=fr_CA" lang="fr-CA">Français (Canada)</a>
+                </li>
+        </ul>
+                        </div>
+                        <div class="profile node">
+			<div class="profileWidget">
+					<a href="#" onclick="j2w.TC.handleViewProfileAction(event)" xml:lang="en-US" lang="en-US" style=" ">View Profile</a>
+			</div>
+                        </div>
+
+
+
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+    <style type="text/css">
+        #content {
+            padding-top: 0px;
+        }
+    </style>
+
+    <script type="text/javascript" classhtmlattribute="keepscript" src="/platform/js/j2w/j2w.bootstrap.collapse.js"></script>
+    <script type="text/javascript" classhtmlattribute="keepscript" src="/platform/js/j2w/j2w.bootstrap.dropdown.js"></script>
+            <div id="innershell" class="innershell">
+                <div id="content" tabindex="-1" class="content" role="main">
+                    <div class="inner">
+            <div class="breadcrumbtrail">
+                <nav aria-label="Breadcrumb">
+                    <ul class="breadcrumb">
+                        <li><a href="/">Home</a></li>
+                                        <li aria-hidden="true"><span class="divider">|</span></li>
+                                        <li class="active" aria-current="page"> at Scotiabank<span class="sr-only">(current page)</span></li>
+                    </ul>
+                </nav>
+            </div>
+            <h1 class="keyword-title">Search results for<span class="securitySearchQuery"> "".</span>
+            </h1>
+        <div id="search-wrapper">
+
+        <div class="well well-small searchwell">
+            <form class="form-inline jobAlertsSearchForm" name="keywordsearch" method="get" action="/search/" xml:lang="en-US" lang="en-US" style="margin: 0;" role="search">
+                <input name="createNewAlert" type="hidden" value="false" />
+                <div class="container-fluid">
+                    <div class="row columnizedSearchForm">
+                        <div class="column col-md-9">
+                            <div class="fieldContainer row">
+                                    <div class="col-md-6 rd-keywordsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Keyword</span>
+
+                                        <i class="keywordsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-q columnized-search" name="q" maxlength="50" aria-label="Search by Keyword" />
+
+                                    </div>
+                                    <div class="col-md-6 rd-locationsearch">
+                                            <span class="lbl" aria-hidden="true">Search by Location</span>
+
+                                        <i class="locationsearch-icon"></i>
+                                        <input type="text" class="keywordsearch-locationsearch columnized-search" name="locationsearch" maxlength="50" aria-label="Search by Location" />
+                                    </div>
+                            </div>
+                                <div class="row optionsLink optionsLink-padding">
+                                </div>
+                        </div>
+                        <div class="rd-searchbutton col-md-2">
+                            <div class="row emptylabelsearchspace labelrow">
+                                 
+                            </div>
+                            <div class="row">
+                                <div class="col-md-12 col-sm-12 col-xs-12 search-submit">
+                                            <input type="submit" class="btn keywordsearch-button" value="Search Jobs" />
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+            </form>
+        </div>
+                    <div class="row clearfix">
+                    </div>
+        </div>
+                <div class="pagination-top clearfix">
+
+        <div class="paginationShell clearfix" xml:lang="en-US" lang="en-US">
+                    <div class="well well-lg pagination-well pagination">
+                        <div class="pagination-label-row">
+                            <span class="paginationLabel" aria-label="Results 1 – 25">Results <b>1 – 25</b> of <b>1902</b></span>
+                            <span class="srHelp" style="font-size:0px">Page 1 of 77</span>
+                        </div>
+                            <ul class="pagination">
+                                <li><a class="paginationItemFirst" href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc" title="First Page"><span aria-hidden="true">«</span></a></li>
+                                            <li class="active"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc" class="current-page" aria-current="page" rel="nofollow" title="Page 1">1</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=25" rel="nofollow" title="Page 2">2</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=50" rel="nofollow" title="Page 3">3</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=75" rel="nofollow" title="Page 4">4</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=100" rel="nofollow" title="Page 5">5</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=125" rel="nofollow" title="Page 6">6</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=150" rel="nofollow" title="Page 7">7</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=175" rel="nofollow" title="Page 8">8</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=200" rel="nofollow" title="Page 9">9</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=225" rel="nofollow" title="Page 10">10</a></li>
+                                <li><a class="paginationItemLast" href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=1900" rel="nofollow" title="Last Page"><span aria-hidden="true">»</span></a></li>
+                            </ul>
+                    </div>
+        </div>
+                </div>
+
+            <div class="searchResultsShell">
+				<table id="searchresults" class="searchResults full table table-striped table-hover" cellpadding="0" cellspacing="0" aria-label="Search results for . Page 1 of 77, Results 1 to 25 of 1902">
+					<thead>
+                            <tr id="search-results-header">
+											<th id="hdrTitle" aria-sort="none" scope="col" width="50%">
+												<span class="jobTitle">
+													<a id="hdrTitleButton" class="jobTitle sort" role="button" href="/Scotiabank/search/?q=&amp;sortColumn=sort_title&amp;sortDirection=desc#hdrTitleButton">Title
+													</a>
+												</span>
+											</th>
+											<th id="hdrDate" aria-sort="descending" scope="col" width="15%" class="hidden-phone">
+												<span class="jobDate">
+													<a id="hdrDateButton" role="button" href="/Scotiabank/search/?q=&amp;sortColumn=referencedate&amp;sortDirection=asc#hdrDateButton">Date <img src="/platform/images/shared/downtri.png" border="0" alt="Sort descending" />
+													</a>
+												</span>
+											</th>
+											<th id="hdrLocation" aria-sort="none" scope="col" width="20px" class="hidden-phone">
+												<span class="jobLocation">
+													<a id="hdrLocationButton" role="button" class="jobLocation sort" href="/Scotiabank/search/?q=&amp;sortColumn=sort_location&amp;sortDirection=desc#hdrLocationButton">Location
+													</a>
+												</span>
+											</th>
+                            </tr>
+                    </thead>
+                    <tbody>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Technical-Delivery-Lead-%28Governance%29-1-ON-M5H-1H1/599350817/" class="jobTitle-link">Technical Delivery Lead (Governance) 1</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Technical-Delivery-Lead-%28Governance%29-1-ON-M5H-1H1/599350817/">Technical Delivery Lead (Governance) 1</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Summerside-Customer-Experience-Associate-Summerside-PEI-%2818_75-hoursweek%29-PE-C1N5J4/600907417/" class="jobTitle-link">Customer Experience Associate - Summerside PEI (18.75 hours/week)</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Summerside-Customer-Experience-Associate-Summerside-PEI-%2818_75-hoursweek%29-PE-C1N5J4/600907417/">Customer Experience Associate - Summerside PEI (18.75 hours/week)</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Summerside, PE, CA, C1N5J4
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Summerside, PE, CA, C1N5J4
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Senior-Analyst%2C-Security-Assurance-ON-M1K5L1/599326417/" class="jobTitle-link">Senior Analyst, Security Assurance</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Senior-Analyst%2C-Security-Assurance-ON-M1K5L1/599326417/">Senior Analyst, Security Assurance</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M1K5L1
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M1K5L1
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Senior-Business-Systems-Analyst-ON-M5H1B6/600203017/" class="jobTitle-link">Senior Business Systems Analyst</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Senior-Business-Systems-Analyst-ON-M5H1B6/600203017/">Senior Business Systems Analyst</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H1B6
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H1B6
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Dallas-Director%2C-Global-Banking-Markets%2C-Business-Architect-TX-10281/593065917/" class="jobTitle-link">Director, Global Banking Markets, Business Architect</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Dallas-Director%2C-Global-Banking-Markets%2C-Business-Architect-TX-10281/593065917/">Director, Global Banking Markets, Business Architect</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Dallas, TX, US, 10281
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Dallas, TX, US, 10281
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-QA-Engineer-ON-M5A3X5/599339217/" class="jobTitle-link">QA Engineer</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-QA-Engineer-ON-M5A3X5/599339217/">QA Engineer</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5A3X5
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5A3X5
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Senior-Payroll-Analyst-%28Bilingual-FrenchEnglish%29-ON-M1L4S2/599351117/" class="jobTitle-link">Senior Payroll Analyst (Bilingual - French/English)</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Senior-Payroll-Analyst-%28Bilingual-FrenchEnglish%29-ON-M1L4S2/599351117/">Senior Payroll Analyst (Bilingual - French/English)</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M1L4S2
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M1L4S2
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Lead-Data-Engineer-Market-&amp;-Reference-Data-%28Capital-Markets%29-ON-M5H4A6/601065217/" class="jobTitle-link">Lead Data Engineer - Market &amp; Reference Data (Capital Markets)</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Lead-Data-Engineer-Market-&amp;-Reference-Data-%28Capital-Markets%29-ON-M5H4A6/601065217/">Lead Data Engineer - Market &amp; Reference Data (Capital Markets)</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H4A6
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H4A6
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Aylmer-Financial-Advisor-42-Talbot-Street-%2837_5-hoursweek%29-ON-N5H1H4/601047717/" class="jobTitle-link">Financial Advisor - 42 Talbot Street (37.5 hours/week)</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Aylmer-Financial-Advisor-42-Talbot-Street-%2837_5-hoursweek%29-ON-N5H1H4/601047717/">Financial Advisor - 42 Talbot Street (37.5 hours/week)</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Aylmer, ON, CA, N5H1H4
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Aylmer, ON, CA, N5H1H4
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Lima-Especialista-De-Modelos-Analiticos-LIM-15047/601043117/" class="jobTitle-link">Especialista De Modelos Analiticos</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Lima-Especialista-De-Modelos-Analiticos-LIM-15047/601043117/">Especialista De Modelos Analiticos</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Lima, LIM, PE, 15047
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Lima, LIM, PE, 15047
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Lead-Engineer-ON-M1K5L1/600205917/" class="jobTitle-link">Lead Engineer</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Lead-Engineer-ON-M1K5L1/600205917/">Lead Engineer</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M1K5L1
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M1K5L1
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Bogota-Quality-Assurance-Functional-Associate-DC/601049717/" class="jobTitle-link">Quality Assurance Functional Associate</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Bogota-Quality-Assurance-Functional-Associate-DC/601049717/">Quality Assurance Functional Associate</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Bogota, DC, CO
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Bogota, DC, CO
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Dallas-Senior-Manager%2C-Margin-&amp;-Collateral-Management-TX-75201/601051117/" class="jobTitle-link">Senior Manager, Margin &amp; Collateral Management</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Dallas-Senior-Manager%2C-Margin-&amp;-Collateral-Management-TX-75201/601051117/">Senior Manager, Margin &amp; Collateral Management</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Dallas, TX, US
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Dallas, TX, US
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Senior-Capital-Markets-&amp;-Reference-Data-Business-Analyst-ON-M5H-1H1/601067317/" class="jobTitle-link">Senior Capital Markets &amp; Reference Data Business Analyst</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Senior-Capital-Markets-&amp;-Reference-Data-Business-Analyst-ON-M5H-1H1/601067317/">Senior Capital Markets &amp; Reference Data Business Analyst</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Ottawa-Programmer-Analyst-Advisory-ON-K1G6R7/601050517/" class="jobTitle-link">Programmer Analyst Advisory</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Ottawa-Programmer-Analyst-Advisory-ON-K1G6R7/601050517/">Programmer Analyst Advisory</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Ottawa, ON, CA, K1G6R7
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Ottawa, ON, CA, K1G6R7
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Senior-Delivery-Lead-ON-M5H-1H1/601068417/" class="jobTitle-link">Senior Delivery Lead</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Senior-Delivery-Lead-ON-M5H-1H1/601068417/">Senior Delivery Lead</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-QA-Analyst-ON-N5A6S9/600213917/" class="jobTitle-link">QA Analyst</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-QA-Analyst-ON-N5A6S9/600213917/">QA Analyst</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, N5A6S9
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, N5A6S9
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Software-Engineer-%28Capital-Markets-&amp;-Reference-Data%29-ON-M5H4A6/601066117/" class="jobTitle-link">Software Engineer (Capital Markets &amp; Reference Data)</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Software-Engineer-%28Capital-Markets-&amp;-Reference-Data%29-ON-M5H4A6/601066117/">Software Engineer (Capital Markets &amp; Reference Data)</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H4A6
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H4A6
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Bogota-Senior-Analyst%2C-Global-KYC-DC/601048617/" class="jobTitle-link">Senior Analyst, Global KYC</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Bogota-Senior-Analyst%2C-Global-KYC-DC/601048617/">Senior Analyst, Global KYC</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Bogota, DC, CO
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Bogota, DC, CO
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Dieppe-Bilingual-%28English-French%29-Banking-Advisor-Champlain-Place%2C-Moncton-NB-NB/601896717/" class="jobTitle-link">Bilingual (English / French) Banking Advisor - Champlain Place, Moncton NB</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Dieppe-Bilingual-%28English-French%29-Banking-Advisor-Champlain-Place%2C-Moncton-NB-NB/601896717/">Bilingual (English / French) Banking Advisor - Champlain Place, Moncton NB</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Dieppe, NB, CA
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 24, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 24, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Dieppe, NB, CA
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Senior-Technical-Analyst-%28Capital-Markets%29-ON-M5C2V9/599281217/" class="jobTitle-link">Senior Technical Analyst (Capital Markets)</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Senior-Technical-Analyst-%28Capital-Markets%29-ON-M5C2V9/599281217/">Senior Technical Analyst (Capital Markets)</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5C2V9
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 23, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 23, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5C2V9
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Bogota-HR-Data-Management-Advisor-DC/599309417/" class="jobTitle-link">HR Data Management Advisor</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Bogota-HR-Data-Management-Advisor-DC/599309417/">HR Data Management Advisor</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Bogota, DC, CO
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 23, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 23, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Bogota, DC, CO
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Director-Engineering-Digital-Retail-Investing-ON-M5A3X5/601028717/" class="jobTitle-link">Director Engineering - Digital Retail Investing</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Director-Engineering-Digital-Retail-Investing-ON-M5A3X5/601028717/">Director Engineering - Digital Retail Investing</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5A3X5
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 23, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 23, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5A3X5
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/Toronto-Senior-Manager-Data-Platforms-ON-M5H-1H1/601011417/" class="jobTitle-link">Senior Manager - Data Platforms</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/Toronto-Senior-Manager-Data-Platforms-ON-M5H-1H1/601011417/">Senior Manager - Data Platforms</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 23, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 23, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            Toronto, ON, CA, M5H 1H1
+            
+        </span>
+											</td>
+                            </tr>
+
+                            <tr class="data-row">
+                                                <td class="colTitle" headers="hdrTitle">
+													<span class="jobTitle hidden-phone">
+														<a href="/job/New-York-City-Associate%2C-Equity-Derivatives-Quant-New-York%2C-NY-NY-10281/601022517/" class="jobTitle-link">Associate, Equity Derivatives Quant - New York, NY</a>
+													</span>
+                                                    <div class="jobdetail-phone visible-phone">
+                                                                    <span class="jobTitle visible-phone">
+                                                                        <a class="jobTitle-link" href="/job/New-York-City-Associate%2C-Equity-Derivatives-Quant-New-York%2C-NY-NY-10281/601022517/">Associate, Equity Derivatives Quant - New York, NY</a>
+                                                                    </span>
+                                                                    <span class="jobLocation visible-phone">
+        
+        <span class="jobLocation">
+            New York City, NY, US, 10281
+            
+        </span></span>
+                                                                    <span class="jobDate visible-phone">May 23, 2026
+													                </span>
+                                                                    <span class="jobDistance visible-phone">0.00 mi</span>
+                                                    </div>
+                                                </td>
+											<td class="colDate hidden-phone" nowrap="nowrap" headers="hdrDate">
+												<span class="jobDate">May 23, 2026
+												</span>
+											</td>
+											<td class="colLocation hidden-phone" headers="hdrLocation">
+        
+        <span class="jobLocation">
+            New York City, NY, US, 10281
+            
+        </span>
+											</td>
+                            </tr>
+                    </tbody>
+
+                </table>
+            </div>
+                <div class="pagination-bottom">
+
+        <div class="paginationShell clearfix" xml:lang="en-US" lang="en-US">
+                    <div class="well well-lg pagination-well pagination">
+                        <div class="pagination-label-row">
+                            <span class="paginationLabel" aria-label="Results 1 – 25">Results <b>1 – 25</b> of <b>1902</b></span>
+                            <span class="srHelp" style="font-size:0px">Page 1 of 77</span>
+                        </div>
+                            <ul class="pagination">
+                                <li><a class="paginationItemFirst" href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc" title="First Page"><span aria-hidden="true">«</span></a></li>
+                                            <li class="active"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc" class="current-page" aria-current="page" rel="nofollow" title="Page 1">1</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=25" rel="nofollow" title="Page 2">2</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=50" rel="nofollow" title="Page 3">3</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=75" rel="nofollow" title="Page 4">4</a></li>
+                                            <li class=" "><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=100" rel="nofollow" title="Page 5">5</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=125" rel="nofollow" title="Page 6">6</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=150" rel="nofollow" title="Page 7">7</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=175" rel="nofollow" title="Page 8">8</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=200" rel="nofollow" title="Page 9">9</a></li>
+                                            <li class="hidden-phone"><a href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=225" rel="nofollow" title="Page 10">10</a></li>
+                                <li><a class="paginationItemLast" href="?q=&amp;sortColumn=referencedate&amp;sortDirection=desc&amp;startrow=1900" rel="nofollow" title="Last Page"><span aria-hidden="true">»</span></a></li>
+                            </ul>
+                    </div>
+        </div>
+                </div>
+
+            <script src="/platform/js/jquery/jquery.watermark.js" type="text/javascript"></script>
+            <script type="text/javascript">jQuery(function($){$('#title').watermark('Title');
+$('#date').watermark('Date (M/d/yy)');
+$('#location').watermark('Location');
+$('#title').watermark('Title');
+$('#location').watermark('Location');
+$('#date').watermark('Date (M/d/yy)');
+$('#distance').watermark('');
+});
+            </script>
+            <div class="row">
+            </div>
+                    </div>
+                </div>
+            </div>
+
+    <div id="footer" role="contentinfo">
+        <div id="footerRowTop" class="footer footerRow">
+            <div class="container  footer-fullwidth">
+
+    <div id="footerInnerLinksSocial" class="row">
+        <ul class="inner links" role="list">
+        </ul>
+        </div>
+            </div>
+        </div>
+            <div id="footerColumnsShell" class="footerRow footerColumnsShell">
+                <div class="container  footer-fullwidth">
+
+    
+
+    <footer id="footerColumns" class="row footerColumns">
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label=" ">
+                <h2 class="footerMenuTitle"> </h2>
+
+                <ul>
+                                <li><a href="/" title=" "> </a></li>
+                </ul>
+            </nav>
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label="Careers">
+                <h2 class="footerMenuTitle">Careers</h2>
+
+                <ul>
+                                <li><a href="https://www.scotiabank.com/ca/en/about/contact-us/privacy.html" title="Privacy Policy" target="_blank">Privacy Policy</a></li>
+                                <li><a href="https://www.scotiabank.com/careers/en/careers/technical-support-for-applicants.html" title="Required Technical Support" target="_blank">Required Technical Support</a></li>
+                                <li><a href="https://www.scotiabank.com/content/dam/scotiabank/canada/en/documents/E-Verify-ParticipationPoster.pdf" title="E-Verify Participation (U.S.)" target="_blank">E-Verify Participation (U.S.)</a></li>
+                                <li><a href="https://www.scotiabank.com/content/dam/scotiabank/canada/en/documents/E-Verify-RightToWorkPoster.pdf" title="E-Verify Right to Work (U.S.)" target="_blank">E-Verify Right to Work (U.S.)</a></li>
+                </ul>
+            </nav>
+                <div class="clearfix visible-xs-block"></div>
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label="Related Sites">
+                <h2 class="footerMenuTitle">Related Sites</h2>
+
+                <ul>
+                                <li><a href="https://www.scotiabank.com/careers/en/careers.html" title="Global" target="_blank">Global</a></li>
+                                <li><a href="http://www.scotiabank.com/careers/en/careers/careers-students-and-new-grads.html" title="Students &amp; New Grads" target="_blank">Students &amp; New Grads</a></li>
+                                <li><a href="https://www.scotiabank.com/ca/en/about/contact-us/privacy/privacy-cookies.html" title="Cookie Settings">Cookie Settings</a></li>
+                </ul>
+            </nav>
+                <div class="clearfix visible-sm-block"></div>
+            <nav class="footerMenu col-xs-6 col-sm-4 col-md-3 col-lg-2" aria-label="Connect">
+                <h2 class="footerMenuTitle">Connect</h2>
+
+                <ul>
+                                <li><a href="https://www.facebook.com/scotiabank/" title="Facebook" target="_blank">Facebook</a></li>
+                                <li><a href="https://twitter.com/scotiabank" title="Twitter" target="_blank">Twitter</a></li>
+                                <li><a href="https://www.linkedin.com/company/scotiabank" title="LinkedIn" target="_blank">LinkedIn</a></li>
+                                <li><a href="https://www.youtube.com/user/Scotiabank" title="YouTube" target="_blank">YouTube</a></li>
+                                <li><a href="https://www.instagram.com/explore/tags/lifeatscotiabank/" title="Instagram" target="_blank">Instagram</a></li>
+                </ul>
+            </nav>
+                <div class="clearfix visible-md-block"></div>
+                <div class="clearfix visible-xs-block"></div>
+    </footer>
+                </div>
+            </div>
+
+        <div id="footerRowBottom" class="footer footerRow">
+            <div class="container  footer-fullwidth">
+                    <p>© 2021 Scotiabank.com All Rights Reserved</p>
+            </div>
+        </div>
+    </div>
+        </div>
+            <script class="keepscript" src="https://jobs.scotiabank.com/platform/bootstrap/3.4.8_NES/js/lib/dompurify/purify.min.js" type="text/javascript"></script>
+            <script class="keepscript" src="https://jobs.scotiabank.com/platform/bootstrap/3.4.8_NES/js/bootstrap.min.js" type="text/javascript"></script><script type="text/javascript"></script>
+		<script type="text/javascript">
+		//<![CDATA[
+			$(function() 
+			{
+				var ctid = '58b61dac-1bc1-4560-ac36-f4f2736f1dd9';
+				var referrer = '';
+				var landing = document.location.href;
+				var brand = '';
+				$.ajax({ url: '/services/t/l'
+						,data: 'referrer='+ encodeURIComponent(referrer)
+								+ '&ctid=' + ctid 
+								+ '&landing=' + encodeURIComponent(landing)
+								+ '&brand=' + brand
+						,dataType: 'json'
+						,cache: false
+						,success: function(){}
+				});
+			});
+		//]]>
+		</script>
+        <script type="text/javascript">
+            //<![CDATA[
+            $(function() {
+                $('input:submit,button:submit').each(function(){
+                    var submitButton = $(this);
+                    if(submitButton.val() == '') submitButton.val('');
+                });
+
+                $('input, textarea').placeholder();
+            });
+            //]]>
+        </script>
+					<script type="text/javascript" src="/platform/js/localized/strings_en_US.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.core.min.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.tc.min.js?h=c4edfb0a"></script>
+
+		<script type="text/javascript">
+			//<![CDATA[
+				j2w.init({
+					"cookiepolicy"   : 1,
+					"useSSL"         : true,
+					"isUsingSSL"     : true,
+					"isResponsive"   : true,
+					"categoryId"     : 0,
+					"siteTypeId"     : 1,
+					"ssoCompanyId"   : 'scotiabank',
+					"ssoUrl"         : 'https://career17.sapsf.com',
+					"passwordRegEx"  : '^(?=.{6,20}$)(?!.*(.)\\1{3})(?=.*([\\d]|[^\\w\\d\\s]))(?=.*[A-Za-z])(?!.*[\\u007F-\\uFFFF\\s])',
+					"emailRegEx"     : '^(?![+])(?=([a-zA-Z0-9\\\'.+!_-])+[@]([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9.-]*[a-zA-Z0-9])[.]([a-zA-Z]){1,63}$)(?!.*[\\u007F-\\uFFFF\\s,])(?!.*[.]{2})',
+					"hasATSUserID"	 : false,
+					"useCASWorkflow" : true,
+					"brand"          : "",
+					"dpcsStateValid" : true
+					,       'q'              : '',       'location'       : '',       'locationsearch' : '',       'geolocation'  : '',       'locale'         : 'en_US'
+				});
+
+				j2w.TC.init({
+					"seekConfig" : {
+						"url" : 'https\x3A\x2F\x2Fwww.seek.com.au\x2Fapi\x2Fiam\x2Foauth2\x2Fauthorize',
+						"id"  : 'successfactors12',
+						"advertiserid" : ''
+					}
+				});
+
+				$.ajaxSetup({
+					cache   : false,
+					headers : {
+						"X-CSRF-Token" : "0c46e89a-08d4-4eba-84b4-e5eb9ec87b1d"
+					}
+				});
+			//]]>
+		</script>
+					<script type="text/javascript" src="/platform/js/search/search.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.user.min.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.agent.min.js?h=c4edfb0a"></script>
+        
+        <script type="text/javascript" src="/platform/js/jquery/js.cookie-2.2.1.min.js"></script>
+        <script type="text/javascript" src="/platform/js/jquery/jquery.lightbox_me.js"></script>
+        <script type="text/javascript" src="/platform/js/jquery/jquery.placeholder.2.0.7.min.js"></script>
+        <script type="text/javascript" src="/js/override.js?locale=en_US&amp;i=2957079"></script>
+        <script type="text/javascript">
+            const jobAlertSpans = document.querySelectorAll("[data-testid=jobAlertSpanText]");
+            jobAlertSpans?.forEach((jobEl) => {
+              jobEl.textContent = window?.jsStr?.tcjobresultscreatejobalertsdetailstext || "";
+            });
+        </script>
+					<script type="text/javascript" src="/platform/js/j2w/min/j2w.apply.min.js?h=c4edfb0a"></script>
+					<script type="text/javascript" src="/platform/js/j2w/min/options-search.min.js?h=c4edfb0a"></script>
+            <script type="application/javascript">
+                //<![CDATA[
+                var j2w = j2w || {};
+                j2w.search = j2w.search || {};
+                j2w.search.options = {
+                    isOpen: false,
+                    facets: [],
+                    showPicklistAllLocales : false
+                };
+                //]]>
+            </script>
+		</body>
+    </html>

--- a/web/lib/scrapers/detect-ats.ts
+++ b/web/lib/scrapers/detect-ats.ts
@@ -183,6 +183,18 @@ const ATS_PATTERNS: ATSPattern[] = [
       return match ? match[1] : null;
     },
   },
+  // Scotiabank SuccessFactors portal: `jobs.scotiabank.com` hosts every
+  // Scotia-family brand under a per-brand path (e.g. `/Scotiabank/...`,
+  // `/Tangerine/...`). The brand path is the identifier — extracted from
+  // the URL path's first segment.
+  {
+    type: "scotiabank",
+    patterns: [/^jobs\.scotiabank\.com$/i],
+    extractIdentifier: (url: URL) => {
+      const first = url.pathname.split("/").filter(Boolean)[0];
+      return first ?? null;
+    },
+  },
   // Avature CRM: also vendor-hosted but white-labelled per tenant. Tight
   // allowlist for now — National Bank's `emplois.bnc.ca` is the only
   // tenant we ship a scraper for, plus the legacy `jobs.nbc.ca` host that
@@ -259,6 +271,7 @@ export const SUPPORTED_ATS = [
   { value: "dayforce", label: "Dayforce", implemented: true },
   { value: "phenom", label: "Phenom CareerConnect", implemented: true },
   { value: "avature", label: "Avature CRM", implemented: true },
+  { value: "scotiabank", label: "Scotiabank SuccessFactors", implemented: true },
   { value: "workday-td", label: "Workday (TD Bank)", implemented: true },
   { value: "workday-cibc", label: "Workday (CIBC)", implemented: true },
   { value: "workday", label: "Workday (generic)", implemented: false },

--- a/web/lib/scrapers/index.ts
+++ b/web/lib/scrapers/index.ts
@@ -144,6 +144,8 @@ export function isBrowserScraper(atsType: string): boolean {
     'workday',
     'workday-td',     // API-based, but still offloaded — see fetchJobs comment.
     'workday-cibc',   // API-based, but still offloaded.
+    'scotiabank',     // HTML-fetch, but a 1,900-job Scotia parent + per-job
+                      // detail enrichment exceeds Vercel's 300s budget.
     'bamboohr',
     'smartrecruiters',
     'dayforce',

--- a/web/lib/scrapers/scotiabank.test.ts
+++ b/web/lib/scrapers/scotiabank.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for the pure-logic pieces of the Scotiabank SuccessFactors scraper.
+ *
+ * The driver function (`fetchScotiabankJobs`) does live HTTP fetches and is
+ * exercised by the smoke script. The tests here cover the parts that don't
+ * need a network: total-count parsing, row parsing for both brand-path
+ * shapes (Tangerine includes `/Tangerine/` in hrefs, Scotia parent omits
+ * it), and detail-page description extraction.
+ *
+ * Fixtures (`__fixtures__/scotiabank-listing.html`,
+ * `__fixtures__/scotiabank-detail.html`) are checked-in snapshots of live
+ * pages from `jobs.scotiabank.com/Scotiabank/` captured when Scotia parent
+ * was added as the 5th Big-6 incumbent.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  extractScotiabankDescriptionHtml,
+  extractTotalJobsFromHtml,
+  parseJobsFromHtml,
+  resolveMaxPages,
+} from "./scotiabank";
+
+const LISTING_HTML = readFileSync(
+  resolve(__dirname, "__fixtures__/scotiabank-listing.html"),
+  "utf8"
+);
+const DETAIL_HTML = readFileSync(
+  resolve(__dirname, "__fixtures__/scotiabank-detail.html"),
+  "utf8"
+);
+
+describe("extractTotalJobsFromHtml", () => {
+  it("parses the count off the real Scotia parent fixture", () => {
+    // Scotia parent renders the count wrapped in <b> tags:
+    // "Results <b>1 – 25</b> of <b>1902</b>". Stripping inline markup before
+    // matching is the fix that distinguishes this scraper from the original
+    // Tangerine-only version.
+    const got = extractTotalJobsFromHtml(LISTING_HTML);
+    expect(got).not.toBeNull();
+    expect(got).toBeGreaterThan(100);
+  });
+
+  it("handles a plain (un-bolded) count header", () => {
+    expect(
+      extractTotalJobsFromHtml(
+        `<div class="paginationLabel">Results 1 – 25 of 391</div>`
+      )
+    ).toBe(391);
+  });
+
+  it("handles the bolded shape that Scotia parent uses", () => {
+    expect(
+      extractTotalJobsFromHtml(
+        `<span class="paginationLabel">Results <b>1 – 25</b> of <b>1902</b></span>`
+      )
+    ).toBe(1902);
+  });
+
+  it("returns null when no count is rendered", () => {
+    expect(extractTotalJobsFromHtml(`<div>no pagination here</div>`)).toBeNull();
+  });
+});
+
+describe("parseJobsFromHtml", () => {
+  it("parses every data-row in the real Scotia fixture", () => {
+    const jobs = parseJobsFromHtml(LISTING_HTML, "Scotiabank", new Set());
+    expect(jobs.length).toBeGreaterThan(0);
+    expect(jobs.length).toBeLessThanOrEqual(25); // page size
+  });
+
+  it("yields well-formed JobData entries from the fixture", () => {
+    const jobs = parseJobsFromHtml(LISTING_HTML, "Scotiabank", new Set());
+    const job = jobs[0];
+    expect(job.external_id).toMatch(/^\d+$/);
+    expect(job.title.length).toBeGreaterThan(2);
+    expect(job.url).toMatch(/^https:\/\/jobs\.scotiabank\.com\/job\//);
+    expect(job.commitment).toBe("full-time");
+  });
+
+  it("matches hrefs that omit the brand-path prefix (Scotia parent shape)", () => {
+    const synthetic = `<tr class="data-row">
+      <td><span class="jobTitle"><a href="/job/Toronto-Senior-Dev-ON-M5H1H1/599281217/" class="jobTitle-link">Senior Developer</a></span></td>
+      <td><span class="jobLocation">Toronto, ON, CA, M5H1H1</span></td>
+      <td><span class="jobDate">May 23, 2026</span></td>
+    </tr>`;
+    const jobs = parseJobsFromHtml(synthetic, "Scotiabank", new Set());
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].external_id).toBe("599281217");
+    expect(jobs[0].title).toBe("Senior Developer");
+  });
+
+  it("matches hrefs that include the brand-path prefix (Tangerine shape)", () => {
+    // Regression coverage: the optional-prefix regex must still match the
+    // original Tangerine layout, otherwise we'd silently break Tangerine
+    // when wiring Scotia.
+    const synthetic = `<tr class="data-row">
+      <td><span class="jobTitle hidden-phone"><a href="/Tangerine/job/Toronto-Mobile-Architect-ON-M2H0A1/598714517/" title="Mobile Architect">Mobile Architect</a></span></td>
+      <td><span class="jobLocation">Toronto, ON, CA, M2H0A1</span></td>
+      <td><span class="jobDate">Feb 7, 2026</span></td>
+    </tr>`;
+    const jobs = parseJobsFromHtml(synthetic, "Tangerine", new Set());
+    expect(jobs).toHaveLength(1);
+    expect(jobs[0].external_id).toBe("598714517");
+    expect(jobs[0].title).toBe("Mobile Architect");
+    expect(jobs[0].url).toBe(
+      "https://jobs.scotiabank.com/Tangerine/job/Toronto-Mobile-Architect-ON-M2H0A1/598714517/"
+    );
+  });
+
+  it("strips trailing postal codes from locations", () => {
+    const synthetic = `<tr class="data-row">
+      <td><a href="/job/role/1/">Senior Analyst</a></td>
+      <td><span class="jobLocation">Toronto, ON, CA, M5H1H1</span></td>
+      <td><span class="jobDate">May 23, 2026</span></td>
+    </tr>`;
+    const jobs = parseJobsFromHtml(synthetic, "Scotiabank", new Set());
+    expect(jobs[0].location).toBe("Toronto, ON, CA");
+  });
+
+  it("de-duplicates by external_id when seen across pages", () => {
+    const synthetic = `<tr class="data-row">
+      <td><a href="/job/role/12345/">Senior Analyst</a></td>
+    </tr>`;
+    const seen = new Set<string>(["12345"]);
+    const jobs = parseJobsFromHtml(synthetic, "Scotiabank", seen);
+    expect(jobs).toHaveLength(0);
+  });
+
+  it("decodes HTML entities in titles", () => {
+    const synthetic = `<tr class="data-row">
+      <td><a href="/job/role/1/">Risk &amp; Compliance Officer</a></td>
+    </tr>`;
+    const jobs = parseJobsFromHtml(synthetic, "Scotiabank", new Set());
+    expect(jobs[0].title).toBe("Risk & Compliance Officer");
+  });
+});
+
+describe("resolveMaxPages", () => {
+  it("defaults to 200 when env var is unset", () => {
+    expect(resolveMaxPages(undefined)).toBe(200);
+    expect(resolveMaxPages("")).toBe(200);
+  });
+
+  it("parses positive integers from env", () => {
+    expect(resolveMaxPages("2")).toBe(2);
+    expect(resolveMaxPages("100")).toBe(100);
+  });
+
+  it("falls back to default for non-numeric, zero, or negative values", () => {
+    expect(resolveMaxPages("abc")).toBe(200);
+    expect(resolveMaxPages("0")).toBe(200);
+    expect(resolveMaxPages("-5")).toBe(200);
+  });
+});
+
+describe("extractScotiabankDescriptionHtml", () => {
+  it("extracts the description block from the real Scotia detail fixture", () => {
+    const desc = extractScotiabankDescriptionHtml(DETAIL_HTML);
+    expect(desc).not.toBeNull();
+    expect(desc!.length).toBeGreaterThan(100);
+  });
+
+  it("matches the itemprop='description' span", () => {
+    const html = `<div><span itemprop="description"><p>hello <b>world</b></p></span></div>`;
+    expect(extractScotiabankDescriptionHtml(html)).toBe(`<p>hello <b>world</b></p>`);
+  });
+
+  it("falls back to the jobdescription class selector", () => {
+    const html = `<div><span class="jobdescription"><p>body</p></span></div>`;
+    expect(extractScotiabankDescriptionHtml(html)).toBe(`<p>body</p>`);
+  });
+
+  it("returns null when neither selector is present", () => {
+    expect(extractScotiabankDescriptionHtml(`<div>nothing here</div>`)).toBeNull();
+  });
+
+  it("strips inline <img> tags from the extracted block", () => {
+    const html = `<div><span itemprop="description"><p>text</p><img src="x.png"><p>more</p></span></div>`;
+    const got = extractScotiabankDescriptionHtml(html);
+    expect(got).not.toContain("<img");
+    expect(got).toContain("text");
+    expect(got).toContain("more");
+  });
+});

--- a/web/lib/scrapers/scotiabank.ts
+++ b/web/lib/scrapers/scotiabank.ts
@@ -28,7 +28,11 @@ export async function fetchScotiabankJobs(
   const pageSize = 25; // SuccessFactors default
   let startRow = 0;
   let totalJobs = Infinity;
-  const maxPages = 20; // safety limit
+  // Page safety + smoke cap. The original 20-page cap silently truncated
+  // brands larger than ~500 jobs (Scotia parent has ~1,900). Default
+  // raised to 200 (= 5,000-job ceiling, ~2.5× headroom over Scotia parent).
+  // `SCOTIABANK_MAX_PAGES=N` overrides for smoke tests.
+  const maxPages = resolveMaxPages(process.env.SCOTIABANK_MAX_PAGES);
   let page = 0;
 
   while (startRow < totalJobs && page < maxPages) {
@@ -56,11 +60,11 @@ export async function fetchScotiabankJobs(
 
     const html = await res.text();
 
-    // Parse total from "Results 1 – 25 of 26"
+    // Parse total from "Results 1 – 25 of 26".
     if (totalJobs === Infinity) {
-      const totalMatch = html.match(/Results\s+\d+\s*[–-]\s*\d+\s+of\s+(\d+)/);
-      if (totalMatch) {
-        totalJobs = parseInt(totalMatch[1], 10);
+      const parsed = extractTotalJobsFromHtml(html);
+      if (parsed !== null) {
+        totalJobs = parsed;
         log.info(`[scotiabank] Total jobs: ${totalJobs}`);
       }
     }
@@ -99,10 +103,44 @@ export async function fetchScotiabankJobs(
 }
 
 /**
+ * Resolve the per-run page cap from an optional env var.
+ *
+ * Returns 200 by default (5,000-job ceiling, ~2.5× headroom over Scotia
+ * parent). A positive integer in `SCOTIABANK_MAX_PAGES` overrides — used by
+ * the smoke script (e.g. SCOTIABANK_MAX_PAGES=2 → ~50 jobs, ~10s run).
+ * Non-numeric, missing, or zero values fall back to the default.
+ *
+ * Exported for testing.
+ */
+export function resolveMaxPages(raw: string | undefined): number {
+  if (!raw) return 200;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return 200;
+  return n;
+}
+
+/**
+ * Extract the "Results 1 – 25 of N" total count from a listing page.
+ *
+ * SuccessFactors wraps both sides of the count in `<b>` tags on some brand
+ * portals (e.g. the Scotiabank parent brand) but not others (Tangerine).
+ * We strip the inline markup first so a single regex handles both.
+ *
+ * Exported for testing.
+ */
+export function extractTotalJobsFromHtml(html: string): number | null {
+  const flatHeader = html.replace(/<[^>]+>/g, " ").replace(/\s+/g, " ");
+  const totalMatch = flatHeader.match(/Results\s+\d+\s*[–-]\s*\d+\s+of\s+(\d+)/);
+  return totalMatch ? parseInt(totalMatch[1], 10) : null;
+}
+
+/**
  * Parse job listings from SuccessFactors HTML.
  * Extracts data from the server-rendered table rows.
+ *
+ * Exported for testing — production callers should use `fetchScotiabankJobs`.
  */
-function parseJobsFromHtml(
+export function parseJobsFromHtml(
   html: string,
   brandPath: string,
   seenIds: Set<string>
@@ -114,13 +152,19 @@ function parseJobsFromHtml(
   const rowRegex = /<tr\s+class="data-row[^"]*"[^>]*>([\s\S]*?)<\/tr>/gi;
   let rowMatch;
 
+  // The brand-path prefix in job hrefs is OPTIONAL: Tangerine includes it
+  // (`/Tangerine/job/...`), the Scotiabank parent brand omits it
+  // (`/job/...`). Match both shapes with a non-capturing optional group so
+  // a single parser handles every Scotiabank SuccessFactors brand.
+  const hrefPrefix = `(?:/${escapeRegex(brandPath)})?/job/`;
+
   while ((rowMatch = rowRegex.exec(html)) !== null) {
     const rowHtml = rowMatch[1];
 
     // Extract job link, title, and ID
     // Pattern: <a href="/Tangerine/job/Toronto-.../598714517/" title="Mobile Architect">
     const linkRegex = new RegExp(
-      `<a[^>]*href="(/${escapeRegex(brandPath)}/job/[^"]+/(\\d+)/?)"[^>]*title="([^"]*)"`,
+      `<a[^>]*href="(${hrefPrefix}[^"]+/(\\d+)/?)"[^>]*title="([^"]*)"`,
       "i"
     );
     const linkMatch = linkRegex.exec(rowHtml);
@@ -128,7 +172,7 @@ function parseJobsFromHtml(
     if (!linkMatch) {
       // Try alternate pattern: title in the link text instead of attribute
       const altLinkRegex = new RegExp(
-        `<a[^>]*href="(/${escapeRegex(brandPath)}/job/[^"]+/(\\d+)/?)"[^>]*>([^<]+)</a>`,
+        `<a[^>]*href="(${hrefPrefix}[^"]+/(\\d+)/?)"[^>]*>([^<]+)</a>`,
         "i"
       );
       const altMatch = altLinkRegex.exec(rowHtml);
@@ -138,7 +182,7 @@ function parseJobsFromHtml(
       if (seenIds.has(jobId)) continue;
       seenIds.add(jobId);
 
-      const jobData = buildJobData(jobId, title.trim(), path, rowHtml);
+      const jobData = buildJobData(jobId, decodeHtmlEntities(title.trim()), path, rowHtml);
       if (jobData) jobs.push(jobData);
       continue;
     }
@@ -286,7 +330,8 @@ export async function enrichScotiabankJobDescriptions(
   return enriched;
 }
 
-function extractScotiabankDescriptionHtml(html: string): string | null {
+/** Exported for testing. */
+export function extractScotiabankDescriptionHtml(html: string): string | null {
   const descriptionByItemprop = extractBalancedSpanInnerHtml(
     html,
     /<span[^>]*itemprop="description"[^>]*>/i

--- a/web/lib/scrapers/workday-cibc.ts
+++ b/web/lib/scrapers/workday-cibc.ts
@@ -116,7 +116,12 @@ export async function fetchWorkdayCibcJobs(): Promise<JobData[]> {
     const data = (await res.json()) as WorkdayListingResponse;
     const rows = data.jobPostings ?? [];
     if (rows.length === 0) break;
-    total = data.total ?? total;
+    // Workday returns the real `total` only on the first page; subsequent
+    // pages echo `total: 0` while still returning real `jobPostings`. Treat
+    // any non-positive value as missing or we exit the loop at offset=40.
+    if (typeof data.total === "number" && data.total > 0) {
+      total = data.total;
+    }
 
     for (const row of rows) {
       const job = parseWorkdayListingRow(row, urls.jobPublicUrl);

--- a/web/lib/scrapers/workday-td.ts
+++ b/web/lib/scrapers/workday-td.ts
@@ -77,7 +77,12 @@ export async function fetchWorkdayTdJobs(): Promise<JobData[]> {
     const data = (await res.json()) as WorkdayListingResponse;
     const rows = data.jobPostings ?? [];
     if (rows.length === 0) break;
-    total = data.total ?? total;
+    // Workday returns the real `total` only on the first page; subsequent
+    // pages echo `total: 0` while still returning real `jobPostings`. Treat
+    // any non-positive value as missing or we exit the loop at offset=40.
+    if (typeof data.total === "number" && data.total > 0) {
+      total = data.total;
+    }
 
     for (const row of rows) {
       const job = parseWorkdayListingRow(row, urls.jobPublicUrl);

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.2.3",
+  "version": "2.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/scripts/backfill-incumbents.ts
+++ b/web/scripts/backfill-incumbents.ts
@@ -1,0 +1,204 @@
+/**
+ * Backfill strategic insights + tech stacks for every incumbent bank.
+ *
+ * Targets `companies WHERE tier = 'incumbent' AND is_active = true`. For each
+ * bank:
+ *  1. generateCompanyInsight() with forceRegenerate=true (idempotent if a
+ *     recent row already exists, but `force` skips the 7-day rate limit so
+ *     re-runs always refresh).
+ *  2. aggregateTechStackFromJobs → enrichTechStackWithAnalysis → store on
+ *     `companies.tech_stack`.
+ *
+ * Sequential per company; ~30–60s of Gemini work per bank, so the full pass
+ * over 5 incumbents takes ~5 minutes. Idempotent — re-running picks up where
+ * it left off (if `--only` is omitted, every bank gets refreshed).
+ *
+ * Usage (from web/):
+ *   npx tsx --env-file=.env.local scripts/backfill-incumbents.ts
+ *   npx tsx --env-file=.env.local scripts/backfill-incumbents.ts --only scotiabank,td
+ *   npx tsx --env-file=.env.local scripts/backfill-incumbents.ts --skip-insights
+ *   npx tsx --env-file=.env.local scripts/backfill-incumbents.ts --skip-tech
+ */
+
+import { createAdminClient } from "../lib/supabase/admin";
+import { generateCompanyInsight } from "../lib/analysis/company-insights";
+import { aggregateTechStackFromJobs } from "../lib/ai/tech-stack-aggregation";
+import { enrichTechStackWithAnalysis } from "../lib/ai/tech-stack-extraction";
+import { buildTechStackStrategicContext } from "../lib/analysis/strategic-context";
+import { getActiveTechStackAiConfig } from "../lib/ai/prompt-config";
+
+interface Flags {
+  only: string[] | null;       // slugs allowlist
+  skipInsights: boolean;
+  skipTech: boolean;
+}
+
+function parseFlags(argv: string[]): Flags {
+  let only: string[] | null = null;
+  let skipInsights = false;
+  let skipTech = false;
+  for (const a of argv) {
+    if (a.startsWith("--only=")) {
+      only = a.slice("--only=".length).split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (a === "--only") {
+      // handled by paired arg in next loop iteration if used as `--only x`
+    } else if (a === "--skip-insights") {
+      skipInsights = true;
+    } else if (a === "--skip-tech") {
+      skipTech = true;
+    }
+  }
+  // also support `--only foo,bar` (space-separated arg)
+  const idx = argv.indexOf("--only");
+  if (idx >= 0 && argv[idx + 1] && !argv[idx + 1].startsWith("--")) {
+    only = argv[idx + 1].split(",").map((s) => s.trim()).filter(Boolean);
+  }
+  return { only, skipInsights, skipTech };
+}
+
+async function main() {
+  const flags = parseFlags(process.argv.slice(2));
+  const supabase = createAdminClient();
+
+  if (!process.env.GEMINI_API_KEY) {
+    console.error("❌ GEMINI_API_KEY is required.");
+    process.exit(1);
+  }
+
+  console.log("🏦 Backfill incumbent intelligence");
+  console.log("═".repeat(70));
+
+  let query = supabase
+    .from("companies")
+    .select("id, slug, name, tech_stack_generated_at")
+    .eq("tier", "incumbent")
+    .eq("is_active", true)
+    .order("slug");
+  if (flags.only) {
+    query = query.in("slug", flags.only);
+  }
+
+  const { data: banks, error } = await query;
+  if (error || !banks || banks.length === 0) {
+    console.error(`No incumbent companies found: ${error?.message ?? "empty result"}`);
+    process.exit(1);
+  }
+
+  console.log(`Found ${banks.length} bank(s): ${banks.map((b) => b.slug).join(", ")}`);
+  console.log(
+    `Insights: ${flags.skipInsights ? "SKIP" : "REGENERATE"}    Tech stacks: ${flags.skipTech ? "SKIP" : "REGENERATE"}\n`
+  );
+
+  const summary: Array<{
+    slug: string;
+    insightOk: boolean;
+    techOk: boolean;
+    insightError?: string;
+    techError?: string;
+    elapsedMs: number;
+  }> = [];
+
+  for (let i = 0; i < banks.length; i++) {
+    const bank = banks[i];
+    const progress = `[${i + 1}/${banks.length}]`;
+    console.log(`${progress} ${bank.name} (${bank.slug})`);
+    const tStart = Date.now();
+    const result: (typeof summary)[number] = {
+      slug: bank.slug,
+      insightOk: false,
+      techOk: false,
+      elapsedMs: 0,
+    };
+
+    // 1) Insight
+    if (!flags.skipInsights) {
+      try {
+        // Clear any stale lock so a previous interrupted run doesn't block us.
+        await supabase
+          .from("insight_generation_locks")
+          .delete()
+          .eq("company_id", bank.id);
+
+        const t0 = Date.now();
+        const insight = await generateCompanyInsight(bank.id, bank.name, {
+          periodDays: 90,
+          researchDepth: "deep",
+          forceRegenerate: true,
+        });
+        const dt = ((Date.now() - t0) / 1000).toFixed(1);
+        console.log(
+          `   ✅ insight (${dt}s) — "${insight.headline}" significance=${insight.significanceScore}/10`
+        );
+        result.insightOk = true;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`   ❌ insight failed: ${msg}`);
+        result.insightError = msg;
+      }
+    }
+
+    // 2) Tech stack
+    if (!flags.skipTech) {
+      try {
+        const t0 = Date.now();
+        const raw = await aggregateTechStackFromJobs(bank.id);
+        if (raw.technologies.length === 0) {
+          console.log(`   ⚠️  tech-stack skipped — no tech data found in job postings`);
+        } else {
+          const strategicContext = await buildTechStackStrategicContext(bank.id);
+          const config = await getActiveTechStackAiConfig();
+          const enriched = await enrichTechStackWithAnalysis(
+            bank.name,
+            raw.technologies,
+            raw.totalJobsAnalyzed,
+            raw.periodStart,
+            raw.periodEnd,
+            strategicContext.context,
+            config
+          );
+          await supabase
+            .from("companies")
+            .update({
+              tech_stack: enriched,
+              tech_stack_generated_at: new Date().toISOString(),
+            })
+            .eq("id", bank.id);
+          const dt = ((Date.now() - t0) / 1000).toFixed(1);
+          const catCount = enriched.categories?.length ?? 0;
+          console.log(
+            `   ✅ tech_stack (${dt}s) — ${catCount} categories from ${raw.totalJobsAnalyzed} jobs`
+          );
+          result.techOk = true;
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.log(`   ❌ tech_stack failed: ${msg}`);
+        result.techError = msg;
+      }
+    }
+
+    result.elapsedMs = Date.now() - tStart;
+    summary.push(result);
+    console.log("");
+  }
+
+  console.log("═".repeat(70));
+  console.log("Summary:");
+  for (const s of summary) {
+    const flags: string[] = [];
+    flags.push(`insight:${s.insightOk ? "ok" : s.insightError ? "FAIL" : "skip"}`);
+    flags.push(`tech:${s.techOk ? "ok" : s.techError ? "FAIL" : "skip"}`);
+    console.log(`  ${s.slug.padEnd(12)} ${(s.elapsedMs / 1000).toFixed(1).padStart(6)}s   ${flags.join("   ")}`);
+  }
+  const fails = summary.filter((s) => s.insightError || s.techError);
+  if (fails.length > 0) {
+    console.log(`\n⚠️  ${fails.length} bank(s) had failures.`);
+    process.exit(1);
+  }
+  console.log("\n✅ Backfill complete.");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/web/scripts/seed-phase3-banks.ts
+++ b/web/scripts/seed-phase3-banks.ts
@@ -63,6 +63,18 @@ const BANKS: IncumbentBankSeed[] = [
     ats_identifier: "bnc",
     careers_url: "https://emplois.bnc.ca/en_CA/careers/searchjobs",
   },
+  {
+    // Scotia parent brand. Tangerine — Scotia's digital subsidiary — is
+    // already tracked separately under the same SuccessFactors host but a
+    // different brand path (`/Tangerine/`), and stays as a fintech-tier
+    // company. Scotia parent is the 5th and final Big-6 incumbent.
+    name: "Scotiabank",
+    slug: "scotiabank",
+    country: "CA",
+    ats_type: "scotiabank",
+    ats_identifier: "Scotiabank",
+    careers_url: "https://jobs.scotiabank.com/Scotiabank/search/",
+  },
 ];
 
 async function main(): Promise<void> {
@@ -104,7 +116,7 @@ async function main(): Promise<void> {
     console.log(`[seed-phase3] upserted ${bank.slug} (${bank.name})`);
   }
 
-  // Tier-integrity assert (Luke's blocker #7). If any of the 4 came back
+  // Tier-integrity assert (Luke's blocker #7). If any seeded row came back
   // with the default 'fintech' tier — e.g. an older row already existed
   // with that value and upsert didn't overwrite it — fail loudly. A bank
   // silently in the fintech tier would leak straight into every aggregator
@@ -129,7 +141,9 @@ async function main(): Promise<void> {
         .join(", ")}`
     );
   }
-  console.log(`[seed-phase3] tier integrity ok — 4/4 rows confirmed 'incumbent'`);
+  console.log(
+    `[seed-phase3] tier integrity ok — ${verify.length}/${BANKS.length} rows confirmed 'incumbent'`
+  );
   console.log(`[seed-phase3] all is_active=false; flip after smoke.`);
 }
 

--- a/web/scripts/smoke-scotiabank.ts
+++ b/web/scripts/smoke-scotiabank.ts
@@ -1,0 +1,89 @@
+/**
+ * Integration smoke: drive the production Scotiabank SuccessFactors
+ * scraper through `fetchJobs("scotiabank", "Scotiabank", …)` and dump the
+ * result for human inspection.
+ *
+ * Usage (from web/):
+ *   npx tsx scripts/smoke-scotiabank.ts
+ *
+ * Output: scripts/artifacts/scotiabank-smoke.json
+ *
+ * What this exercises:
+ *   - The real factory dispatch in web/lib/scrapers/index.ts
+ *   - The real scraper in web/lib/scrapers/scotiabank.ts (pagination over
+ *     /Scotiabank/search?startrow= + concurrent detail-page description
+ *     enrichment via extractScotiabankDescriptionHtml)
+ *   - The optional brand-path prefix in job hrefs (Scotia parent omits it;
+ *     Tangerine includes it — same parser handles both)
+ *
+ * Cap: forces SCOTIABANK_MAX_PAGES=2 so a local smoke pulls ~50 jobs in
+ * ~30s, not the ~1,900 jobs / several minutes a full parent scrape would.
+ * The env var is an optional cap — unset (the production default) the
+ * scraper paginates to the corpus total.
+ */
+
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fetchJobs } from "../lib/scrapers";
+
+const SMOKE_MAX_PAGES = 2; // ~50 jobs
+const OUT = resolve(__dirname, "artifacts/scotiabank-smoke.json");
+
+async function main(): Promise<void> {
+  // Cap the production scraper to a small, fast run.
+  process.env.SCOTIABANK_MAX_PAGES = String(SMOKE_MAX_PAGES);
+
+  let error: string | null = null;
+  let jobs: Awaited<ReturnType<typeof fetchJobs>> = [];
+
+  try {
+    console.log(`[smoke] dispatching fetchJobs("scotiabank", "Scotiabank", …)`);
+    // Pass undefined for browser — the Scotiabank scraper is server-HTML,
+    // no Puppeteer required.
+    jobs = await fetchJobs(
+      "scotiabank",
+      "Scotiabank",
+      undefined,
+      undefined
+    );
+    console.log(`[smoke] factory returned ${jobs.length} jobs`);
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+    console.error(`[smoke] fetchJobs failed:`, error);
+  }
+
+  // Quality stats: how many got descriptions?
+  const withDescriptions = jobs.filter(
+    (j) => !!j.description_text && j.description_text.trim().length > 0
+  ).length;
+  const withLocation = jobs.filter((j) => !!j.location).length;
+  const withPostedDate = jobs.filter((j) => !!j.posted_date).length;
+
+  const payload = {
+    ranAt: new Date().toISOString(),
+    maxPages: SMOKE_MAX_PAGES,
+    error,
+    jobCount: jobs.length,
+    withDescriptions,
+    withLocation,
+    withPostedDate,
+    notes: [
+      "Driven through the real fetchJobs(\"scotiabank\", \"Scotiabank\", …) factory and the production scotiabank.ts scraper.",
+      "SCOTIABANK_MAX_PAGES is an optional cap; unset = full corpus, this smoke forces 2 (~50 jobs).",
+      "description_text on each job is the FULL extracted text from the per-detail-page itemprop=\"description\" span.",
+    ],
+    jobs,
+  };
+
+  mkdirSync(dirname(OUT), { recursive: true });
+  writeFileSync(OUT, JSON.stringify(payload, null, 2));
+  console.log(`[smoke] wrote ${OUT}`);
+  console.log(
+    `[smoke] descriptions: ${withDescriptions}/${jobs.length}, locations: ${withLocation}/${jobs.length}, dates: ${withPostedDate}/${jobs.length}`
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- **Scotiabank joins the incumbent lens.** Adds the parent brand on `jobs.scotiabank.com/Scotiabank/` (1,902 visible jobs) as the 5th and final Big-6 Canadian bank. Reuses the existing `scotiabank.ts` SuccessFactors scraper that already serves Tangerine — one parser, two brands, optional brand-prefix in hrefs.
- **Workday TD/CIBC pagination fix (v2.2.4)** — `data.total` echoes `0` after page 1, which clobbered the loop and capped both banks at 40 jobs each. Guard: only update `total` when positive. Unlocked **1,491 + 495 = 1,986 previously-hidden jobs.**
- **Insight generation more resilient (v2.3.1)** — `maxOutputTokens` raised 4096 → 8192 and added empty-response / parse-failure retries (up to 2 attempts with backoff). Incumbent backfills were dying mid-string on "Unterminated string in JSON" because the original cap was too tight for grounded-research context + executive summaries.

## What landed in production (paste of post-merge DB state)

| Bank | Jobs (before → after) | Insight | Tech |
|---|---|---|---|
| BMO | 666 → 666 | ✅ | ✅ |
| BNC | 391 → 391 | ✅ | ✅ |
| CIBC | **40 → 535** (workday fix) | ✅ | ✅ |
| RBC | 1,558 → 1,558 | ✅ | ✅ |
| **Scotiabank** | **0 → 1,863** (new) | ✅ | ✅ |
| TD | **40 → 1,531** (workday fix) | ✅ | ✅ |
| **Total** | **2,695 → 6,544** | | |

Sample insight headlines (all written this run, all bank-specific):
- Scotiabank: "Scotiabank prioritizes capital markets technology and risk management hiring"
- TD: "TD Bank prioritizes regulatory compliance and customer support operations hiring" (sig 7)
- CIBC: "CIBC hires for US structured finance and digital customer support"

## Scraper changes

- **`scotiabank.ts`**:
  - href-prefix regex made optional: Scotia parent's hrefs use `/job/...`; Tangerine uses `/Tangerine/job/...`. One non-capturing group handles both. Regression test included.
  - Total-count regex tolerates the `<b>` tags SuccessFactors wraps the count in on Scotia parent (strips inline markup before matching).
  - Hardcoded `maxPages = 20` (which would have silently truncated Scotia at ~500 jobs) → `SCOTIABANK_MAX_PAGES` env, default 200 (5,000-job ceiling = ~2.5× headroom over Scotia parent).
  - Pure helpers exported for testability (`parseJobsFromHtml`, `extractScotiabankDescriptionHtml`, `extractTotalJobsFromHtml`, `resolveMaxPages`).
- **`index.ts`** — `scotiabank` added to `isBrowserScraper` so 1,900-job + per-detail enrichment offloads to `scrape-heavy.yml`.
- **`detect-ats.ts`** — pattern for `jobs.scotiabank.com`; identifier = first path segment (so both Tangerine and Scotiabank URLs detect correctly).
- **`workday-td.ts`** + **`workday-cibc.ts`** — `total` only updated when positive.

## Operational tooling

- **`web/scripts/smoke-scotiabank.ts`** — 50-job smoke through the production factory. Run before commit: 50/50 jobs with descriptions, locations, dates. Output captured in `scripts/artifacts/scotiabank-smoke.json`.
- **`web/scripts/backfill-incumbents.ts`** — one-pass insight + tech-stack regeneration for every `tier='incumbent'` row. Supports `--only`, `--skip-insights`, `--skip-tech`. Used to run the table above end-to-end.
- **`web/scripts/seed-phase3-banks.ts`** extended with Scotia + made the integrity-check count-agnostic.

## Tests

- **19 new unit tests** in `scotiabank.test.ts`: total-count parsing across both shapes, listing parsing for both brand-prefix shapes (Tangerine regression coverage included), postal-code strip, dedupe, entity decode, description extraction, `resolveMaxPages` env helper.
- Full suite: **269/269 passing**, `npm run build` clean, 1 pre-existing lint warning unrelated to this PR.

## Docs hygiene

- `config/companies.yaml` — Scotia row added.
- `web/lib/scrapers/CLAUDE.md` — one-line entry updated to describe both brand variants.
- `web/data/releases.json` — two entries (v2.3.0 = Scotia + workday, v2.3.1 = insight resilience).

## Test plan

- [x] 19/19 unit tests passing
- [x] Live smoke against `jobs.scotiabank.com/Scotiabank/` returned 50/50 with descriptions
- [x] `scrape-heavy.yml` against this branch successfully ingested Scotia (1,863 jobs), CIBC (535), TD (1,531)
- [x] Backfill script successfully ran insight + tech_stack across all 6 incumbents
- [x] `npm run build` clean
- [ ] Eyeball /companies/scotiabank in the deployed preview to confirm the strategic-insight card + tech-stack panel render

🤖 Generated with [Claude Code](https://claude.com/claude-code)