### PR TITLE
fix(jobs): a11y + design-system polish on search UI (v2.7.2)

### DIFF
--- a/web/components/jobs/JobsHeader.tsx
+++ b/web/components/jobs/JobsHeader.tsx
@@ -365,7 +365,11 @@ export function JobsHeader({
         {/* Search-mode toggle. Keyword = lexical full-text (matches as you
             type). Semantic = vector similarity ("find roles like this"),
             embedded on submit. */}
-        <div className="inline-flex rounded-md border border-sand-200 bg-card p-[3px]">
+        <div
+          role="group"
+          aria-label="Search mode"
+          className="inline-flex rounded-md border border-sand-200 bg-card p-[3px]"
+        >
           {([
             ["keyword", "Keyword"],
             ["semantic", "Semantic"],
@@ -375,6 +379,7 @@ export function JobsHeader({
               <button
                 key={k}
                 type="button"
+                aria-pressed={active}
                 onClick={() => onModeChange(k)}
                 className={cn(
                   "rounded px-2.5 py-1.5 text-[11.5px] font-medium transition-colors",

--- a/web/components/jobs/JobsListTable.tsx
+++ b/web/components/jobs/JobsListTable.tsx
@@ -300,7 +300,7 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
                 </span>
                 {isNew && (
                   <span
-                    className="inline-flex shrink-0 items-center rounded-[4px] bg-sunset-100 font-display uppercase text-sunset-800"
+                    className="inline-flex shrink-0 items-center rounded-[4px] bg-sunset-100 font-mono uppercase text-sunset-800"
                     style={{
                       fontSize: 10,
                       padding: "3px 6px",

--- a/web/components/jobs/SearchHelpPopover.tsx
+++ b/web/components/jobs/SearchHelpPopover.tsx
@@ -51,6 +51,7 @@ export function SearchHelpPopover({ className }: { className?: string }) {
         type="button"
         aria-label="Search syntax help"
         aria-expanded={open}
+        aria-controls="search-syntax-help"
         onClick={() => setOpen((v) => !v)}
         className={cn(
           "flex h-5 w-5 items-center justify-center rounded-full text-sand-400 transition-colors hover:text-sand-600",
@@ -62,7 +63,7 @@ export function SearchHelpPopover({ className }: { className?: string }) {
 
       {open && (
         <div
-          role="dialog"
+          id="search-syntax-help"
           aria-label="Search syntax"
           className="absolute right-0 top-7 z-50 w-[300px] rounded-lg border border-sand-200 bg-white p-3 shadow-lg"
         >

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.7.2",
+    "date": "2026-05-30",
+    "changes": [
+      { "type": "improvement", "description": "Jobs search polish: the Keyword / Semantic mode toggle now announces its pressed state to screen readers, the “?” syntax help is wired as a proper labelled disclosure, and the “new” posting pill uses the standard mono label type instead of the editorial display face — bringing it in line with the design system." }
+    ]
+  },
+  {
     "version": "2.7.1",
     "date": "2026-05-30",
     "changes": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Small, no-behavior-change polish on the just-shipped Jobs search UI, from the Meredith (ux-design-advisor) review. These are the **objective** fixes — a11y correctness and a documented design-system violation. The subjective product calls from the review (mode-label wording, toggle placement, syntax discoverability, relevance-sort recoverability) are intentionally left out for separate triage.

## Changes
- **Mode toggle a11y** (`JobsHeader.tsx`) — `aria-pressed` on each Keyword/Semantic button + `role="group"` / `aria-label="Search mode"` on the container, so assistive tech announces the active mode.
- **Help popover semantics** (`SearchHelpPopover.tsx`) — removed the false `role="dialog"` (the popover never trapped/managed focus; its own docblock says so) and wired a real disclosure relationship: `aria-controls` on the trigger ↔ `id` on the panel.
- **"new" pill type** (`JobsListTable.tsx`) — was `font-display` (Fraunces), a [CLAUDE.md §8](../blob/main/CLAUDE.md) anti-pattern outside the four approved editorial surfaces. Now `font-mono`, matching the chip/label system.

## Verification
- `npm run build` ✓
- `npm run lint` ✓ (0 errors; one pre-existing unrelated warning)
- No behavior change; no schema/cron/AI/auth surface touched.

## Changelog
- `web/package.json` → 2.7.2
- `web/data/releases.json` → improvement entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)