### PR TITLE
feat(jobs): active-only default + status scope + Load-more pagination (v2.8.0)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -56,6 +56,10 @@ We construct every tsquery operator (`:*`, `&`, `<->`, `!`) ourselves and feed `
 
 When a search is active the row cap lifts from 500 → 1000; if the cap is hit the function returns `truncated: true` and JobsPageClient renders a banner inviting the user to refine. Every search emits a `jobs.search` log event with `ts_query`, `result_count`, `truncated`, `duration_ms` — the canary for graduating to keyset pagination / `ts_rank` relevance ordering later.
 
+**Activity scope (`?status=`).** The board defaults to **active-only** — `getJobsListData` pins `.eq("is_active", true)` unless told otherwise (`status: "active" | "inactive" | "all"`, default `active`). This is a server-side scope like the tier toggle (a `JobsHeader` segmented control pushes the `?status=` param and re-queries), so the row budget is spent on the chosen set rather than loaded-then-hidden — the old behavior loaded the 500 most-recent *regardless* of `is_active`, so closed roles padded the list. `active` drops the param so a plain `/jobs` URL stays canonical. A digest deep-link (`?inDigest=`) forces `all` because its snapshot is historical and many of its roles have since closed. Inactive rows render dimmed with a neutral mono "Closed" chip; the eyebrow "N ACTIVE ROLES" stat is unchanged (it always counted `is_active` within the loaded set).
+
+**Client paging.** The table reveals `PAGE_SIZE` (25) rows at a time with an append-style "Load more" footer (`JobsListTable`), not a numbered pager — the list is ranked (newest / most-relevant first), so the top is what matters and appending preserves cross-page selection. Paging is purely client-side over the already-loaded, already-filtered set; it resets to the first page whenever the result set or sort order changes. The header counter reads "N matches" (the full filtered count, independent of how many rows are revealed); the footer reads "Showing 1–N of M".
+
 ## Verifying before deletion
 
 When code *looks* unused, verify before you delete it:

--- a/web/app/(dashboard)/jobs/page.tsx
+++ b/web/app/(dashboard)/jobs/page.tsx
@@ -70,6 +70,19 @@ function parseTierFilter(
   return "fintech";
 }
 
+/**
+ * Resolve the `?status=` param to the activity scope. Default / absent /
+ * unrecognized → `active` (the Jobs board shows only live roles unless the
+ * user opts into closed ones). Drives a server re-query, like the tier toggle.
+ */
+function parseStatusScope(
+  value: string | undefined
+): "active" | "inactive" | "all" {
+  if (value === "inactive") return "inactive";
+  if (value === "all") return "all";
+  return "active";
+}
+
 type DigestCompanyRow = {
   company_id: string;
   job_ids: unknown;
@@ -115,6 +128,12 @@ export default async function JobsPage({
   const toParam = parseIsoDateParam(params.to);
   const tiers = parseTierParam(params.tier);
   const tierFilter = parseTierFilter(params.tier);
+  // A digest deep-link is a historical snapshot — many of its roles have since
+  // closed, so it forces `all` to keep the snapshot whole regardless of the
+  // active-only default.
+  const statusFilter = params.inDigest?.trim()
+    ? "all"
+    : parseStatusScope(params.status);
 
   // Resolve digest snapshot scope — when inDigest is set, the relevant
   // job IDs are pulled from weekly_digest_companies.job_ids and act as
@@ -166,6 +185,7 @@ export default async function JobsPage({
       tiers,
       searchQuery: initialQ || null,
       searchMode,
+      status: statusFilter,
     }),
     getFunctionHeatData(30),
     getCrossCompanyThemes(),
@@ -256,6 +276,7 @@ export default async function JobsPage({
       newCount={newCount}
       companyCount={companyCount ?? companies.length}
       tierFilter={tierFilter}
+      statusFilter={statusFilter}
       searchTruncated={truncated}
       relevanceOrder={relevanceOrder}
     />

--- a/web/components/jobs/JobsHeader.tsx
+++ b/web/components/jobs/JobsHeader.tsx
@@ -78,6 +78,13 @@ export interface JobsHeaderProps {
    */
   tierFilter: "fintech" | "incumbent" | "all";
 
+  /**
+   * Activity scope (URL-seeded). Like the tier control this drives a server
+   * re-query — changing it pushes the `?status=` param. `active` is the
+   * default (the board only shows live roles) so that value drops the param.
+   */
+  statusFilter: "active" | "inactive" | "all";
+
   /** Notify parent of filter changes (debounced search inside). */
   onChange: (next: JobsFilterState) => void;
 
@@ -106,6 +113,7 @@ export function JobsHeader({
   initial,
   digestContext,
   tierFilter,
+  statusFilter,
   onChange,
   onExportCsv,
 }: JobsHeaderProps) {
@@ -231,6 +239,24 @@ export function JobsHeader({
     [router]
   );
 
+  // The status (activity) control also re-queries on the server, so it pushes
+  // the `?status=` param directly. `active` is the default → drop the param so
+  // a plain /jobs URL stays canonical and shows only live roles.
+  const setStatus = React.useCallback(
+    (next: "active" | "inactive" | "all") => {
+      if (typeof window === "undefined") return;
+      const params = new URLSearchParams(window.location.search);
+      if (next === "active") params.delete("status");
+      else params.set("status", next);
+      const qs = params.toString();
+      router.push(
+        qs ? `${window.location.pathname}?${qs}` : window.location.pathname,
+        { scroll: false }
+      );
+    },
+    [router]
+  );
+
   const hasDigestContext =
     Boolean(digestContext.themeId) ||
     Boolean(digestContext.inDigest) ||
@@ -282,7 +308,7 @@ export function JobsHeader({
             Jobs
           </h1>
           <p className="max-w-[66ch] text-[13.5px] leading-[1.55] text-sand-700">
-            Every active role across the {companyCount} fintechs we cover.
+            Every active role across the {companyCount} companies we cover.
             Filter by company, function, and recency.
           </p>
         </div>
@@ -423,7 +449,11 @@ export function JobsHeader({
         </Select>
 
         {/* Recency segmented control */}
-        <div className="inline-flex rounded-md border border-sand-200 bg-card p-[3px]">
+        <div
+          role="group"
+          aria-label="Posted within"
+          className="inline-flex rounded-md border border-sand-200 bg-card p-[3px]"
+        >
           {([
             ["any", "Any time"],
             ["7", "Last 7d"],
@@ -434,6 +464,7 @@ export function JobsHeader({
               <button
                 key={k}
                 type="button"
+                aria-pressed={active}
                 onClick={() => setRecency(k)}
                 className={cn(
                   "rounded px-2.5 py-1.5 text-[11.5px] font-medium transition-colors",
@@ -451,7 +482,11 @@ export function JobsHeader({
         {/* Tier segmented control — scopes which company tiers the list
             shows. Drives the `?tier=` URL param (server re-query). Kept
             understated: same segmented styling as the recency control. */}
-        <div className="inline-flex rounded-md border border-sand-200 bg-card p-[3px]">
+        <div
+          role="group"
+          aria-label="Company tier"
+          className="inline-flex rounded-md border border-sand-200 bg-card p-[3px]"
+        >
           {([
             ["fintech", "Fintech"],
             ["incumbent", "Incumbent"],
@@ -462,6 +497,7 @@ export function JobsHeader({
               <button
                 key={k}
                 type="button"
+                aria-pressed={active}
                 onClick={() => setTier(k)}
                 className={cn(
                   "rounded px-2.5 py-1.5 text-[11.5px] font-medium transition-colors",
@@ -476,8 +512,42 @@ export function JobsHeader({
           })}
         </div>
 
+        {/* Status (activity) segmented control — scopes the board to live,
+            closed, or all roles. Drives the `?status=` URL param (server
+            re-query). Default `Active` keeps closed postings out of the way. */}
+        <div
+          role="group"
+          aria-label="Posting status"
+          className="inline-flex rounded-md border border-sand-200 bg-card p-[3px]"
+        >
+          {([
+            ["active", "Active"],
+            ["inactive", "Inactive"],
+            ["all", "All"],
+          ] as const).map(([k, label]) => {
+            const active = statusFilter === k;
+            return (
+              <button
+                key={k}
+                type="button"
+                aria-pressed={active}
+                onClick={() => setStatus(k)}
+                className={cn(
+                  "rounded px-2.5 py-1.5 text-[11.5px] font-medium transition-colors",
+                  active
+                    ? "bg-sand-50 text-sand-900 ring-1 ring-sand-200"
+                    : "text-sand-500 hover:text-sand-700"
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+
         <span className="ml-auto font-mono text-[12px] tabular-nums text-sand-500">
-          {filteredCount.toLocaleString()} of {totalCount.toLocaleString()}
+          {filteredCount.toLocaleString()}{" "}
+          {filteredCount === 1 ? "match" : "matches"}
         </span>
       </div>
     </div>

--- a/web/components/jobs/JobsListTable.tsx
+++ b/web/components/jobs/JobsListTable.tsx
@@ -13,6 +13,11 @@
  * pushes the `?q=` term into Postgres full-text search over the `search_tsv`
  * column (title + location + description body). Row data here is already the
  * filtered set; this component does not re-search.
+ *
+ * Rendering is paged client-side: only the first `PAGE_SIZE` sorted rows show,
+ * with a "Load more" footer that appends the next chunk in place (the ranked
+ * list's top is what matters, so append beats a numbered pager). Paging resets
+ * whenever the result set or its sort order changes.
  */
 
 import * as React from "react";
@@ -24,6 +29,7 @@ import {
   FunctionDot,
   SignalTag,
 } from "@/components/design";
+import { Button } from "@/components/ui/button";
 import { TierBadge } from "@/components/ui/TierBadge";
 import type { JobsListRow } from "@/lib/dashboard-queries";
 import { useJobSelection } from "@/components/jobs/JobSelectionContext";
@@ -135,6 +141,10 @@ const GRID_COLS =
 const HIDE_BELOW_LG = "hidden lg:flex";
 const HIDE_BELOW_LG_INLINE = "hidden lg:inline-flex";
 
+/** Rows revealed per page / per "Load more" press. 25 fills a tall viewport
+ *  without drowning the eye or bloating the DOM. */
+const PAGE_SIZE = 25;
+
 export function JobsListTable({ rows, relevanceOrder = false }: JobsListTableProps) {
   const router = useRouter();
   const { toggle, isSelected } = useJobSelection();
@@ -168,6 +178,17 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
       setSort(relevanceOrder ? { key: "relevance", dir: "asc" } : { key: "posted", dir: "asc" });
     }
   }, [relevanceOrder]);
+
+  // Client-side paging: reveal PAGE_SIZE rows at a time. Reset to the first
+  // page whenever the result set (`rows` identity changes when a filter /
+  // search / scope changes) or the sort order changes — a stale "page 3" of a
+  // freshly-ranked list is meaningless. Deliberately NOT keyed on selection,
+  // so toggling a checkbox (or returning from a posting) keeps the user's
+  // expanded list intact.
+  const [visibleCount, setVisibleCount] = React.useState(PAGE_SIZE);
+  React.useEffect(() => {
+    setVisibleCount(PAGE_SIZE);
+  }, [rows, sort.key, sort.dir]);
 
   const onSortClick = React.useCallback((key: SortKey) => {
     setSort((s) =>
@@ -206,6 +227,10 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
     });
     return arr;
   }, [rows, sort]);
+
+  const visible = sorted.slice(0, visibleCount);
+  const hasMore = visibleCount < sorted.length;
+  const remaining = sorted.length - visibleCount;
 
   if (sorted.length === 0) {
     return (
@@ -248,7 +273,7 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
       </div>
 
       {/* Body rows */}
-      {sorted.map((row, idx) => {
+      {visible.map((row, idx) => {
         const isNew = row.ageDays !== null && row.ageDays <= 7;
         const remote = deriveRemote(row);
         const sigs = row.keywords.slice(0, 3);
@@ -266,7 +291,10 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
               GRID_COLS,
               "cursor-pointer py-[11px] transition-colors hover:bg-sand-100",
               checked && "bg-pacific-50",
-              idx !== sorted.length - 1 && "border-b border-sand-100"
+              // Closed roles read as background: dimmed at rest, full on hover
+              // so they're still scannable when the user opts to show them.
+              !row.isActive && "opacity-60 hover:opacity-100",
+              idx !== visible.length - 1 && "border-b border-sand-100"
             )}
           >
             {/* Selection checkbox */}
@@ -326,6 +354,22 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
                     }}
                   >
                     new
+                  </span>
+                )}
+                {/* Closed = the posting went inactive. Neutral sand chip (the
+                    inverse of the warm NEW pill) — a state cue, not an alarm.
+                    A role can be both NEW and Closed: NEW first, then Closed. */}
+                {!row.isActive && (
+                  <span
+                    className="inline-flex shrink-0 items-center rounded-[4px] bg-sand-100 font-mono uppercase text-sand-600"
+                    style={{
+                      fontSize: 10,
+                      padding: "3px 6px",
+                      lineHeight: 1,
+                      letterSpacing: "0.04em",
+                    }}
+                  >
+                    closed
                   </span>
                 )}
               </div>
@@ -446,6 +490,38 @@ export function JobsListTable({ rows, relevanceOrder = false }: JobsListTablePro
           </div>
         );
       })}
+
+      {/* Pagination footer — only when there's more than one page to show.
+          Append-style "Load more": the range label announces the new count to
+          AT via aria-live; focus stays on the button across presses. */}
+      {sorted.length > PAGE_SIZE && (
+        <nav
+          aria-label="Job results pagination"
+          className="flex flex-col items-center gap-2.5 border-t border-sand-200 px-4 py-3 sm:flex-row sm:justify-between"
+        >
+          <span
+            role="status"
+            aria-live="polite"
+            className="font-mono text-[12px] tabular-nums text-sand-600"
+          >
+            {hasMore
+              ? `Showing 1–${visible.length.toLocaleString()} of ${sorted.length.toLocaleString()}`
+              : `Showing all ${sorted.length.toLocaleString()}`}
+          </span>
+          {hasMore && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="w-full sm:w-auto"
+              onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+            >
+              {remaining >= PAGE_SIZE
+                ? `Load ${PAGE_SIZE} more`
+                : `Load last ${remaining.toLocaleString()}`}
+            </Button>
+          )}
+        </nav>
+      )}
     </div>
   );
 }

--- a/web/components/jobs/JobsPageClient.tsx
+++ b/web/components/jobs/JobsPageClient.tsx
@@ -44,6 +44,9 @@ export interface JobsPageClientProps {
   companyCount: number;
   /** Active tier scope, URL-seeded — drives the JobsHeader tier control. */
   tierFilter: "fintech" | "incumbent" | "all";
+  /** Active activity scope, URL-seeded — drives the JobsHeader status control.
+   *  Server-filtered, so `rows` already contains only the chosen set. */
+  statusFilter: "active" | "inactive" | "all";
   /** True when the server-side search hit its row cap and older / less-
    *  relevant matches were trimmed. The banner only renders when a query is
    *  actually active — a stale `truncated` from a prior URL has no effect. */
@@ -73,6 +76,7 @@ function JobsPageClientInner({
   newCount,
   companyCount,
   tierFilter,
+  statusFilter,
   searchTruncated,
   relevanceOrder,
 }: JobsPageClientProps) {
@@ -126,6 +130,7 @@ function JobsPageClientInner({
         initial={initial}
         digestContext={digestContext}
         tierFilter={tierFilter}
+        statusFilter={statusFilter}
         onChange={onChange}
         onExportCsv={() => {
           const stem =

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "2.8.0",
+    "date": "2026-05-30",
+    "changes": [
+      { "type": "feature", "description": "The Jobs board now shows only active roles by default. A new Active / Inactive / All control next to the tier toggle lets you bring closed postings back when you want them, and any role that has since closed is clearly marked with a “Closed” tag and dimmed in the list — so you’re never quietly looking at filled jobs." },
+      { "type": "feature", "description": "Long result sets are now paged. The Jobs table shows the first 25 matches with a “Load 25 more” button instead of rendering everything at once, the counter reads a meaningful “N matches,” and a “Showing 1–25 of N” line tracks where you are. Filtering, searching, or re-sorting jumps you back to the top." },
+      { "type": "improvement", "description": "Accessibility polish on the Jobs filter bar: the Recency, Tier, and Status controls now announce their selected state to screen readers." }
+    ]
+  },
+  {
     "version": "2.7.3",
     "date": "2026-05-30",
     "changes": [

--- a/web/lib/dashboard-queries.test.ts
+++ b/web/lib/dashboard-queries.test.ts
@@ -72,6 +72,15 @@ function tierFilterArgs(table: string): unknown[][] {
     .map((c) => c.args as unknown[]);
 }
 
+/** `.eq("is_active", …)` calls recorded against a table — drives the
+ *  activity-scope assertions for the Jobs list. */
+function isActiveEqArgs(table: string): unknown[][] {
+  const log = callLogs[table] ?? [];
+  return log
+    .filter((c) => c.method === "eq" && c.args[0] === "is_active")
+    .map((c) => c.args as unknown[]);
+}
+
 beforeEach(() => {
   for (const key of Object.keys(callLogs)) delete callLogs[key];
 });
@@ -176,6 +185,28 @@ describe("getJobsListData tier filter (Phase 2 Step 1 — leak G4)", () => {
     const result = await getJobsListData({ jobIds: [] });
     expect(result).toEqual({ rows: [], truncated: false });
     expect(tierFilterArgs("job_postings")).toEqual([]);
+  });
+});
+
+describe("getJobsListData activity scope (active-only default)", () => {
+  it("defaults to active-only so closed roles don't pad the board", async () => {
+    await getJobsListData();
+    expect(isActiveEqArgs("job_postings")).toEqual([["is_active", true]]);
+  });
+
+  it("scopes to closed roles when status is 'inactive'", async () => {
+    await getJobsListData({ status: "inactive" });
+    expect(isActiveEqArgs("job_postings")).toEqual([["is_active", false]]);
+  });
+
+  it("applies no is_active predicate when status is 'all'", async () => {
+    await getJobsListData({ status: "all" });
+    expect(isActiveEqArgs("job_postings")).toEqual([]);
+  });
+
+  it("still scopes active-only alongside a full-text search", async () => {
+    await getJobsListData({ searchQuery: "engineer", status: "active" });
+    expect(isActiveEqArgs("job_postings")).toEqual([["is_active", true]]);
   });
 });
 

--- a/web/lib/dashboard-queries.ts
+++ b/web/lib/dashboard-queries.ts
@@ -1135,6 +1135,12 @@ export const JOBS_SEMANTIC_MAX_ROWS = 200;
  *  similarity ("find roles like this"). */
 export type JobsSearchMode = "keyword" | "semantic";
 
+/** Which postings the Jobs list shows by activity. `active` (the default) is
+ *  the live board — only currently-open roles; `inactive` is closed/removed
+ *  roles; `all` is both. Server-side scope (like the tier toggle) so the row
+ *  budget is spent on the chosen set rather than loaded-then-hidden. */
+export type JobsStatusScope = "active" | "inactive" | "all";
+
 export interface JobsListResult {
   rows: JobsListRow[];
   /** True when the search hit its row cap — older / less-relevant matches were
@@ -1144,6 +1150,15 @@ export interface JobsListResult {
 
 const JOBS_LIST_SELECT =
   "id, title, standardized_department, function_category, location, location_structured, is_active, first_seen_date, keywords, company_id, companies!inner(id, name, slug, tier)";
+
+/** Map the activity scope to the `is_active` value to pin, or `null` for `all`
+ *  (no predicate). Callers apply it inline — a generic builder wrapper blows
+ *  past TS's instantiation-depth limit on PostgREST's recursive types. */
+function statusScopePredicate(status: JobsStatusScope): boolean | null {
+  if (status === "active") return true;
+  if (status === "inactive") return false;
+  return null;
+}
 
 /** Map one raw join row to the shape the Jobs table renders. */
 function mapJobRow(j: JobsListRawRow, now: number): JobsListRow {
@@ -1186,7 +1201,8 @@ async function runSemanticJobSearch(
   supabase: SupabaseLike,
   rawQuery: string,
   tierList: CompanyTier[],
-  jobIds: string[] | null
+  jobIds: string[] | null,
+  status: JobsStatusScope
 ): Promise<JobsListResult | null> {
   const startedAt = performance.now();
   const embedded = await embedText(rawQuery, { callSite: "jobs.search.semantic" });
@@ -1224,11 +1240,14 @@ async function runSemanticJobSearch(
     return { rows: [], truncated: false };
   }
 
-  const { data, error } = await supabase
+  let hydrate = supabase
     .from("job_postings")
     .select(JOBS_LIST_SELECT)
     .in("companies.tier", tierList)
     .in("id", orderedIds);
+  const statusValue = statusScopePredicate(status);
+  if (statusValue !== null) hydrate = hydrate.eq("is_active", statusValue);
+  const { data, error } = await hydrate;
   if (error || !data) return { rows: [], truncated: false };
 
   const now = Date.now();
@@ -1340,6 +1359,9 @@ export async function getJobsListData(
      *  "semantic", embeds the query and ranks by vector similarity; falls
      *  back to keyword if embedding is unavailable. */
     searchMode?: JobsSearchMode;
+    /** Activity scope. Default "active" — the Jobs board only shows live roles
+     *  unless the user opts into "inactive" / "all" via the status toggle. */
+    status?: JobsStatusScope;
   } = {}
 ): Promise<JobsListResult> {
   const supabase = await createClient();
@@ -1351,6 +1373,7 @@ export async function getJobsListData(
 
   const tierList = [...(options.tiers ?? DEFAULT_TIERS)];
   const rawQuery = options.searchQuery?.trim() ?? "";
+  const status: JobsStatusScope = options.status ?? "active";
 
   // Semantic mode embeds the query and ranks by vector similarity. On any
   // embedding/RPC failure runSemanticJobSearch returns null and we fall
@@ -1360,7 +1383,8 @@ export async function getJobsListData(
       supabase,
       rawQuery,
       tierList,
-      options.jobIds ?? null
+      options.jobIds ?? null,
+      status
     );
     if (semantic) return semantic;
   }
@@ -1375,6 +1399,9 @@ export async function getJobsListData(
     .in("companies.tier", tierList)
     .order("first_seen_date", { ascending: false })
     .limit(limit);
+
+  const statusValue = statusScopePredicate(status);
+  if (statusValue !== null) query = query.eq("is_active", statusValue);
 
   if (hasSearch) {
     // Full-text match on the GIN-indexed search_tsv column. Default fts type

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.7.3",
+  "version": "2.8.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Two related Jobs-board changes, each worked through with Meredith (UX). Both touch the same files, so they ship together.

> **Stacked on #103** (back-link fix). Base is `fix/jobs-back-link-preserves-search` so the diff here is only the new work — retarget to `main` once #103 merges.

---

## 1. Active-only by default + status scope (regression fix)

**The bug:** `getJobsListData` had lost its `is_active` filter, so the table loaded the 500 most-recent postings *regardless of status*. Closed/filled roles padded the list — the eyebrow read "192 ACTIVE ROLES" while the table showed "500 of 500".

**The fix:**
- New **server-side** activity scope in `getJobsListData` (`status: "active" | "inactive" | "all"`, default `active`), applied on both the keyword and semantic-search paths. Server-side (like the tier toggle) so the row budget is spent on live roles rather than loaded-then-hidden — client-side filtering would have starved active coverage given the ~192/500 ratio.
- A 3-way **Active / Inactive / All** segmented control in `JobsHeader`, next to the Tier toggle, driving a `?status=` URL param (`active` drops the param so a plain `/jobs` stays canonical). Always visible = discoverable.
- A digest deep-link (`?inDigest=`) forces `all` — its snapshot is historical and many roles have since closed.
- **Row-level signal:** inactive rows render dimmed (`opacity-60 hover:opacity-100`) with a neutral mono **"Closed"** chip (the inverse of the warm NEW pill). Active rows stay unmarked. A role can be both NEW and Closed.

## 2. Load-more pagination

**The bug:** the table rendered *every* matching row at once, so the counter always read "N of N" (e.g. "500 of 500") — useless.

**The fix** (`JobsListTable`):
- Reveal **25** rows at a time with an append-style **"Load 25 more"** footer — not a numbered pager. The list is ranked (newest / most-relevant first), so the top is what matters and appending keeps multi-row selection intact across pages.
- Resets to the first page whenever the result set or sort order changes; **not** on selection toggles.
- Header counter now reads **"N matches"** (the full filtered count); footer reads **"Showing 1–25 of N"** (with `aria-live` so screen readers hear each reveal).
- **CSV export unchanged** — still the entire filtered set, not the visible page (it already carries an "Active" column).

## Also
- `aria-pressed` on the Recency / Tier / Status segmented controls (a11y consistency pass Meredith flagged).
- Sub-headline copy "fintechs" → "companies" (the board spans tiers now).

## Deliberately deferred
Meredith also suggested a "· 308 closed hidden" numeric nudge beside the counter. Deferred: it can't be computed accurately alongside the client-side recency/company/function filters, and the always-visible status control already carries the discoverability. Noted for a future pass.

## Verification
- `cd web && npm run build` — clean.
- `npm test -- dashboard-queries` — **36 pass** (4 new: active-only default, inactive scope, all scope, active+search).
- `npx eslint` on all changed files — clean.
- No new migration (the `is_active` column already exists; `JobsListRow.isActive` was already populated, just never rendered).

## Changelog / version
- `web/package.json` 2.7.3 → **2.8.0** (minor — new features).
- `web/data/releases.json` — two `feature` entries + one `improvement`.
- `docs/AGENTS.md` — Jobs section updated (activity scope + paging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)