### PR TITLE
feat(auth): email + password sign-up alongside Google OAuth

### DIFF
--- a/web/app/(auth)/account/update-password/page.tsx
+++ b/web/app/(auth)/account/update-password/page.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useEmailAuth } from "@/hooks/use-email-auth";
+import { createClient } from "@/lib/supabase/client";
+import {
+  firstZodError,
+  updatePasswordSchema,
+} from "@/lib/auth/validation";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+export default function UpdatePasswordPage() {
+  const router = useRouter();
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [hasSession, setHasSession] = useState<boolean | null>(null);
+  const { updatePassword, isLoading, error, setError } = useEmailAuth();
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data }) => {
+      setHasSession(Boolean(data.user));
+    });
+  }, []);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const parsed = updatePasswordSchema.safeParse({ password, confirm });
+    if (!parsed.success) {
+      setError(firstZodError(parsed.error));
+      return;
+    }
+    const result = await updatePassword(parsed.data.password);
+    if (result.ok) {
+      router.replace("/dashboard?password_updated=1");
+    }
+  }
+
+  return (
+    <main className="min-h-[100svh] grid grid-cols-1 md:grid-cols-[minmax(380px,1fr)_minmax(0,1.1fr)]">
+      <section className="flex items-center justify-center px-6 py-12 md:px-12">
+        <div className="w-full max-w-[420px] space-y-8">
+          <div className="space-y-3">
+            <p className="font-mono text-[11px] uppercase tracking-[0.08em] text-primary">
+              Set a new password
+            </p>
+            <h1 className="font-display font-semibold text-[44px] tracking-[-0.022em] leading-[1.08] max-w-[12ch] text-foreground">
+              Choose a new password.
+            </h1>
+            <p className="text-sm text-muted-foreground leading-relaxed max-w-[36ch]">
+              At least 8 characters with a letter and a number.
+            </p>
+          </div>
+
+          {hasSession === false ? (
+            <div className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive" role="alert">
+              This reset link has expired or already been used. Request a fresh one
+              from the <a href="/forgot-password" className="underline">forgot password</a> page.
+            </div>
+          ) : (
+            <>
+              {error && (
+                <div
+                  className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  <span className="font-semibold">Error:</span> {error}
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-1.5">
+                  <label htmlFor="password" className="text-xs font-medium text-foreground">
+                    New password
+                  </label>
+                  <Input
+                    id="password"
+                    type="password"
+                    autoComplete="new-password"
+                    required
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    disabled={isLoading || hasSession === null}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <label htmlFor="confirm" className="text-xs font-medium text-foreground">
+                    Confirm new password
+                  </label>
+                  <Input
+                    id="confirm"
+                    type="password"
+                    autoComplete="new-password"
+                    required
+                    value={confirm}
+                    onChange={(e) => setConfirm(e.target.value)}
+                    disabled={isLoading || hasSession === null}
+                  />
+                </div>
+
+                <Button
+                  type="submit"
+                  size="lg"
+                  disabled={isLoading || hasSession === null}
+                  className="h-11 w-full text-sm"
+                >
+                  {isLoading ? "Updating…" : "Update password"}
+                </Button>
+              </form>
+            </>
+          )}
+        </div>
+      </section>
+
+      <aside
+        aria-hidden
+        className="hidden md:flex relative items-center justify-center px-12 py-12 overflow-hidden"
+        style={{ background: "var(--gradient-coast)" }}
+      />
+    </main>
+  );
+}

--- a/web/app/(auth)/forgot-password/page.tsx
+++ b/web/app/(auth)/forgot-password/page.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useEmailAuth } from "@/hooks/use-email-auth";
+import { firstZodError, forgotPasswordSchema } from "@/lib/auth/validation";
+import Link from "next/link";
+import { useState } from "react";
+
+export default function ForgotPasswordPage() {
+  const [email, setEmail] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+  const { requestPasswordReset, isLoading, error, setError } = useEmailAuth();
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const parsed = forgotPasswordSchema.safeParse({ email });
+    if (!parsed.success) {
+      setError(firstZodError(parsed.error));
+      return;
+    }
+    await requestPasswordReset(parsed.data.email);
+    // Always show the same confirmation, even on Supabase errors, to avoid
+    // leaking which addresses have accounts.
+    setSubmitted(true);
+  }
+
+  return (
+    <main className="min-h-[100svh] grid grid-cols-1 md:grid-cols-[minmax(380px,1fr)_minmax(0,1.1fr)]">
+      <section className="flex items-center justify-center px-6 py-12 md:px-12">
+        <div className="w-full max-w-[420px] space-y-8">
+          <div className="space-y-3">
+            <p className="font-mono text-[11px] uppercase tracking-[0.08em] text-primary">
+              Reset password
+            </p>
+            <h1 className="font-display font-semibold text-[44px] tracking-[-0.022em] leading-[1.08] max-w-[12ch] text-foreground">
+              Forgot your password?
+            </h1>
+            <p className="text-sm text-muted-foreground leading-relaxed max-w-[36ch]">
+              Enter your email and we&apos;ll send you a link to set a new one.
+            </p>
+          </div>
+
+          {submitted ? (
+            <div className="space-y-4">
+              <div
+                className="rounded-md border border-border bg-card px-4 py-3 text-sm text-foreground"
+                role="status"
+              >
+                If an account exists for <span className="font-semibold">{email}</span>,
+                we just sent a reset link. Check your inbox.
+              </div>
+              <Link
+                href="/login"
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                ← Back to log in
+              </Link>
+            </div>
+          ) : (
+            <>
+              {error && (
+                <div
+                  className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  <span className="font-semibold">Error:</span> {error}
+                </div>
+              )}
+
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-1.5">
+                  <label
+                    htmlFor="email"
+                    className="text-xs font-medium text-foreground"
+                  >
+                    Email
+                  </label>
+                  <Input
+                    id="email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    disabled={isLoading}
+                  />
+                </div>
+
+                <Button
+                  type="submit"
+                  size="lg"
+                  disabled={isLoading}
+                  className="h-11 w-full text-sm"
+                >
+                  {isLoading ? "Sending…" : "Send reset link"}
+                </Button>
+
+                <div className="text-center">
+                  <Link
+                    href="/login"
+                    className="text-sm text-muted-foreground hover:text-foreground"
+                  >
+                    ← Back to log in
+                  </Link>
+                </div>
+              </form>
+            </>
+          )}
+        </div>
+      </section>
+
+      <aside
+        aria-hidden
+        className="hidden md:flex relative items-center justify-center px-12 py-12 overflow-hidden"
+        style={{ background: "var(--gradient-coast)" }}
+      />
+    </main>
+  );
+}

