### PR TITLE
feat(simplii): break Simplii out as distinct fintech sub-brand (v2.4.0)

### DIFF
--- a/config/companies.yaml
+++ b/config/companies.yaml
@@ -107,12 +107,21 @@ companies:
     careers_url: https://cibc.wd3.myworkdayjobs.com/search
     tier: incumbent
     is_active: false
-    # Note: Simplii Financial postings (if any) surface inside CIBC's
-    # Workday tenant. The scraper's `isSimpliiPosting` classifier runs in
-    # log-only mode for Phase 3 — no row is added for Simplii yet. After
-    # the first scrape confirms Simplii postings appear in the data, a
-    # follow-up adds the `simplii` row (tier=fintech) and flips the
-    # classifier to actually route via `companySlugOverride`.
+
+  - name: Simplii Financial
+    slug: simplii
+    country: CA
+    # Simplii shares CIBC's Workday tenant — no own listing endpoint.
+    # In the DB this row has parent_company_id=<cibc.id>, which causes
+    # the collect cron to skip it. Its jobs land via CIBC's scrape with
+    # `companySlugOverride: 'simplii'` set by the `isSimpliiPosting`
+    # classifier in workday-cibc.ts. ats_type/identifier mirror CIBC for
+    # parity but aren't used at runtime.
+    ats_type: workday-cibc
+    ats_identifier: cibc
+    careers_url: https://www.simplii.com
+    tier: fintech
+    is_active: false
 
   - name: National Bank
     slug: bnc

--- a/web/app/api/cron/collect/route.ts
+++ b/web/app/api/cron/collect/route.ts
@@ -58,11 +58,14 @@ async function runCollect(req: NextRequest) {
       log.info({ staleTaskCount: staleTasks.length }, "Cleaned up stale tasks before collection run");
     }
 
-    // Get all active companies
+    // Get all active companies. Skip sub-brands that piggy-back on a
+    // parent's scrape (parent_company_id IS NOT NULL) — their jobs land
+    // via the parent's scraper with `companySlugOverride` routing.
     const { data: companies, error: companiesError } = await supabase
       .from("companies")
       .select("id, name, ats_type")
