### PR TITLE
fix(ingest+canary): paginate dedup, rewrite canary, surface task errors

### DIFF
--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "2.5.1",
+    "date": "2026-05-28",
+    "changes": [
+      { "type": "fix", "description": "Scraper-break canary email no longer fires false alarms for incumbents. The canary's bulk `.select()` against the 8-day window silently hit PostgREST's 1000-row cap once the incumbent corpus exceeded that — today's freshly-inserted rows fell outside the returned window, so half the banks showed `0 new today` even when scrapers were ingesting normally. Rewritten as per-company `count(head:true)` pairs; no row materialization, no cap. The rolling-avg window also excludes the per-company backfill cutoff (created_at + 48h, same definition as the dashboard) so the one-shot onboarding ingest no longer poisons the average and keeps the canary firing daily for a week after every new incumbent comes online." },
+      { "type": "fix", "description": "Job-postings ingest dedup now loads the full existing corpus via paginated `.range()`. The previous unbounded `.select()` capped at 1000 rows, so for any company with >1000 active postings (RBC, TD, Scotia) the dedup map was incomplete and the next scrape re-INSERTed already-known rows. The incumbent-bets dashboard query had the same shape and is fixed the same way." },
+      { "type": "fix", "description": "`updateTaskProgress` now surfaces the underlying PostgREST error (code + message) when the task lookup fails, instead of the generic `Task X not found` that hid the real cause of the May 2026 TD ingest failure." }
+    ]
+  },
+  {
     "version": "2.5.0",
     "date": "2026-05-27",
     "changes": [

--- a/web/lib/dashboard-queries.ts
+++ b/web/lib/dashboard-queries.ts
@@ -1230,43 +1230,63 @@ export async function getIncumbentBets(options?: {
   const windowStart = subDays(new Date(), windowDays).toISOString();
 
   // Signal-window jobs: active incumbent postings first seen in the window.
-  let signalQuery = supabase
-    .from("job_postings")
-    .select(
-      "id, title, seniority_level, function_category, location, company_id, companies!inner(id, name, slug, is_active, tier)"
-    )
-    .eq("is_active", true)
-    .eq("companies.is_active", true)
-    .eq("companies.tier", "incumbent")
-    .gte("first_seen_date", windowStart);
-  if (options?.companyId) {
-    signalQuery = signalQuery.eq("company_id", options.companyId);
+  // Paginated because the unbounded .select() previously hit PostgREST's
+  // 1000-row default cap — incumbents carry ~6,000+ active postings, so
+  // the rail silently rendered partial data.
+  type SignalRow = {
+    id: string;
+    title: string | null;
+    seniority_level: string | null;
+    function_category: string | null;
+    location: string | null;
+    company_id: string;
+    companies: { id: string; name: string; slug: string; is_active: boolean; tier: string | null } |
+      Array<{ id: string; name: string; slug: string; is_active: boolean; tier: string | null }>;
+  };
+  const PAGE = 1000;
+  const signalJobs: SignalRow[] = [];
+  for (let offset = 0; ; offset += PAGE) {
+    let q = supabase
+      .from("job_postings")
+      .select(
+        "id, title, seniority_level, function_category, location, company_id, companies!inner(id, name, slug, is_active, tier)"
+      )
+      .eq("is_active", true)
+      .eq("companies.is_active", true)
+      .eq("companies.tier", "incumbent")
+      .gte("first_seen_date", windowStart)
+      .order("id", { ascending: true })
+      .range(offset, offset + PAGE - 1);
+    if (options?.companyId) {
+      q = q.eq("company_id", options.companyId);
+    }
+    const { data: page } = await q;
+    if (!page || page.length === 0) break;
+    signalJobs.push(...(page as SignalRow[]));
+    if (page.length < PAGE) break;
   }
 
-  // All active incumbent postings (no window, no signal filter) — for the
-  // per-company total. Only the id+company is needed; tally in JS.
-  let totalQuery = supabase
-    .from("job_postings")
-    .select("company_id, companies!inner(is_active, tier)")
-    .eq("is_active", true)
-    .eq("companies.is_active", true)
-    .eq("companies.tier", "incumbent");
-  if (options?.companyId) {
-    totalQuery = totalQuery.eq("company_id", options.companyId);
-  }
-
-  const [{ data: signalJobs }, { data: totalJobs }] = await Promise.all([
-    signalQuery,
-    totalQuery,
-  ]);
-
+  // Per-company active totals via count() — no row materialization, no cap.
+  // Only the 6 incumbents are eligible, so this is at most ~6 round-trips.
   const totalOpenByCompany = new Map<string, number>();
-  for (const job of totalJobs ?? []) {
-    totalOpenByCompany.set(
-      job.company_id,
-      (totalOpenByCompany.get(job.company_id) ?? 0) + 1
-    );
-  }
+  const { data: incumbentCompanies } = await supabase
+    .from("companies")
+    .select("id")
+    .eq("is_active", true)
+    .eq("tier", "incumbent");
+  const eligibleIds = (incumbentCompanies ?? [])
+    .map((c) => c.id as string)
+    .filter((id) => !options?.companyId || id === options.companyId);
+  await Promise.all(
+    eligibleIds.map(async (cid) => {
+      const { count } = await supabase
+        .from("job_postings")
+        .select("id", { count: "exact", head: true })
+        .eq("company_id", cid)
+        .eq("is_active", true);
+      totalOpenByCompany.set(cid, count ?? 0);
+    })
+  );
 
   // Group signal jobs by company, then collapse identical roles.
   interface CompanyAccum {

--- a/web/lib/email/scraper-health.ts
+++ b/web/lib/email/scraper-health.ts
@@ -250,7 +250,7 @@ export async function detectIncumbentCanaries(
   try {
     const { data: companies, error: companiesError } = await supabase
       .from("companies")
-      .select("id, name, slug")
+      .select("id, name, slug, created_at")
       .eq("tier", "incumbent")
       .eq("is_active", true);
 
@@ -277,46 +277,71 @@ export async function detectIncumbentCanaries(
     const todayStartIso = todayStart.toISOString();
     const rollingStartIso = rollingStart.toISOString();
 
-    const companyIds = companies.map((c) => c.id);
+    // Per-company count() pairs. The previous implementation pulled every
+    // row in the 8-day window into memory, which silently capped at
+    // PostgREST's default 1000 rows — at ~6,500+ incumbent rows in the
+    // window the cap dropped today's freshly-inserted rows and produced
+    // false "0 new today" alerts for half the banks. count(head:true)
+    // returns only the aggregate, so no cap applies.
+    //
+    // The rolling-avg window also excludes the per-company backfill cutoff
+    // (created_at + 48h, same definition as `isBackfill` in
+    // dashboard-queries.ts). The big-bang onboarding ingest can dwarf
+    // organic daily volume by 100×, which would poison the rolling avg
+    // for ~7 days after every new incumbent comes online and keep this
+    // canary firing daily.
+    const counts = await Promise.all(
+      companies.map(async (company) => {
+        const backfillCutoffIso = company.created_at
+          ? new Date(
+              new Date(company.created_at as string).getTime() + 48 * 60 * 60 * 1000
+            ).toISOString()
+          : null;
+        const rollingFloorIso =
+          backfillCutoffIso && backfillCutoffIso > rollingStartIso
+            ? backfillCutoffIso
+            : rollingStartIso;
 
-    // One round-trip for the last 8 days' worth of incumbent postings.
-    // ~7,500 incumbent rows in steady state across 5 banks — this is cheap.
-    const { data: rows, error: rowsError } = await supabase
-      .from("job_postings")
-      .select("company_id, first_seen_date")
-      .in("company_id", companyIds)
-      .gte("first_seen_date", rollingStartIso)
-      .not("first_seen_date", "is", null);
+        const [{ count: todayCount }, { count: rollingCount }] = await Promise.all([
+          supabase
+            .from("job_postings")
+            .select("id", { count: "exact", head: true })
+            .eq("company_id", company.id)
+            .gte("first_seen_date", todayStartIso),
+          supabase
+            .from("job_postings")
+            .select("id", { count: "exact", head: true })
+            .eq("company_id", company.id)
+            .gte("first_seen_date", rollingFloorIso)
+            .lt("first_seen_date", todayStartIso),
+        ]);
 
-    if (rowsError) {
-      log.error(
-        { err: rowsError.message },
-        "Canary: failed to fetch recent postings"
-      );
-      return [];
-    }
-
-    const todayByCompany = new Map<string, number>();
-    const rollingByCompany = new Map<string, number>();
-    for (const row of rows ?? []) {
-      if (!row.first_seen_date) continue;
-      if (row.first_seen_date >= todayStartIso) {
-        todayByCompany.set(
-          row.company_id,
-          (todayByCompany.get(row.company_id) ?? 0) + 1
+        // Number of full days the rolling window actually covers (1-7).
+        // A bank onboarded 3 days ago has at most 3 days of organic data;
+        // dividing by 7 would understate the average and over-fire.
+        const rollingDays = Math.max(
+          1,
+          Math.min(
+            7,
+            Math.ceil(
+              (todayStart.getTime() - new Date(rollingFloorIso).getTime()) /
+                (24 * 60 * 60 * 1000)
+            )
+          )
         );
-      } else {
-        rollingByCompany.set(
-          row.company_id,
-          (rollingByCompany.get(row.company_id) ?? 0) + 1
-        );
-      }
-    }
+
+        return {
+          company,
+          today: todayCount ?? 0,
+          rollingTotal: rollingCount ?? 0,
+          rollingDays,
+        };
+      })
+    );
 
     const canaries: ScraperCanary[] = [];
-    for (const company of companies) {
-      const today = todayByCompany.get(company.id) ?? 0;
-      const rolling = (rollingByCompany.get(company.id) ?? 0) / 7;
+    for (const { company, today, rollingTotal, rollingDays } of counts) {
+      const rolling = rollingTotal / rollingDays;
       const decision = evaluateCanary({ today, rolling });
       if (!decision.fire) continue;
       canaries.push({

--- a/web/lib/jobs/processor.ts
+++ b/web/lib/jobs/processor.ts
@@ -240,12 +240,32 @@ export async function runIngestStage(
 
     // Load existing job_postings for parent + every resolved sub-brand
     // so per-company existingMap/fetchedIds (used by closure detection)
-    // are computed correctly.
+    // are computed correctly. Paginated because PostgREST caps a single
+    // .select() at 1000 rows — RBC/TD/Scotia each carry >1000 active
+    // postings, so the unpaginated query silently dropped dedup entries
+    // and the next scrape re-INSERTed already-known rows.
     const ingestCompanyIds = [company.id, ...Array.from(overrideCompanies.values()).map((c) => c.id)];
-    const { data: existing } = await supabase
-      .from('job_postings')
-      .select('id, external_id, description_hash, company_id')
-      .in('company_id', ingestCompanyIds);
+    const PAGE = 1000;
+    const existing: Array<{
+      id: string;
+      external_id: string;
+      description_hash: string | null;
+      company_id: string;
+    }> = [];
+    for (let offset = 0; ; offset += PAGE) {
+      const { data: page, error: pageError } = await supabase
+        .from('job_postings')
+        .select('id, external_id, description_hash, company_id')
+        .in('company_id', ingestCompanyIds)
+        .order('id', { ascending: true })
+        .range(offset, offset + PAGE - 1);
+      if (pageError) {
+        throw new Error(`Failed to load existing postings for dedup: ${pageError.message}`);
+      }
+      if (!page || page.length === 0) break;
+      existing.push(...(page as typeof existing));
+      if (page.length < PAGE) break;
+    }
 
     const existingByCompany = new Map<
       string,

--- a/web/lib/jobs/progress.ts
+++ b/web/lib/jobs/progress.ts
@@ -13,12 +13,20 @@ export async function updateTaskProgress(
   const supabase = createAdminClient();
 
   // Get current task to merge progress
-  const { data: task } = await supabase
+  const { data: task, error: fetchError } = await supabase
     .from('job_run_tasks')
     .select('stage_progress, current_stage')
     .eq('id', taskId)
-    .single();
+    .maybeSingle();
 
+  if (fetchError) {
+    // Without the underlying message, a PostgREST/RLS/transport failure
+    // surfaces as a generic "Task not found" downstream and the real cause
+    // is lost. See May 2026 TD ingest incident.
+    throw new Error(
+      `Task ${taskId} lookup failed: ${fetchError.message} (code=${fetchError.code ?? 'n/a'})`
+    );
+  }
   if (!task) {
     throw new Error(`Task ${taskId} not found`);
   }

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary

Four related fixes triggered by the May 28 incumbent scraper-health email that reported \"0 new today\" for all 6 incumbents when 5 were ingesting normally and TD had a separate, recoverable failure.

- **Canary query** ([scraper-health.ts:284-289](web/lib/email/scraper-health.ts#L284-L289)) — the unbounded \`.select()\` against the 8-day window silently hit PostgREST's 1000-row cap once incumbents exceeded that. Today's freshly-inserted rows fell outside the returned set, so half the banks showed \`0 new today\` even when scrapers were ingesting normally. Rewritten as per-company \`count(head:true)\` pairs. **Also excludes per-company backfill cutoff (created_at + 48h)** from the rolling avg so the one-shot onboarding ingest doesn't poison the average for a week after every new incumbent comes online. Verified: canary returns 0 false positives against current prod state.

- **Processor dedup loader** ([processor.ts:245-248](web/lib/jobs/processor.ts#L245-L248)) — same 1000-row cap. For any company with >1000 active postings (RBC, TD, Scotia) the dedup map was incomplete and subsequent scrapes re-INSERTed already-known rows, inflating apparent daily \"new\" counts. Paginated via \`.range()\`.

- **getIncumbentBets** ([dashboard-queries.ts:1232-1256](web/lib/dashboard-queries.ts#L1232-L1256)) — both the signal-window query and the totals query had the same cap. Signal query paginated; totals rewritten as per-company \`count(head:true)\` for the 6 incumbents.

- **updateTaskProgress** ([progress.ts:22-24](web/lib/jobs/progress.ts#L22-L24)) — the task lookup ignored the PostgREST \`error\` field and threw a generic \`Task X not found\`, hiding the real cause of the May 27 TD ingest failure (1523 jobs scraped, none ingested). Now surfaces the underlying message + code.

## Test plan

- [x] \`npm run build\` clean
- [x] Diagnostic script confirms old canary query returns 1000 rows (capped) and mis-reports per-company today counts
- [x] Diagnostic script confirms new canary returns 0 false positives against current prod state
- [ ] After merge: re-trigger TD scrape via \`scrape-heavy.yml\` workflow_dispatch (yesterday's 1523 jobs never landed)
- [ ] Tomorrow's 06:00 UTC cron — confirm canary email is accurate (or absent if everything's healthy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)