--- a/web/app/(auth)/login/page.tsx
+++ b/web/app/(auth)/login/page.tsx
@@ -7,19 +7,25 @@
  *   On screens < 880px, aside collapses (hidden) and form fills the viewport.
  * - Hero headline: Fraunces 44px, tight tracking, max-width 11ch.
  *
- * Auth: keeps the existing Google OAuth Supabase logic intact via useGoogleAuth.
- * Pull-quote: server-fetched from the most recent published digest in a sibling
- * component (LoginAside). For now this renders a default editorial quote because
- * the route is currently a client component; promote to server fetch when we
- * convert the page.
+ * Auth: Google OAuth (useGoogleAuth) + email/password (useEmailAuth).
+ * Mode (`log in` vs `sign up`) is driven by `?mode=signup` so it's deep-linkable
+ * from the marketing CTA and the AuthHeader's "Get started" button.
  */
 
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { useGoogleAuth } from "@/hooks/use-google-auth";
-import { useSearchParams } from "next/navigation";
-import { useEffect } from "react";
+import { useEmailAuth } from "@/hooks/use-email-auth";
+import {
+  firstZodError,
+  signInSchema,
+  signUpSchema,
+} from "@/lib/auth/validation";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 
 // Google brand colors are vendor-required and must not be tokenized — Google's
@@ -37,73 +43,268 @@ function GoogleIcon({ className }: { className?: string }) {
 }
 /* eslint-enable design-system/no-raw-color */
 