-      .eq("is_active", true);
+      .eq("is_active", true)
+      .is("parent_company_id", null);
 
     if (companiesError) {
       log.error({ err: companiesError.message }, "Failed to fetch companies");

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.4.0",
+    "date": "2026-05-24",
+    "changes": [
+      { "type": "feature", "description": "Simplii Financial split out as a distinct fintech card. Simplii (CIBC's direct digital bank) has no separate careers portal — every Simplii role posts through CIBC's Workday. The Phase 3 classifier (previously log-only) now tags those rows with a sub-brand override; the ingestion processor routes them to a separate `simplii` companies row (tier=fintech, parent=cibc) so Simplii gets its own strategic-insight + tech-stack panel and is excluded from CIBC's totals." }
+    ]
+  },
+  {
     "version": "2.3.1",
     "date": "2026-05-23",
     "changes": [

--- a/web/lib/jobs/processor.test.ts
+++ b/web/lib/jobs/processor.test.ts
@@ -63,26 +63,78 @@ let existingRows: Array<{
   id: string;
   external_id: string;
   description_hash: string | null;
+  company_id?: string;
 }> = [];
 
+// For tests that need to control the companySlugOverride child lookup.
+let overrideCompanyRows: Array<{
+  id: string;
+  slug: string;
+  name: string;
+  parent_company_id: string;
+}> = [];
+
+// Track inserted job_postings rows so override-routing tests can assert
+// what landed where.
+let insertedRows: Array<Record<string, unknown>> = [];
+
 function buildSupabaseMock() {
-  const updateChain = {
-    eq: vi.fn(() => Promise.resolve({ count: 0, data: null, error: null })),
-    select: vi.fn(() => updateChain),
-    single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+  // Update chain supports: .eq(...), .eq(...).eq(...) (closure path), .in(...)
+  // (companies.last_collected_at over parent + sub-brands), and being
+  // awaited directly. Implemented as a chainable thenable.
+  const makeThenableChain = (
+    payload: { count?: number; data?: unknown; error?: unknown } = { count: 0, data: null, error: null }
+  ) => {
+    const chain: Record<string, unknown> = {};
+    chain.eq = vi.fn(() => makeThenableChain(payload));
+    chain.in = vi.fn(() => makeThenableChain(payload));
+    chain.select = vi.fn(() => chain);
+    chain.single = vi.fn(() => Promise.resolve(payload));
+    chain.then = (onFulfilled: (v: unknown) => unknown) =>
+      Promise.resolve(payload).then(onFulfilled);
+    return chain;
   };
+  const buildUpdateChain = () => makeThenableChain();
+
   const insertChain: Record<string, unknown> = {};
   insertChain.select = vi.fn(() => insertChain);
-  insertChain.single = vi.fn(() => Promise.resolve({ data: { id: "new-job-id" }, error: null }));
-  const selectChain = {
-    eq: vi.fn(() => Promise.resolve({ data: existingRows, error: null })),
-  };
+  insertChain.single = vi.fn(() =>
+    Promise.resolve({ data: { id: `new-job-${insertedRows.length}` }, error: null })
+  );
+
   return {
-    from: vi.fn(() => ({
-      select: vi.fn(() => selectChain),
-      update: vi.fn(() => updateChain),
-      insert: vi.fn(() => insertChain),
-    })),
+    from: vi.fn((table: string) => {
+      if (table === "companies") {
+        // companies query: `.select('id, slug, name, parent_company_id').in('slug', [...]).eq('parent_company_id', cid)`
+        const eqStep = (data: unknown) => Promise.resolve({ data, error: null });
+        const inChain: Record<string, unknown> = {};
+        inChain.eq = vi.fn(() => eqStep(overrideCompanyRows));
+        const selectChain: Record<string, unknown> = {};
+        selectChain.in = vi.fn(() => inChain);
+        return {
+          select: vi.fn(() => selectChain),
+          update: vi.fn(() => buildUpdateChain()),
+          insert: vi.fn(() => insertChain),
+        };
+      }
+      // job_postings: `.select(...).in('company_id', [...])`
+      const inChain: Record<string, unknown> = {
+        then: undefined,
+      };
+      Object.assign(inChain, Promise.resolve({ data: existingRows, error: null }));
+      const selectChain: Record<string, unknown> = {
+        in: vi.fn(() => Promise.resolve({ data: existingRows, error: null })),
+        eq: vi.fn(() => Promise.resolve({ data: existingRows, error: null })),
+      };
+      return {
+        select: vi.fn(() => selectChain),
+        update: vi.fn(() => buildUpdateChain()),
+        insert: vi.fn((row: Record<string, unknown>) => {
+          insertedRows.push(row);
+          return insertChain;
+        }),
+      };
+    }),
   };
 }
 
@@ -122,6 +174,8 @@ describe("runIngestStage description_hash gate", () => {
   beforeEach(() => {
     extractJobStructureMock.mockClear();
     existingRows = [];
+    overrideCompanyRows = [];
+    insertedRows = [];
   });
 
   it("skips the Gemini extraction call when the stored hash matches the new description", async () => {
@@ -130,6 +184,7 @@ describe("runIngestStage description_hash gate", () => {
         id: "existing-job-1",
         external_id: FIXTURE_JOB.external_id,
         description_hash: STORED_HASH_MATCH,
+        company_id: FIXTURE_COMPANY.id,
       },
     ];
 
@@ -145,6 +200,7 @@ describe("runIngestStage description_hash gate", () => {
         id: "existing-job-1",
         external_id: FIXTURE_JOB.external_id,
         description_hash: STORED_HASH_DIFFERENT,
+        company_id: FIXTURE_COMPANY.id,
       },
     ];
 
@@ -152,5 +208,75 @@ describe("runIngestStage description_hash gate", () => {
     await runIngestStage("task-2", FIXTURE_COMPANY as never, [FIXTURE_JOB] as never);
 
     expect(extractJobStructureMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("runIngestStage companySlugOverride routing", () => {
+  beforeEach(() => {
+    extractJobStructureMock.mockClear();
+    existingRows = [];
+    overrideCompanyRows = [];
+    insertedRows = [];
+  });
+
+  it("routes a job with companySlugOverride to the matching sub-brand's company_id", async () => {
+    // Parent (CIBC analogue) has no existing rows; sub-brand (Simplii) is
+    // a known child of the parent.
+    overrideCompanyRows = [
+      {
+        id: "sub-co-1",
+        slug: "subbrand",
+        name: "Sub Brand",
+        parent_company_id: FIXTURE_COMPANY.id,
+      },
+    ];
+
+    const childJob = {
+      ...FIXTURE_JOB,
+      external_id: "ext-sub-1",
+      title: "Director, Sub Brand",
+      companySlugOverride: "subbrand",
+    };
+    const parentJob = {
+      ...FIXTURE_JOB,
+      external_id: "ext-parent-1",
+      title: "Director, Parent",
+    };
+
+    const { runIngestStage } = await import("./processor");
+    await runIngestStage(
+      "task-override",
+      FIXTURE_COMPANY as never,
+      [parentJob, childJob] as never
+    );
+
+    // Both rows should have been inserted, each under the correct company_id.
+    const parentRow = insertedRows.find((r) => r.external_id === "ext-parent-1");
+    const childRow = insertedRows.find((r) => r.external_id === "ext-sub-1");
+    expect(parentRow?.company_id).toBe(FIXTURE_COMPANY.id);
+    expect(childRow?.company_id).toBe("sub-co-1");
+  });
+
+  it("falls back to the parent company_id when the override slug is unknown", async () => {
+    // No sub-brand rows configured → override lookup returns empty.
+    overrideCompanyRows = [];
+
+    const childJob = {
+      ...FIXTURE_JOB,
+      external_id: "ext-ghost-1",
+      title: "Ghost role",
+      companySlugOverride: "does-not-exist",
+    };
+
+    const { runIngestStage } = await import("./processor");
+    await runIngestStage(
+      "task-fallback",
+      FIXTURE_COMPANY as never,
+      [childJob] as never
+    );
+
+    // Falls back to parent — the job is inserted under the parent company_id.
+    expect(insertedRows).toHaveLength(1);
+    expect(insertedRows[0].company_id).toBe(FIXTURE_COMPANY.id);
   });
 });

--- a/web/lib/jobs/processor.ts
+++ b/web/lib/jobs/processor.ts
@@ -202,19 +202,71 @@ export async function runIngestStage(
   });
 
   try {
-    // Get existing job postings
+    // Sub-brand override routing: scrapers can tag a job with
+    // `companySlugOverride` to route it to a different companies row
+    // that shares the parent's ATS (e.g. Simplii on CIBC's Workday).
+    // Resolve overrides up-front so we can build per-company maps.
+    const overrideSlugs = new Set<string>();
+    for (const j of jobs) {
+      if (j.companySlugOverride && j.companySlugOverride !== company.slug) {
+        overrideSlugs.add(j.companySlugOverride);
+      }
+    }
+    const overrideCompanies = new Map<string, { id: string; name: string }>();
+    if (overrideSlugs.size > 0) {
+      const { data: rows } = await supabase
+        .from('companies')
+        .select('id, slug, name, parent_company_id')
+        .in('slug', Array.from(overrideSlugs))
+        .eq('parent_company_id', company.id);
+      for (const r of rows ?? []) {
+        overrideCompanies.set(r.slug as string, { id: r.id as string, name: r.name as string });
+      }
+      const missing = Array.from(overrideSlugs).filter((s) => !overrideCompanies.has(s));
+      if (missing.length > 0) {
+        log.warn(
+          { parent: company.slug, missingChildSlugs: missing },
+          '[ingest] companySlugOverride references unknown sub-brand(s); falling back to parent'
+        );
+      }
+    }
+    const resolveCompanyId = (job: JobData): string => {
+      if (job.companySlugOverride) {
+        const child = overrideCompanies.get(job.companySlugOverride);
+        if (child) return child.id;
+      }
+      return company.id;
+    };
+
+    // Load existing job_postings for parent + every resolved sub-brand
+    // so per-company existingMap/fetchedIds (used by closure detection)
+    // are computed correctly.
+    const ingestCompanyIds = [company.id, ...Array.from(overrideCompanies.values()).map((c) => c.id)];
     const { data: existing } = await supabase
       .from('job_postings')
-      .select('id, external_id, description_hash')
-      .eq('company_id', company.id);
+      .select('id, external_id, description_hash, company_id')
+      .in('company_id', ingestCompanyIds);
 
-    const existingMap = new Map(
-      (existing ?? []).map((e) => [
-        e.external_id,
-        { id: e.id as string, descriptionHash: (e.description_hash ?? null) as string | null },
-      ])
-    );
-    const fetchedIds = new Set(jobs.map((j) => j.external_id));
+    const existingByCompany = new Map<
+      string,
+      Map<string, { id: string; descriptionHash: string | null }>
+    >();
+    for (const cid of ingestCompanyIds) existingByCompany.set(cid, new Map());
+    for (const e of existing ?? []) {
+      const m = existingByCompany.get(e.company_id as string);
+      if (!m) continue;
+      m.set(e.external_id as string, {
+        id: e.id as string,
+        descriptionHash: (e.description_hash ?? null) as string | null,
+      });
+    }
+
+    const fetchedByCompany = new Map<string, Set<string>>();
+    for (const cid of ingestCompanyIds) fetchedByCompany.set(cid, new Set());
+    for (const j of jobs) {
+      const cid = resolveCompanyId(j);
+      fetchedByCompany.get(cid)?.add(j.external_id);
+    }
 
     let newJobs = 0;
     let updatedJobs = 0;
@@ -222,20 +274,29 @@ export async function runIngestStage(
     let extractionsSkippedByHash = 0;
     const newJobIds: string[] = [];
     const extractionPromises: Promise<void>[] = [];
+    const overrideRoutedCount = new Map<string, number>();
 
     const total = jobs.length;
     let processed = 0;
 
     // Process each job
     for (const job of jobs) {
+      const targetCompanyId = resolveCompanyId(job);
+      if (job.companySlugOverride && targetCompanyId !== company.id) {
+        overrideRoutedCount.set(
+          job.companySlugOverride,
+          (overrideRoutedCount.get(job.companySlugOverride) ?? 0) + 1
+        );
+      }
+
       const row = {
         ...jobToRow(job),
-        company_id: company.id,
+        company_id: targetCompanyId,
         last_seen_date: new Date().toISOString(),
         is_active: true,
       };
 
-      const existingEntry = existingMap.get(job.external_id);
+      const existingEntry = existingByCompany.get(targetCompanyId)?.get(job.external_id);
       // Content fingerprint for the description_hash gate (Phase 2). A null
       // stored hash is treated as "changed" so the first scrape after deploy
       // still populates everything, matching the intent of the SQL backfill.
@@ -345,30 +406,47 @@ export async function runIngestStage(
       );
     }
 
-    // Mark jobs as closed if no longer in feed
-    // Only update jobs that are currently active to avoid overwriting
-    // closed_date on already-closed jobs every collection run
-    for (const [extId, entry] of existingMap) {
-      if (!fetchedIds.has(extId)) {
-        const { count } = await supabase
-          .from('job_postings')
-          .update({
-            is_active: false,
-            closed_date: new Date().toISOString(),
-          })
-          .eq('id', entry.id)
-          .eq('is_active', true);
-        if (count && count > 0) {
-          closedJobs++;
+    // Mark jobs as closed if no longer in feed. Runs per ingest-target
+    // company (parent + every sub-brand we routed jobs into) — a job that
+    // was last seen under CIBC but is now classified as Simplii would
+    // otherwise be flagged "closed" forever under CIBC. Each company
+    // closes only those of its own rows that didn't show up in this run.
+    for (const cid of ingestCompanyIds) {
+      const existingMap = existingByCompany.get(cid);
+      const fetchedIds = fetchedByCompany.get(cid);
+      if (!existingMap || !fetchedIds) continue;
+      for (const [extId, entry] of existingMap) {
+        if (!fetchedIds.has(extId)) {
+          const { count } = await supabase
+            .from('job_postings')
+            .update({
+              is_active: false,
+              closed_date: new Date().toISOString(),
+            })
+            .eq('id', entry.id)
+            .eq('is_active', true);
+          if (count && count > 0) {
+            closedJobs++;
+          }
         }
       }
     }
 
-    // Update company's last_collected_at
+    // Update last_collected_at on every ingest-target company (parent +
+    // sub-brands). Sub-brands don't have their own scrape, so the parent's
+    // run is the authoritative refresh signal.
     await supabase
       .from('companies')
       .update({ last_collected_at: new Date().toISOString() })
-      .eq('id', company.id);
+      .in('id', ingestCompanyIds);
+
+    // Sub-brand routing telemetry.
+    for (const [slug, n] of overrideRoutedCount) {
+      log.info(
+        { parent: company.slug, child: slug, routed: n },
+        '[ingest] sub-brand routing'
+      );
+    }
 
     // Update task with results
     await supabase

--- a/web/lib/jobs/types.ts
+++ b/web/lib/jobs/types.ts
@@ -62,6 +62,7 @@ export interface JobRun {
 
 export interface Company {
   id: string;
+  slug: string;
   name: string;
   ats_type: string;
   ats_identifier: string | null;

--- a/web/lib/scrapers/types.ts
+++ b/web/lib/scrapers/types.ts
@@ -10,6 +10,15 @@ export interface JobData {
   commitment?: string | null;
   posted_date?: Date | null;
   url?: string | null;
+  /**
+   * Routing hint: when set, the processor inserts this job under the
+   * named company slug instead of the parent company being scraped.
+   * Used for sub-brands that share an ATS tenant (e.g. Simplii on
+   * CIBC's Workday). The target company must exist with
+   * `parent_company_id` pointing at the parent. Not persisted to the
+   * `job_postings` row.
+   */
+  companySlugOverride?: string;
 }
 
 export function jobToRow(job: JobData) {

--- a/web/lib/scrapers/workday-cibc.ts
+++ b/web/lib/scrapers/workday-cibc.ts
@@ -3,12 +3,13 @@
  *
  * Tenant: `cibc`. Instance: `wd3`. Site: `search`.
  *
- * **Simplii classifier is LOG-ONLY for Phase 3.** Each listing row is
- * inspected for a Simplii brand marker (in `bulletFields`, title, or any
- * other visible string). When matched, we log and continue — we do NOT
- * set a `companySlugOverride` field. Per Farhan: confirm Simplii postings
- * actually surface from CIBC's Workday in production before adding the
- * override mechanism + the Simplii companies row (Phase 3.5).
+ * **Simplii classifier is live.** Each listing row is inspected for a
+ * Simplii brand marker (in title, bulletFields, or any tenant-emitted
+ * brand/business-unit field). When matched, the job is tagged with
+ * `companySlugOverride: 'simplii'` and the processor routes it to the
+ * Simplii companies row (tier=fintech, parent_company_id=cibc.id)
+ * instead of CIBC. Sub-brand split is per-row only — there is no
+ * separate Simplii URL or listing endpoint.
  *
  * Cost knob: `WORKDAY_CIBC_MAX_JOBS` env caps the run. Unset → full
  * corpus.
@@ -127,18 +128,20 @@ export async function fetchWorkdayCibcJobs(): Promise<JobData[]> {
       const job = parseWorkdayListingRow(row, urls.jobPublicUrl);
       if (!job) continue;
 
-      // Simplii classifier — log-only mode for Phase 3. Do NOT mutate
-      // the job; Phase 3.5 wires the override + companies row.
+      // Simplii classifier. When matched, tag the job with the override
+      // slug; the processor reads `companySlugOverride` and writes the
+      // job under the Simplii companies row (parent_company_id=cibc).
       const simplii = isSimpliiPosting(row);
       if (simplii.isMatch) {
         simpliiSeen++;
+        job.companySlugOverride = "simplii";
         log.info(
           {
             jobReqId: job.external_id,
             title: job.title,
             marker: simplii.marker,
           },
-          "[workday-cibc] would-route-to-simplii (log-only Phase 3)"
+          "[workday-cibc] routing to simplii"
         );
       }
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/scripts/regenerate-simplii.ts
+++ b/web/scripts/regenerate-simplii.ts
@@ -1,0 +1,97 @@
+/**
+ * One-off: regenerate strategic insight + tech stack for Simplii.
+ *
+ * Simplii is a CIBC sub-brand seeded by migration
+ * `20260524000000_parent_company.sql`. With only 2 historical (closed)
+ * Simplii rows, the insight leans heavily on grounded research and the
+ * tech-stack will likely come back empty/thin — both are accurate.
+ *
+ * Usage (from `web/`):
+ *   npx tsx --env-file=.env.local scripts/regenerate-simplii.ts
+ */
+
+import { createAdminClient } from "../lib/supabase/admin";
+import { generateCompanyInsight } from "../lib/analysis/company-insights";
+import { aggregateTechStackFromJobs } from "../lib/ai/tech-stack-aggregation";
+import { enrichTechStackWithAnalysis } from "../lib/ai/tech-stack-extraction";
+import { buildTechStackStrategicContext } from "../lib/analysis/strategic-context";
+import { getActiveTechStackAiConfig } from "../lib/ai/prompt-config";
+
+async function main(): Promise<void> {
+  if (!process.env.GEMINI_API_KEY) {
+    console.error("❌ GEMINI_API_KEY required.");
+    process.exit(1);
+  }
+
+  const supabase = createAdminClient();
+  const { data: company, error } = await supabase
+    .from("companies")
+    .select("id, name, slug")
+    .eq("slug", "simplii")
+    .single();
+  if (error || !company) {
+    console.error(`Simplii row not found: ${error?.message}`);
+    process.exit(1);
+  }
+
+  console.log(`▶ ${company.name} (${company.slug})`);
+
+  // Clear any stale insight lock.
+  await supabase
+    .from("insight_generation_locks")
+    .delete()
+    .eq("company_id", company.id);
+
+  // 1) Strategic insight
+  try {
+    const t0 = Date.now();
+    const insight = await generateCompanyInsight(company.id, company.name, {
+      periodDays: 90,
+      researchDepth: "deep",
+      forceRegenerate: true,
+    });
+    console.log(
+      `  ✅ insight (${((Date.now() - t0) / 1000).toFixed(1)}s) — "${insight.headline}" significance=${insight.significanceScore}/10`
+    );
+  } catch (err) {
+    console.log(`  ❌ insight failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  // 2) Tech stack
+  try {
+    const t0 = Date.now();
+    const raw = await aggregateTechStackFromJobs(company.id);
+    if (raw.technologies.length === 0) {
+      console.log(`  ⚠️  tech_stack skipped — no tech signal in Simplii's 2 historical job rows`);
+    } else {
+      const strategicContext = await buildTechStackStrategicContext(company.id);
+      const config = await getActiveTechStackAiConfig();
+      const enriched = await enrichTechStackWithAnalysis(
+        company.name,
+        raw.technologies,
+        raw.totalJobsAnalyzed,
+        raw.periodStart,
+        raw.periodEnd,
+        strategicContext.context,
+        config
+      );
+      await supabase
+        .from("companies")
+        .update({
+          tech_stack: enriched,
+          tech_stack_generated_at: new Date().toISOString(),
+        })
+        .eq("id", company.id);
+      console.log(
+        `  ✅ tech_stack (${((Date.now() - t0) / 1000).toFixed(1)}s) — ${enriched.categories?.length ?? 0} categories from ${raw.totalJobsAnalyzed} jobs`
+      );
+    }
+  } catch (err) {
+    console.log(`  ❌ tech_stack failed: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/web/scripts/seed-phase3-banks.ts
+++ b/web/scripts/seed-phase3-banks.ts
@@ -11,11 +11,13 @@
  * re-runs are safe. is_active stays false on first insert — flip it after
  * smoke + 24h of clean job_runs entries.
  *
- * NOTE: There is intentionally NO `simplii` row in this seed. Phase 3
- * ships the Simplii classifier in LOG-ONLY mode (see workday-cibc.ts).
- * Once production logs confirm Simplii postings actually surface inside
- * CIBC's Workday tenant, a follow-up adds the row + flips the classifier
- * to route via `companySlugOverride`.
+ * NOTE: This seeder owns the 4 incumbent rows only. Simplii Financial
+ * (CIBC's direct-bank sub-brand) is seeded by migration
+ * `20260524000000_parent_company.sql` because it carries a
+ * `parent_company_id` FK to CIBC and tier=fintech — different shape
+ * from the rows here. The Simplii classifier in workday-cibc.ts is now
+ * live (no longer log-only); it sets `companySlugOverride: 'simplii'`
+ * and the processor routes those jobs to the simplii companies row.
  */
 
 import { createAdminClient } from "@/lib/supabase/admin";

--- a/web/supabase/migrations/20260524000000_parent_company.sql
+++ b/web/supabase/migrations/20260524000000_parent_company.sql
@@ -1,0 +1,54 @@
+-- Parent/child company relationship for shared-ATS sub-brands.
+--
+-- Some sub-brands (e.g. Simplii Financial) post all their roles on the
+-- parent's ATS (CIBC's Workday) rather than running their own careers
+-- portal. We still want them visible as distinct fintech cards on the
+-- dashboard, with their own insight + tech-stack and a clean denominator.
+--
+-- Mechanism: add `parent_company_id` (nullable FK to companies). The
+-- collect cron skips any row where this is set — those companies don't
+-- have their own scrape; their jobs land via the parent's scrape with
+-- a `companySlugOverride` set by the parent's scraper-side classifier
+-- (see `workday-cibc.ts` for Simplii). The processor buckets jobs by
+-- override slug and writes each bucket under its own company_id.
+--
+-- This is the same architectural slot Tangerine uses, except Tangerine
+-- has its own brand-path on Scotia's SuccessFactors, so it scrapes
+-- itself and `parent_company_id` is null. Use this column only for
+-- sub-brands that piggy-back on the parent's listing endpoint.
+
+ALTER TABLE companies
+  ADD COLUMN parent_company_id UUID REFERENCES companies(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_companies_parent_company_id
+  ON companies(parent_company_id)
+  WHERE parent_company_id IS NOT NULL;
+
+COMMENT ON COLUMN companies.parent_company_id IS
+  'When set, this company piggy-backs on the parent''s scrape (no own listing endpoint). The collect cron filters parent_company_id IS NULL; jobs land via the parent scraper with companySlugOverride routing in the processor.';
+
+-- Seed the Simplii Financial row as a CIBC sub-brand. Idempotent — if a
+-- prior session already inserted the row we just attach the parent FK.
+INSERT INTO companies (
+  name, slug, country, ats_type, ats_identifier, careers_url,
+  tier, is_active, organization_id, parent_company_id
+)
+SELECT
+  'Simplii Financial',
+  'simplii',
+  'CA',
+  'workday-cibc',
+  'cibc',
+  'https://www.simplii.com',
+  'fintech',
+  true,
+  c.organization_id,
+  c.id
+FROM companies c
+WHERE c.slug = 'cibc'
+  AND NOT EXISTS (SELECT 1 FROM companies WHERE slug = 'simplii');
+
+UPDATE companies
+SET parent_company_id = (SELECT id FROM companies WHERE slug = 'cibc'),
+    tier = 'fintech'
+WHERE slug = 'simplii' AND parent_company_id IS NULL;


### PR DESCRIPTION
## Summary

- Simplii Financial is now a distinct **fintech** card on the dashboard (tier=fintech, parent=cibc). It has no separate careers portal — every Simplii role posts through CIBC's Workday. The Phase 3 log-only classifier is flipped to set `companySlugOverride: 'simplii'`, and the ingestion processor routes those rows to the new `simplii` companies row instead of CIBC.
- New `parent_company_id` FK on `companies` (migration `20260524000000_parent_company.sql`) declares the sub-brand relationship. The collect cron now skips rows where `parent_company_id IS NOT NULL` — Simplii has no own scrape.
- Per-company closure detection: `runIngestStage` now resolves overrides up-front (only to children whose `parent_company_id` matches the scraped company), buckets jobs by target company_id, and runs closure detection per bucket. A row reclassified CIBC→Simplii is no longer flagged closed forever under CIBC.

## Final state (verified in DB)

| slug | tier | parent | total jobs | active | insight | tech-stack |
|---|---|---|---:|---:|---|---|
| cibc | incumbent | — | 535 | 40 | ✅ | 6 categories |
| simplii | fintech | cibc | 2 | 0 | ✅ "Simplii Financial recruits mobile engineering and product leadership for digital platform" (significance=5/10) | 3 categories |

Both historical Simplii-titled rows (`Director, Product - Simplii Financial` and `Sr. Mobile Consultant, Simplii Technology`) backfilled CIBC → Simplii via service-role UPDATE. Currently both inactive — Simplii's posting volume in CIBC's Workday is tiny (~2 distinct-brand roles at any time). New Simplii postings will land via the daily cron with the override routing.

## Notes on coordination with PR #85

This branch is based on `origin/main` (v2.2.3), so it does not include PR #85's v2.3.0/v2.3.1 changes. It does carry an identical copy of the v2.3.1 insight-resilience fix (`maxOutputTokens: 4096 → 8192` + retry-on-empty/parse-failure in `generateInsightWithLLM`) because Simplii insight generation hits the same bug. Whichever PR merges second will resolve the trivial conflict on `company-insights.ts` (the change is byte-identical).

The v2.3.0 Scotia work and the `backfill-incumbents.ts` script stay scoped to PR #85.

## Test plan

- [x] Unit tests: 252/252 pass (`npm run test`). Two new tests in `lib/jobs/processor.test.ts` cover the override-routing happy path and the unknown-sub-brand fallback to the parent company.
- [x] `npm run build` green; `npm run lint` clean (no new warnings).
- [x] Migration applied to prod DB; `companies.parent_company_id` column + index exist; Simplii row seeded with `parent_company_id=cibc.id`.
- [x] CIBC scrape on feature branch (run [26360850256](https://github.com/tascheidt/fintech_insights/actions/runs/26360850256)) finished green; `simpliiSeen: 0` (CIBC took down the 2 historical Simplii roles in the last 10 hours, expected — they're already inactive in DB). Earlier Phase-3 scrape at 02:24 confirmed the classifier picks the right rows (`simpliiSeen: 2` matching the two backfilled historicals).
- [x] Backfill: 2 historical Simplii rows moved CIBC → Simplii; CIBC totals dropped from 537 → 535.
- [x] Insight + tech-stack generated for Simplii (`scripts/regenerate-simplii.ts`).
- [ ] Eyeball `/companies/simplii` in the deployed preview to confirm the strategic-insight card + tech-stack panel render with the small denominator (and that no UI assumes a non-zero active-jobs count).

🤖 Generated with [Claude Code](https://claude.com/claude-code)