### PR TITLE
fix(scrapers): dedicated Revolut scraper + Node 24 actions sweep

### DIFF
--- a/.github/workflows/auto-implement.yml
+++ b/.github/workflows/auto-implement.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -97,10 +97,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -188,7 +188,7 @@ jobs:
       # `web/`. Cost of always checking out is ~1s; gate still skips
       # everything else when secrets are absent.
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Skip when Supabase secrets are absent
         id: gate
@@ -206,7 +206,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.gate.outputs.skip != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/doc-drift-check.yml
+++ b/.github/workflows/doc-drift-check.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/editorial-cron.yml
+++ b/.github/workflows/editorial-cron.yml
@@ -60,9 +60,9 @@ jobs:
             fi
           done
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/scrape-heavy.yml
+++ b/.github/workflows/scrape-heavy.yml
@@ -18,10 +18,10 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'

--- a/web/lib/scrapers/CLAUDE.md
+++ b/web/lib/scrapers/CLAUDE.md
@@ -45,11 +45,17 @@ Workday returns `externalPath` already prefixed with `/job/...`. The detail URL 
 
 Resist the urge to refactor `browser.ts` before launch. It works. The complexity is load-bearing — selector heuristics, retry logic, and per-site quirks are baked in. Post-launch, split it by site and add tests; before launch, do not.
 
-## Custom scrapers (offloaded to GitHub Actions)
+## Revolut (offloaded to GitHub Actions)
 
-Companies with `ats_type: custom` use the generic Puppeteer scraper (`scrapeGenericJobBoard` from `browser.ts`). They are offloaded to GitHub Actions via `isBrowserScraper`.
+Revolut's careers page is a custom-built Next.js SPA behind Cloudflare anti-bot. Not on any third-party ATS (probed Smartrecruiters / Lever / Greenhouse / Workable — all return 404 or empty for any Revolut slug variant). The generic `scrapeGenericJobBoard` drops every job because Revolut URLs are slug+UUID (`/careers/position/head-of-risk-257ab149-12e7-4a84-bda0-1ab1a1d36760/`), not `/jobs/<digits>` as the generic ID-extraction regex requires.
 
-- **Revolut Canada** — `slug: revolut-canada`, `careers_url: https://www.revolut.com/en-US/careers/?city=Canada`. Revolut uses a custom-built SPA careers page (not a known ATS). Location filtering via the `?city=Canada` query parameter. Seeded by `web/scripts/seed-revolut-canada.ts`.
+- **`revolut.ts`** — anchors on `a[href^="/careers/position/"]` and uses the trailing UUID as `external_id`. Listing is server-rendered on first response (no client-side pagination), so a single page load + `waitForSelector` is enough. Description enrichment is deferred to a follow-up (the hot path tolerates null descriptions). Cloudflare passes from a GH Actions runner IP but typically blocks local-dev Puppeteer; debug against the workflow.
+
+Tenants today: **Revolut Canada** — `slug: revolut-canada`, `ats_type: revolut`, `careers_url: https://www.revolut.com/en-US/careers/?city=Canada`. Location filtering happens server-side via the `?city=` query param, so the same scraper handles any Revolut-Country tenant by changing only the company row's `careers_url`.
+
+## Generic custom scrapers (offloaded to GitHub Actions)
+
+Companies with `ats_type: custom` use the generic Puppeteer scraper (`scrapeGenericJobBoard` from `browser.ts`). They are offloaded to GitHub Actions via `isBrowserScraper`. Use this only for sites whose URLs contain a numeric job ID (the generic ID extractor requires `\d+`) — slug-based custom careers pages need a dedicated scraper modeled on `revolut.ts`.
 
 ## ATS detection
 

--- a/web/lib/scrapers/index.ts
+++ b/web/lib/scrapers/index.ts
@@ -11,6 +11,7 @@ import { fetchPhenomBmoJobs } from "./phenom-bmo";
 import { fetchAvatureBncJobs } from "./avature-bnc";
 import { fetchWorkdayTdJobs } from "./workday-td";
 import { fetchWorkdayCibcJobs } from "./workday-cibc";
+import { fetchRevolutJobs } from "./revolut";
 
 export type { JobData } from "./types";
 export { jobToRow } from "./types";