-export default function LoginPage() {
-  const searchParams = useSearchParams();
-  const { signInWithGoogle, isLoading, error, setError } = useGoogleAuth();
-  const nextPath = searchParams.get("next");
-  const handleSignIn = () => signInWithGoogle(nextPath);
+type Mode = "login" | "signup";
 
+export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const mode: Mode = searchParams.get("mode") === "signup" ? "signup" : "login";
+  const nextPath = searchParams.get("next");
+
+  const google = useGoogleAuth();
+  const email = useEmailAuth();
+
+  const [fullName, setFullName] = useState("");
+  const [emailValue, setEmailValue] = useState("");
+  const [password, setPassword] = useState("");
+  const [pendingConfirmEmail, setPendingConfirmEmail] = useState<string | null>(null);
+
+  // URL-encoded ?error= from /auth/callback. Surfaces in either hook's error state.
   useEffect(() => {
     const errorParam = searchParams.get("error");
     if (errorParam) {
-      setError(decodeURIComponent(errorParam));
+      google.setError(decodeURIComponent(errorParam));
     }
-  }, [searchParams, setError]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  // Clear the form-level error when the user toggles mode.
+  useEffect(() => {
+    email.setError(null);
+    google.setError(null);
+    setPendingConfirmEmail(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode]);
+
+  const displayedError = email.error ?? google.error;
+  const busy = email.isLoading || google.isLoading;
+
+  const headline = useMemo(
+    () => (mode === "signup" ? "Get started in seconds." : "Decode hiring strategy."),
+    [mode],
+  );
+  const subhead = useMemo(
+    () =>
+      mode === "signup"
+        ? "Create your account to read the weekly briefing on fintech hiring."
+        : "A weekly analyst briefing on fintech hiring — read the moves before the market does.",
+    [mode],
+  );
+
+  function switchMode(next: Mode) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next === "signup") params.set("mode", "signup");
+    else params.delete("mode");
+    const query = params.toString();
+    router.replace(query ? `/login?${query}` : "/login");
+  }
+
+  async function handleEmailSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (mode === "signup") {
+      const parsed = signUpSchema.safeParse({
+        fullName,
+        email: emailValue,
+        password,
+      });
+      if (!parsed.success) {
+        email.setError(firstZodError(parsed.error));
+        return;
+      }
+      const result = await email.signUp(
+        parsed.data.email,
+        parsed.data.password,
+        parsed.data.fullName,
+        nextPath,
+      );
+      if (result.ok && result.needsConfirmation) {
+        setPendingConfirmEmail(parsed.data.email);
+      } else if (result.ok) {
+        // Email confirmation disabled in Supabase — session is live, hard nav.
+        window.location.assign(nextPath && nextPath.startsWith("/") ? nextPath : "/dashboard");
+      }
+    } else {
+      const parsed = signInSchema.safeParse({ email: emailValue, password });
+      if (!parsed.success) {
+        email.setError(firstZodError(parsed.error));
+        return;
+      }
+      await email.signIn(parsed.data.email, parsed.data.password, nextPath);
+    }
+  }
 
   return (
     <main className="min-h-[100svh] grid grid-cols-1 md:grid-cols-[minmax(380px,1fr)_minmax(0,1.1fr)]">
       {/* Form panel */}
       <section className="flex items-center justify-center px-6 py-12 md:px-12">
-        <div className="w-full max-w-[420px] space-y-8">
+        <div className="w-full max-w-[420px] space-y-7">
           <div className="space-y-3">
             <p className="font-mono text-[11px] uppercase tracking-[0.08em] text-primary">
               The Fintech Talent Brief
             </p>
             <h1 className="font-display font-semibold text-[44px] tracking-[-0.022em] leading-[1.08] max-w-[11ch] text-foreground">
-              Decode hiring strategy.
+              {headline}
             </h1>
             <p className="text-sm text-muted-foreground leading-relaxed max-w-[36ch]">
-              A weekly analyst briefing on fintech hiring — read the moves before the market does.
+              {subhead}
             </p>
           </div>
 
-          {error && (
+          {/* Mode toggle */}
+          <div className="inline-flex items-center gap-1 rounded-full border border-border bg-card p-1 text-xs font-medium">
+            <button
+              type="button"
+              onClick={() => switchMode("login")}
+              className={
+                "h-7 rounded-full px-4 transition-colors " +
+                (mode === "login"
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground")
+              }
+              aria-pressed={mode === "login"}
+            >
+              Log in
+            </button>
+            <button
+              type="button"
+              onClick={() => switchMode("signup")}
+              className={
+                "h-7 rounded-full px-4 transition-colors " +
+                (mode === "signup"
+                  ? "bg-foreground text-background"
+                  : "text-muted-foreground hover:text-foreground")
+              }
+              aria-pressed={mode === "signup"}
+            >
+              Sign up
+            </button>
+          </div>
+
+          {pendingConfirmEmail ? (
             <div
-              className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive"
-              role="alert"
+              className="rounded-md border border-border bg-card px-4 py-3 text-sm text-foreground"
+              role="status"
             >
-              <span className="font-semibold">Error:</span> {error}
+              <p className="font-semibold mb-1">Check your email.</p>
+              <p className="text-muted-foreground">
+                We sent a confirmation link to{" "}
+                <span className="text-foreground font-medium">{pendingConfirmEmail}</span>.
+                Click it to finish creating your account.
+              </p>
             </div>
-          )}
-
-          <div className="space-y-3">
-            <Button
-              size="lg"
-              onClick={handleSignIn}
-              disabled={isLoading}
-              className="h-11 w-full text-sm gap-2"
-            >
-              {isLoading ? "Connecting…" : (
-                <>
-                  Get started free
-                  <ArrowRight className="h-4 w-4" />
-                </>
+          ) : (
+            <>
+              {displayedError && (
+                <div
+                  className="rounded-md bg-destructive/10 px-4 py-3 text-sm text-destructive"
+                  role="alert"
+                >
+                  <span className="font-semibold">Error:</span> {displayedError}
+                </div>
               )}
-            </Button>
-            <Button
-              variant="outline"
-              size="lg"
-              onClick={handleSignIn}
-              disabled={isLoading}
-              className="h-11 w-full text-sm gap-2"
-            >
-              <GoogleIcon className="h-4 w-4" />
-              Continue with Google
-            </Button>
-            <p className="text-xs text-muted-foreground text-center pt-2">
-              Free for teams. No credit card required.
-            </p>
-          </div>
+
+              <Button
+                variant="outline"
+                size="lg"
+                onClick={() => google.signInWithGoogle(nextPath)}
+                disabled={busy}
+                className="h-11 w-full text-sm gap-2"
+              >
+                <GoogleIcon className="h-4 w-4" />
+                Continue with Google
+              </Button>
+
+              <div className="flex items-center gap-3 text-[11px] uppercase tracking-[0.08em] text-muted-foreground">
+                <span className="h-px flex-1 bg-border" />
+                <span>or continue with email</span>
+                <span className="h-px flex-1 bg-border" />
+              </div>
+
+              <form onSubmit={handleEmailSubmit} className="space-y-4">
+                {mode === "signup" && (
+                  <div className="space-y-1.5">
+                    <label htmlFor="fullName" className="text-xs font-medium text-foreground">
+                      Full name
+                    </label>
+                    <Input
+                      id="fullName"
+                      type="text"
+                      autoComplete="name"
+                      required
+                      value={fullName}
+                      onChange={(e) => setFullName(e.target.value)}
+                      disabled={busy}
+                    />
+                  </div>
+                )}
+
+                <div className="space-y-1.5">
+                  <label htmlFor="email" className="text-xs font-medium text-foreground">
+                    Email
+                  </label>
+                  <Input
+                    id="email"
+                    type="email"
+                    autoComplete="email"
+                    required
+                    value={emailValue}
+                    onChange={(e) => setEmailValue(e.target.value)}
+                    disabled={busy}
+                  />
+                </div>
+
+                <div className="space-y-1.5">
+                  <div className="flex items-center justify-between">
+                    <label htmlFor="password" className="text-xs font-medium text-foreground">
+                      Password
+                    </label>
+                    {mode === "login" && (
+                      <Link
+                        href="/forgot-password"
+                        className="text-xs text-muted-foreground hover:text-foreground"
+                      >
+                        Forgot?
+                      </Link>
+                    )}
+                  </div>
+                  <Input
+                    id="password"
+                    type="password"
+                    autoComplete={mode === "signup" ? "new-password" : "current-password"}
+                    required
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    disabled={busy}
+                  />
+                  {mode === "signup" && (
+                    <p className="text-[11px] text-muted-foreground">
+                      At least 8 characters, with a letter and a number.
+                    </p>
+                  )}
+                </div>
+
+                <Button
+                  type="submit"
+                  size="lg"
+                  disabled={busy}
+                  className="h-11 w-full text-sm gap-2"
+                >
+                  {busy ? (
+                    "Working…"
+                  ) : (
+                    <>
+                      {mode === "signup" ? "Create account" : "Log in"}
+                      <ArrowRight className="h-4 w-4" />
+                    </>
+                  )}
+                </Button>
+              </form>
+
+              <p className="text-xs text-muted-foreground text-center">
+                Free for teams. No credit card required.
+              </p>
+            </>
+          )}
         </div>
       </section>
 

--- a/web/app/(marketing)/page.tsx
+++ b/web/app/(marketing)/page.tsx
@@ -81,7 +81,7 @@ export default async function MarketingPage() {
           </p>
           <div className="mt-8 flex flex-wrap items-center gap-3">
             <Link
-              href="/login"
+              href="/login?mode=signup"
               className="inline-flex h-11 items-center gap-2 rounded-full bg-primary px-6 text-sm font-medium text-primary-foreground hover:bg-pacific-600 transition-colors"
             >
               Get started free

--- a/web/components/auth/AuthHeader.tsx
+++ b/web/components/auth/AuthHeader.tsx
@@ -1,14 +1,8 @@
-"use client";
-
 import { Button } from "@/components/ui/button";
-import { useGoogleAuth } from "@/hooks/use-google-auth";
 import Link from "next/link";
 import { BrandMark } from "@/components/layout/BrandMark";
 
 export function AuthHeader() {
-  const { signInWithGoogle, isLoading } = useGoogleAuth();
-  const handleSignIn = () => signInWithGoogle();
-
   return (
     <header className="fixed top-0 left-0 right-0 z-50 flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8 bg-background/80 backdrop-blur-sm border-b border-border/40">
       <div className="flex items-center gap-2">
@@ -22,20 +16,15 @@ export function AuthHeader() {
       </div>
 
       <div className="flex items-center gap-2 sm:gap-4">
-        <Button 
-          variant="ghost" 
-          onClick={handleSignIn}
-          disabled={isLoading}
+        <Button
+          asChild
+          variant="ghost"
           className="text-muted-foreground hover:text-foreground hidden sm:flex"
         >
-          Log in
+          <Link href="/login">Log in</Link>
         </Button>
-        <Button 
-          onClick={handleSignIn}
-          disabled={isLoading}
-          className="font-medium"
-        >
-          Get started
+        <Button asChild className="font-medium">
+          <Link href="/login?mode=signup">Get started</Link>
         </Button>
       </div>
     </header>

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.5.0",
+    "date": "2026-05-27",
+    "changes": [
+      { "type": "feature", "description": "Sign up and sign in with email and password, in addition to Google. The login page now has a Log in / Sign up toggle that shows both Google OAuth and an email-and-password form; a separate forgot-password flow sends a Supabase reset link that lands users on a new set-a-new-password page. The marketing CTA deep-links to the Sign up tab so new visitors start in the right mode." }
+    ]
+  },
+  {
     "version": "2.4.1",
     "date": "2026-05-26",
     "changes": [

--- a/web/hooks/use-email-auth.ts
+++ b/web/hooks/use-email-auth.ts
@@ -1,0 +1,134 @@
+"use client";
+
+import { createClient } from "@/lib/supabase/client";
+import { useState } from "react";
+
+function stashNextCookie(next?: string | null) {
+  const safe = next && next.startsWith("/") && !next.startsWith("//") ? next : null;
+  if (safe && typeof document !== "undefined") {
+    document.cookie = `auth_next=${encodeURIComponent(safe)}; path=/; SameSite=Lax; max-age=300`;
+  }
+}
+
+function callbackUrl(searchParams?: string) {
+  if (typeof window === "undefined") return "/auth/callback";
+  const base = `${window.location.protocol}//${window.location.host}/auth/callback`;
+  return searchParams ? `${base}?${searchParams}` : base;
+}
+
+export function useEmailAuth() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function signIn(email: string, password: string, next?: string | null) {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const supabase = createClient();
+      const { error: signInError } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      });
+      if (signInError) {
+        setError(signInError.message);
+        setIsLoading(false);
+        return { ok: false as const };
+      }
+      const safeNext =
+        next && next.startsWith("/") && !next.startsWith("//") ? next : "/dashboard";
+      window.location.assign(safeNext);
+      return { ok: true as const };
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sign-in failed");
+      setIsLoading(false);
+      return { ok: false as const };
+    }
+  }
+
+  async function signUp(
+    email: string,
+    password: string,
+    fullName: string,
+    next?: string | null,
+  ) {
+    try {
+      setIsLoading(true);
+      setError(null);
+      stashNextCookie(next);
+      const supabase = createClient();
+      const { data, error: signUpError } = await supabase.auth.signUp({
+        email,
+        password,
+        options: {
+          data: { full_name: fullName },
+          emailRedirectTo: callbackUrl(),
+        },
+      });
+      if (signUpError) {
+        setError(signUpError.message);
+        setIsLoading(false);
+        return { ok: false as const, needsConfirmation: false };
+      }
+      // When email confirmation is required, Supabase returns a user but no session.
+      const needsConfirmation = !data.session;
+      setIsLoading(false);
+      return { ok: true as const, needsConfirmation };
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Sign-up failed");
+      setIsLoading(false);
+      return { ok: false as const, needsConfirmation: false };
+    }
+  }
+
+  async function requestPasswordReset(email: string) {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const supabase = createClient();
+      const { error: resetError } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo: callbackUrl("next=/account/update-password"),
+      });
+      if (resetError) {
+        setError(resetError.message);
+        setIsLoading(false);
+        return { ok: false as const };
+      }
+      setIsLoading(false);
+      return { ok: true as const };
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Reset request failed");
+      setIsLoading(false);
+      return { ok: false as const };
+    }
+  }
+
+  async function updatePassword(password: string) {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const supabase = createClient();
+      const { error: updateError } = await supabase.auth.updateUser({ password });
+      if (updateError) {
+        setError(updateError.message);
+        setIsLoading(false);
+        return { ok: false as const };
+      }
+      setIsLoading(false);
+      return { ok: true as const };
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Password update failed");
+      setIsLoading(false);
+      return { ok: false as const };
+    }
+  }
+
+  return {
+    signIn,
+    signUp,
+    requestPasswordReset,
+    updatePassword,
+    isLoading,
+    error,
+    setError,
+  };
+}

--- a/web/lib/auth/CLAUDE.md
+++ b/web/lib/auth/CLAUDE.md
@@ -51,3 +51,30 @@ if (denied) return denied;
 Anonymous routes are not allowed — if you genuinely need an unauthenticated
 public endpoint, document the exception in the route file and add rate
 limiting (see Stream P1 — `/api/feedback` rate limit).
+
+## Email + password auth (in addition to Google OAuth)
+
+Two client hooks back all browser-side auth:
+
+- **`useGoogleAuth()`** (`web/hooks/use-google-auth.ts`) — `signInWithOAuth({ provider: "google" })`.
+- **`useEmailAuth()`** (`web/hooks/use-email-auth.ts`) — wraps `signUp`,
+  `signInWithPassword`, `resetPasswordForEmail`, and `updateUser({ password })`.
+
+All flows land at `/auth/callback`, which calls `exchangeCodeForSession(code)` —
+provider-agnostic, so the same handler works for OAuth, email confirmation
+links, and password-reset links. The `auth_next` cookie (set on the client
+before any redirect) survives the email round-trip and tells the callback
+where to send the user.
+
+Confirmation and reset emails are sent by **Supabase's built-in email
+service**. To upgrade deliverability/rate limits, configure Resend SMTP in the
+Supabase Console → Auth → SMTP Settings — no app code changes required.
+
+Zod validation schemas live in `web/lib/auth/validation.ts`. Forms are plain
+controlled components (no react-hook-form) — keep it that way unless we add a
+materially more complex form.
+
+Public unauthenticated routes are gated in `web/proxy.ts` via the
+`PUBLIC_PATHS` set: `/login`, `/forgot-password`, `/account/update-password`.
+Add any new unauthenticated page to that set, not by widening the negative
+check.

--- a/web/lib/auth/validation.ts
+++ b/web/lib/auth/validation.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+export const emailSchema = z
+  .string()
+  .trim()
+  .min(1, "Email is required")
+  .email("Enter a valid email address");
+
+export const passwordSchema = z
+  .string()
+  .min(8, "Password must be at least 8 characters")
+  .regex(/[A-Za-z]/, "Password must contain a letter")
+  .regex(/\d/, "Password must contain a number");
+
+export const fullNameSchema = z
+  .string()
+  .trim()
+  .min(1, "Name is required")
+  .max(120, "Name is too long");
+
+export const signInSchema = z.object({
+  email: emailSchema,
+  password: z.string().min(1, "Password is required"),
+});
+
+export const signUpSchema = z.object({
+  fullName: fullNameSchema,
+  email: emailSchema,
+  password: passwordSchema,
+});
+
+export const forgotPasswordSchema = z.object({
+  email: emailSchema,
+});
+
+export const updatePasswordSchema = z
+  .object({
+    password: passwordSchema,
+    confirm: z.string().min(1, "Confirm your password"),
+  })
+  .refine((d) => d.password === d.confirm, {
+    message: "Passwords do not match",
+    path: ["confirm"],
+  });
+
+export type SignInInput = z.infer<typeof signInSchema>;
+export type SignUpInput = z.infer<typeof signUpSchema>;
+export type ForgotPasswordInput = z.infer<typeof forgotPasswordSchema>;
+export type UpdatePasswordInput = z.infer<typeof updatePasswordSchema>;
+
+export function firstZodError(error: z.ZodError): string {
+  return error.issues[0]?.message ?? "Invalid input";
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.4.1",
+  "version": "2.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -2,6 +2,15 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 import { fetchWithRetry } from "@/lib/supabase/fetch-retry";
 
+// Paths the unauthenticated user is allowed to reach. /account/update-password is
+// here because the reset-link flow lands the user with a fresh session that the
+// page itself reads; the page guards against missing sessions inline.
+const PUBLIC_PATHS = new Set([
+  "/login",
+  "/forgot-password",
+  "/account/update-password",
+]);
+
 export async function proxy(request: NextRequest) {
   const pathname = request.nextUrl.pathname;
 
@@ -36,7 +45,7 @@ export async function proxy(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  if (!user && pathname !== "/login") {
+  if (!user && !PUBLIC_PATHS.has(pathname)) {
     // Preserve the original destination so that links from emails (and
     // any other deep link) land where the user intended after logging in.
     const loginUrl = new URL("/login", request.url);
@@ -47,7 +56,7 @@ export async function proxy(request: NextRequest) {
     return NextResponse.redirect(loginUrl);
   }
 
-  if (user && pathname === "/login") {
+  if (user && (pathname === "/login" || pathname === "/forgot-password")) {
     const next = request.nextUrl.searchParams.get("next");
     const safeNext = next && next.startsWith("/") && !next.startsWith("//") ? next : "/";
     return NextResponse.redirect(new URL(safeNext, request.url));


### PR DESCRIPTION
## Summary

- Adds Supabase email + password auth as a second path beside Google OAuth. `/login` now has a Log in / Sign up toggle that shares one Google button plus an email/password form.
- New `/forgot-password` flow sends a Supabase reset link that lands the user on a new `/account/update-password` page to set a fresh password.
- New \`useEmailAuth\` hook wraps \`signUp\` / \`signInWithPassword\` / \`resetPasswordForEmail\` / \`updateUser({ password })\`. Mirrors \`useGoogleAuth\` and reuses the \`auth_next\` cookie. Zod schemas live in \`web/lib/auth/validation.ts\`.
- \`/auth/callback\` is **unchanged** — \`exchangeCodeForSession(code)\` already handles OAuth, email confirmation, and reset-link codes.
- \`AuthHeader\` switches to \`<Link>\`s instead of triggering Google directly; marketing CTA deep-links to \`/login?mode=signup\`.
- \`web/proxy.ts\`: single-path allow check replaced with a \`PUBLIC_PATHS\` set (\`/login\`, \`/forgot-password\`, \`/account/update-password\`).
- Docs: \`web/lib/auth/CLAUDE.md\` addendum on the new architecture + \`PUBLIC_PATHS\` rule. Changelog + version bump to 2.5.0.

## Supabase Console (already done before merge)

- Auth → Providers → Email: **enabled**, "Confirm email" = ON.
- \`/auth/callback\` already in allowed redirect URLs.
- Default Supabase email service for v1; swappable to Resend SMTP via the Console with zero code changes.

## Test plan

- [ ] Sign up new email → confirmation email arrives → click link → lands on \`/dashboard\` with session.
- [ ] Sign in existing email/password → lands on \`/dashboard\`.
- [ ] Google sign-in regression — still works end-to-end.
- [ ] Forgot password → reset email arrives → reset link → set new password → can sign in with the new one.
- [ ] Wrong password / invalid email → inline \`destructive\` error renders, no console crashes.
- [ ] Visit \`/login?mode=signup\` from the marketing CTA → Sign up tab is active by default.
- [ ] Unauthenticated visit to \`/forgot-password\` → page renders (not redirected). Authenticated user → bounced to dashboard.
- [ ] Confirm a \`profiles\` row is created on first email signup (the existing \`handle_new_user\` trigger should populate \`email\` + \`full_name\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)