### PR TITLE
fix(jobs): "Back to Jobs" restores the search you came from (v2.7.3)

### DIFF
--- a/web/app/(dashboard)/jobs/[id]/page.tsx
+++ b/web/app/(dashboard)/jobs/[id]/page.tsx
@@ -46,10 +46,10 @@ export default async function JobDetailPage({
   searchParams,
 }: {
   params: Promise<{ id: string }>;
-  searchParams: Promise<{ source?: string }>;
+  searchParams: Promise<{ source?: string; back?: string }>;
 }) {
   const { id } = await params;
-  const { source } = await searchParams;
+  const { source, back } = await searchParams;
   const supabase = await createClient();
 
   const { data: job, error } = await supabase
@@ -82,7 +82,9 @@ export default async function JobDetailPage({
           <Link
             href={
               source === "jobs"
-                ? "/jobs"
+                ? back
+                  ? `/jobs?${back}`
+                  : "/jobs"
                 : company?.slug
                   ? `/companies/${company.slug}`
                   : "/companies"

--- a/web/components/jobs/JobsListTable.tsx
+++ b/web/components/jobs/JobsListTable.tsx
@@ -138,6 +138,23 @@ const HIDE_BELOW_LG_INLINE = "hidden lg:inline-flex";
 export function JobsListTable({ rows, relevanceOrder = false }: JobsListTableProps) {
   const router = useRouter();
   const { toggle, isSelected } = useJobSelection();
+
+  // Open a posting, carrying the current list filters (search, company,
+  // function, recency, mode, tier — all URL-encoded) into the detail page as a
+  // `back` param so its "← Back to Jobs" link restores the exact search the
+  // user came from. Read at click time to capture the latest debounced URL.
+  const openJob = React.useCallback(
+    (id: string) => {
+      const qs =
+        typeof window !== "undefined"
+          ? window.location.search.replace(/^\?/, "")
+          : "";
+      const params = new URLSearchParams({ source: "jobs" });
+      if (qs) params.set("back", qs);
+      router.push(`/jobs/${id}?${params.toString()}`);
+    },
+    [router]
+  );
   const [sort, setSort] = React.useState<{ key: SortKey; dir: SortDir }>(
     relevanceOrder ? { key: "relevance", dir: "asc" } : { key: "posted", dir: "asc" }
   );
@@ -241,9 +258,9 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
             key={row.id}
             role="link"
             tabIndex={0}
-            onClick={() => router.push(`/jobs/${row.id}?source=jobs`)}
+            onClick={() => openJob(row.id)}
             onKeyDown={(e) => {
-              if (e.key === "Enter") router.push(`/jobs/${row.id}?source=jobs`);
+              if (e.key === "Enter") openJob(row.id);
             }}
             className={cn(
               GRID_COLS,

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.7.3",
+    "date": "2026-05-30",
+    "changes": [
+      { "type": "improvement", "description": "“← Back to Jobs” now returns you to the exact search you came from. Opening a posting from the Jobs page and clicking back restores your search text, mode, company / function / recency filters, and tier scope instead of resetting to the full list." }
+    ]
+  },
+  {
     "version": "2.7.2",
     "date": "2026-05-30",
     "changes": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## What

Opening a posting from **/jobs** and clicking **"← Back to Jobs"** used to dump the user back on the *unfiltered* full list — losing whatever search query, mode, company / function / recency filters, and tier scope they had set up. Reported with a `?q=salesforce` search that vanished on the round trip.

## Why it happened

The Jobs list state is entirely URL-encoded (`?q=&company=&function=&recency=&mode=&tier=`), but the row-click navigated to `/jobs/[id]?source=jobs` (querystring dropped) and the detail page's back link hardcoded `/jobs`.

## Fix

- **List → detail** ([`JobsListTable.tsx`](web/components/jobs/JobsListTable.tsx)): new `openJob(id)` helper reads the live `window.location.search` at click time and carries it into the detail URL as a `back` param (`?source=jobs&back=<encoded querystring>`). Single-encoded via `URLSearchParams`.
- **Detail → list** ([`jobs/[id]/page.tsx`](web/app/(dashboard)/jobs/[id]/page.tsx)): reads `back` (Next.js decodes once on read, so inner filter values round-trip intact) and reconstructs `/jobs?<back>`. Falls back to plain `/jobs` when `back` is absent — deep links, refreshes, and company-sourced views are unaffected.

No new state, no client storage, no extra round-trips — the restored URL re-seeds `JobsHeader`'s initial filters exactly as a fresh load would. Stays shareable and survives refresh.

## Scope notes

- Column **sort** is client-only state (not URL-backed), so it isn't part of "search criteria" and isn't restored — pre-existing behavior, unchanged here.
- Other detail-page entry points (HotRolesFeed, StrategyTimeline, company JobHistoryView) use a different `source` and have no list filters to restore — untouched.

## Verification

- `cd web && npm run build` — clean.
- `npx eslint` on both changed files — clean.
- Manual: `/jobs?q=salesforce&recency=7&tier=incumbent` → open a role → "← Back to Jobs" returns to that exact filtered view.

## Changelog / version

- `web/package.json` 2.7.2 → **2.7.3** (patch).
- `web/data/releases.json` — `improvement` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)