@@ -84,6 +85,14 @@ export async function fetchJobs(
     case "workday-cibc":
       return fetchWorkdayCibcJobs();
 
+    // Revolut runs a custom Next.js careers page behind Cloudflare. The
+    // generic Puppeteer scraper drops every job because their URLs are
+    // slug+UUID, not `/jobs/\d+`. This tenant-specific scraper anchors on
+    // the stable `/careers/position/` href prefix and uses the trailing
+    // UUID as external_id. See ./revolut.ts.
+    case "revolut":
+      return fetchRevolutJobs(atsIdentifier, careersUrl, browser);
+
     case "successfactors": {
       if (!careersUrl) {
         throw new Error(`${atsType} requires a careers URL for browser-based scraping`);
@@ -152,6 +161,7 @@ export function isBrowserScraper(atsType: string): boolean {
     'successfactors',
     'phenom',
     'avature',
+    'revolut',        // Custom Next.js careers page behind Cloudflare.
     'taleo',
     'icims',
     'custom',         // Generic Puppeteer scraper — needs browser, offload.

--- a/web/lib/scrapers/revolut.ts
+++ b/web/lib/scrapers/revolut.ts
@@ -1,0 +1,247 @@
+/**
+ * Revolut careers scraper — custom-built SPA at `revolut.com/careers/`.
+ *
+ * Not on any third-party ATS (probed Smartrecruiters / Lever / Greenhouse /
+ * Workable — Revolut is fully custom, Next.js + Cloudflare anti-bot in
+ * front). Browser-based via puppeteer-core + @sparticuz/chromium, offloaded
+ * to `scrape-heavy.yml`.
+ *
+ * The listing page (`/en-US/careers/?city=<location>`) server-renders every
+ * job for the active filter as a stable anchor:
+ *
+ *   <a href="/careers/position/<slug>-<uuid>/" class="...">
+ *     <span>
+ *       <h2>Title</h2>
+ *       <span>...<span>Remote: Canada</span></span>
+ *     </span>
+ *   </a>
+ *
+ * The UUID trailing the slug is the canonical external_id. There's no
+ * pagination — the page renders the full filtered set (Canada = 3 today;
+ * other filters can return more, but Revolut still emits all of them on the
+ * first response).
+ *
+ * Description enrichment is deferred. Detail pages need a separate parser
+ * pass and the production hot path tolerates null descriptions (the
+ * description_hash gate in `processor.ts` simply skips Flash extraction for
+ * that row, and the Pro analyzer grounds against the URL anyway). Add
+ * enrichment in a follow-up once the listing pipeline is proven green.
+ *
+ * Cloudflare: a plain curl hits a "Just a quick security check" challenge
+ * page (~873KB of Cloudflare-injected Inter font data). Puppeteer in a GH
+ * Actions runner clears it because the IP/UA pair reads as residential
+ * enough. Local dev runs may fail the challenge — that's expected; debug
+ * against the workflow.
+ */
+
+import type { JobData } from "./types";
+import type { Browser, Page } from "puppeteer-core";
+import { detectLocationType } from "./utils";
+import { log } from "@/lib/log";
+
+const REVOLUT_ORIGIN = "https://www.revolut.com";
+const USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+// ---------------------------------------------------------------------------
+// Pure-logic helpers (testable without a browser; HTML-string in, data out)
+// ---------------------------------------------------------------------------
+
+export interface RevolutRawJob {
+  externalId: string;
+  title: string;
+  url: string;
+  location: string | null;
+}
+
+function parseHtml(html: string): Document {
+  const G = globalThis as unknown as {
+    DOMParser?: { new (): { parseFromString(s: string, t: string): Document } };
+  };
+  if (G.DOMParser) {
+    return new G.DOMParser().parseFromString(html, "text/html");
+  }
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const jsdom = require("jsdom") as {
+    JSDOM: new (s: string) => { window: { document: Document } };
+  };
+  return new jsdom.JSDOM(html).window.document;
+}
+
+/**
+ * Extract the trailing UUID from a Revolut job href.
+ *   /careers/position/head-of-risk-257ab149-12e7-4a84-bda0-1ab1a1d36760/
+ *     → "257ab149-12e7-4a84-bda0-1ab1a1d36760"
+ *
+ * The UUID is the stable per-job identifier; the slug prefix can change if
+ * Revolut renames the role. Trailing slash tolerated. Returns "" when no
+ * UUID is found — caller filters those out.
+ */
+export function extractExternalId(href: string): string {
+  if (!href) return "";
+  const match = href.match(
+    /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i
+  );
+  return match ? match[1].toLowerCase() : "";
+}
+
+/**
+ * Parse the listing HTML → raw rows. Walks every anchor whose href starts
+ * with `/careers/position/` (the stable URL prefix), pulls the `<h2>` for
+ * the title and the deepest text node under the anchor for the location
+ * (Revolut puts "Remote: Canada" / "London, UK" / etc. in a span sibling to
+ * the location icon — we grab it by skipping any element with the icon
+ * class and taking the last non-empty descendant text).
+ */
+export function parseListingPage(html: string): RevolutRawJob[] {
+  const doc = parseHtml(html);
+  const anchors = doc.querySelectorAll<HTMLAnchorElement>(
+    'a[href^="/careers/position/"]'
+  );
+
+  const jobs: RevolutRawJob[] = [];
+  const seen = new Set<string>();
+  for (const a of Array.from(anchors)) {
+    const href = a.getAttribute("href") || "";
+    const externalId = extractExternalId(href);
+    if (!externalId || seen.has(externalId)) continue;
+
+    const titleEl = a.querySelector("h2, h3, h1");
+    const title = (titleEl?.textContent || "").trim();
+    if (!title) continue;
+
+    // Location: pick the last meaningful text node under the anchor that
+    // isn't the title itself. Revolut renders it as the deepest text in a
+    // sibling span. Falling back to all-text-minus-title keeps it resilient
+    // to wrapper changes.
+    let location: string | null = null;
+    const all = (a.textContent || "").replace(/\s+/g, " ").trim();
+    if (all && title && all.startsWith(title)) {
+      const rest = all.slice(title.length).trim();
+      location = rest || null;
+    }
+
+    seen.add(externalId);
+    jobs.push({
+      externalId,
+      title,
+      url: new URL(href, REVOLUT_ORIGIN).toString(),
+      location,
+    });
+  }
+
+  return jobs;
+}
+
+/**
+ * Map a raw row → canonical JobData. Description fields left null;
+ * enrichment is deferred (see file header).
+ *
+ * Location-type heuristic: Revolut spells remote jobs as `Remote: <city>`.
+ * Hybrid/On-site aren't surfaced on the listing — the Flash extractor will
+ * refine from the description on the next pipeline pass.
+ */
+export function mapRevolutJob(raw: RevolutRawJob): JobData {
+  const loc = (raw.location || "").toLowerCase();
+  let locationType: string | null = null;
+  if (/^remote\b|: remote/.test(loc) || /\bremote\b/.test(loc)) {
+    locationType = "remote";
+  } else {
+    locationType = detectLocationType(raw.location || "", "");
+  }
+
+  return {
+    external_id: raw.externalId,
+    title: raw.title,
+    department: null,
+    team: null,
+    location: raw.location,
+    location_type: locationType,
+    description_html: null,
+    description_text: null,
+    commitment: "full-time",
+    posted_date: null,
+    url: raw.url,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Puppeteer driver
+// ---------------------------------------------------------------------------
+
+interface BrowserHandles {
+  browser: Browser;
+  owned: boolean;
+}
+
+async function acquireBrowser(injected?: Browser): Promise<BrowserHandles> {
+  if (injected) return { browser: injected, owned: false };
+  const puppeteer = await import("puppeteer-core");
+  const chromiumModule = await import("@sparticuz/chromium");
+  type ChromiumLike = {
+    args: string[];
+    defaultViewport?: { width: number; height: number } | null;
+    executablePath: () => Promise<string>;
+  };
+  const chromium = (
+    (chromiumModule as { default?: ChromiumLike }).default ?? chromiumModule
+  ) as unknown as ChromiumLike;
+  const executablePath = await chromium.executablePath();
+  const browser = await puppeteer.default.launch({
+    args: chromium.args,
+    defaultViewport: chromium.defaultViewport,
+    executablePath,
+    headless: true,
+  });
+  return { browser, owned: true };
+}
+
+async function fetchListing(page: Page, careersUrl: string): Promise<string> {
+  await page.goto(careersUrl, { waitUntil: "networkidle2", timeout: 60_000 });
+  // Wait for the listing to render. The selector also serves as a
+  // proof-of-pass for the Cloudflare challenge — if we never see a position
+  // anchor, we're either still on the challenge page or the filter
+  // genuinely returned zero results.
+  await page
+    .waitForSelector('a[href^="/careers/position/"]', { timeout: 20_000 })
+    .catch(() => {
+      log.warn(
+        { careersUrl },
+        "[revolut] no position anchors after 20s — Cloudflare may be holding the page, or the filter returned zero jobs"
+      );
+    });
+  return page.content();
+}
+
+export async function fetchRevolutJobs(
+  atsIdentifier: string,
+  careersUrl: string | undefined,
+  browser?: Browser
+): Promise<JobData[]> {
+  void atsIdentifier;
+  if (!careersUrl) {
+    throw new Error(
+      "[revolut] careersUrl is required (e.g. https://www.revolut.com/en-US/careers/?city=Canada)"
+    );
+  }
+
+  const { browser: browserInstance, owned } = await acquireBrowser(browser);
+
+  try {
+    const page = await browserInstance.newPage();
+    await page.setUserAgent(USER_AGENT);
+    try {
+      const html = await fetchListing(page, careersUrl);
+      const raw = parseListingPage(html);
+      log.info(
+        { careersUrl, count: raw.length },
+        "[revolut] listing parsed"
+      );
+      return raw.map(mapRevolutJob);
+    } finally {
+      await page.close();
+    }
+  } finally {
+    if (owned) await browserInstance.close();
+  }
+}

--- a/web/scripts/seed-revolut-canada.ts
+++ b/web/scripts/seed-revolut-canada.ts
@@ -1,9 +1,10 @@
 /**
  * One-off seed: insert the Revolut Canada company row into the `companies`
- * table. Revolut uses a custom-built SPA careers page (not a known ATS like
- * Greenhouse/Lever/Ashby/Workable). The generic browser scraper
- * (`scrapeGenericJobBoard`) handles it via the `custom` ATS type, offloaded
- * to GitHub Actions.
+ * table. Revolut runs a custom-built Next.js careers SPA behind Cloudflare
+ * — the dedicated `web/lib/scrapers/revolut.ts` scraper handles it (the
+ * generic Puppeteer fallback drops every job because Revolut URLs are
+ * slug+UUID, not `/jobs/\d+`). Offloaded to GitHub Actions via
+ * `isBrowserScraper`.
  *
  * Usage (from `web/`):
  *   npx tsx --env-file=.env.local scripts/seed-revolut-canada.ts
@@ -33,8 +34,8 @@ async function main(): Promise<void> {
     name: "Revolut Canada",
     slug: "revolut-canada",
     country: "CA",
-    ats_type: "custom",
-    ats_identifier: "revolut-canada",
+    ats_type: "revolut",
+    ats_identifier: "revolut",
     careers_url: "https://www.revolut.com/en-US/careers/?city=Canada",
     is_active: false,
     tier: "fintech" as const,


### PR DESCRIPTION
## Summary

- **Add `web/lib/scrapers/revolut.ts`** — dedicated scraper for Revolut's custom Next.js careers SPA. The auto-implemented routing in #89 sent Revolut through `ats_type='custom'` → `scrapeGenericJobBoard`, which silently drops every job (the generic ID extractor requires `/jobs/<digits>` in the href, but Revolut URLs are `/careers/position/<slug>-<uuid>/`). New scraper anchors on `a[href^=\"/careers/position/\"]` and uses the trailing UUID as `external_id`. Wired as `ats_type='revolut'` in `fetchJobs` + `isBrowserScraper`.
- **Sweep `actions/checkout` and `actions/setup-node` from `@v4` → `@v5`** across all five workflows. `@v5` ships on Node 24; `@v4` is deprecated for GH Actions runners (forced default June 2026, removed September 2026). Different axis from the existing CLAUDE.md anti-pattern on `node-version: '20'` — that one is about script runtime, this is about the action runtime itself.

## Context

The Revolut Canada wiring landed via auto-implement (#89/#90) but the scrape ran successfully with 0 results — the generic Puppeteer scraper found the anchors but dropped them at the ID-extraction step. Confirmed via inspection of Revolut's actual DOM: `<a href=\"/careers/position/head-of-risk-257ab149-12e7-4a84-bda0-1ab1a1d36760/\">` ← UUID is the stable identifier, slug rotates. Canada filter currently returns exactly 3 jobs (Head of Risk, MLRO, Head of Finance); same scraper handles any future Revolut-Country tenant via `careers_url` only.

API discovery deliberately exhausted: probed 9 guessed JSON endpoints (all 404), 6 Smartrecruiters slug variants (all 0 results), Lever / Greenhouse / Workable (all 404). Revolut is fully custom, Next.js + Cloudflare. Cloudflare passes from GH Actions runner IPs but typically blocks local-dev Puppeteer.

**DB note:** the `companies` row for `revolut-canada` (`id: 2c40e691-54f3-4eaa-8ae9-227e451fb7af`) was updated out-of-band via Supabase MCP to set `ats_type='revolut'`, `ats_identifier='revolut'`. Still `is_active=false` per the seed script comment (\"flip after test scrape\"). The seed script in this PR matches the DB.

## Test plan

- [x] `cd web && npm run build` passes locally
- [ ] Dispatch `scrape-heavy.yml` against `fix/revolut-scraper-and-node20-sweep` with `company_id=2c40e691-54f3-4eaa-8ae9-227e451fb7af`
- [ ] Confirm 3 rows land in `job_postings` (Head of Risk, MLRO, Head of Finance)
- [ ] Confirm workflow Node-24 warning is gone
- [ ] CI green on the new branch (this PR also runs the bumped `ci.yml` against itself)
- [ ] After merge, flip `is_active=true` on the Revolut Canada row

## Follow-ups (not in this PR)

- Description enrichment for Revolut detail pages (the hot path tolerates null descriptions; landing listing data first is the smaller blast radius)
- Decide whether to add more Revolut-Country tenants (UK has ~600 jobs, US has more); each is a one-row insert with `careers_url=?city=<country>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)