### PR TITLE
perf(ai): cut Gemini extraction cost + un-blind the cost alarm (v2.9.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Two AI calls per job. `analyzeJob` (in `web/lib/analysis/strategic.ts`) and `cat
 - Vercel weekly Mon 5 AM UTC: `/api/cron/report` — generates the weekly digest.
 - GitHub Actions weekly Mon 9 AM UTC: `company-insights-cron.yml` — scheduled company-insight regeneration.
 - GitHub Actions weekly Mon 11 AM UTC: `editorial-cron.yml` — runs `web/scripts/regenerate-editorial.ts` against stale companies (`companies.thesis / interpretation / bets`) and refreshes cross-company theme labels.
-- GitHub Actions daily 14:00 UTC: `gemini-cost-alarm.yml` — sums last 24h `gemini_usage_events.estimated_usd` and fires `Sentry.captureMessage` over threshold.
+- GitHub Actions daily 14:00 UTC: `gemini-cost-alarm.yml` — reads last 24h `gemini_usage_events` and fires `Sentry.captureMessage` on any of three tripwires (calibrated USD / grounded-call count / token volume; `estimated_usd` alone under-counts grounding ~2.7x). Tripwire math in `web/lib/ai/cost-alarm-eval.ts`.
 - GitHub Actions daily 07:30 UTC: `embeddings-backfill-cron.yml` — runs `web/scripts/backfill-job-embeddings.ts` to (re-)embed job rows with a null/stale `embedding` for Jobs semantic search. Decoupled from the ingest hot path on purpose.
 
 Heavy browser scraping is offloaded to GitHub Actions on demand via `triggerScrapeWorkflow` in `web/lib/github.ts` (`scrape-heavy.yml`). Full topology, secrets, and decision tree in [`docs/CRON_TOPOLOGY.md`](./docs/CRON_TOPOLOGY.md).

--- a/docs/AI_HYGIENE.md
+++ b/docs/AI_HYGIENE.md
@@ -73,7 +73,7 @@ Single source of truth lives in `web/lib/ai/prompt-config.ts` (`AI_MODEL_OPTIONS
 
 - `gemini-pro-latest` — advanced analysis with web search/grounding; deeper reasoning and narrative quality.
 - `gemini-flash-latest` — fast, cost-effective; default for extraction, classification, digest, chat.
-- `gemini-flash-lite-latest` — cheapest tier for high-volume, low-stakes calls. Use only where the comparison report confirms ≥95% L1 field agreement.
+- `gemini-flash-lite-latest` — cheapest tier for high-volume, low-stakes calls. Use only where the comparison report confirms ≥95% L1 field agreement. (Extraction was evaluated against it in 2026-05 and **kept on Flash** — it failed the gate. See "Cheaper extraction" below.)
 
 ## Editorial pipeline call sites
 
@@ -87,6 +87,30 @@ The v2 editorial fields (working thesis, interpretation, strategic bets, last me
 Both are refreshable via `web/scripts/regenerate-editorial.ts` (per company or `--all`) and the `editorial-cron.yml` GH Actions workflow (Mondays 11:00 UTC). The bet auto-suggestions surfaced in the editorial form are rule-based (`web/lib/analysis/bet-suggester.ts`) — no AI calls.
 
 **Never pin a versioned or preview model ID** (e.g. `gemini-3-flash-preview`, `gemini-2.0-flash`, `gemini-1.5-pro`). Always the `-latest` alias. The comparison harness and production telemetry are how we catch a bad alias rotation; pinning bypasses that signal.
+
+## Cost reconciliation & the daily alarm
+
+`estimateUsd` (`web/lib/ai/gemini-pricing.ts`) is a **cost model, not the invoice**. A 2026-05 audit found telemetry (`SUM(estimated_usd)`) under-counted the GCP bill ~2.7x ($66 telemetry vs $178.75 billed for May), the gap concentrated on the **grounded Pro path** (`analyzeJobAdvanced`, `performDeepResearch`): grounding is billed as search-query fan-out plus search-injected context tokens that `input_tokens` under-reports, while the model charges a flat `$0.035`/request.
+
+- **Calibration knob:** `GROUNDING_CALIBRATION` (default **1**, a no-op) scales the grounded portion of `estimateUsd`. Set it from a clean GCP SKU export: `invoice grounding $ ÷ telemetry grounding $` over the same window. `COST_CALIBRATION_NOTE` records the audit numbers in code. Re-reconcile quarterly — this is a model, not parity.
+- **The daily alarm is multi-signal.** `/api/admin/cost-alarm` no longer trusts one dollar number (that's why the May spike never paged — telemetry saw $27 < $50 on a ~$90 day). It trips on ANY of: calibrated USD (`GEMINI_DAILY_USD_THRESHOLD`, $50), grounded-call **count** (`GEMINI_DAILY_GROUNDED_CALL_THRESHOLD`, 500), or **token volume** (`GEMINI_DAILY_TOKEN_THRESHOLD`, 15M). The count + token wires read un-priced SDK fields, so a fan-out spike pages even when the dollar estimate is wrong. Pure tripwire math is in `web/lib/ai/cost-alarm-eval.ts` (unit-tested).
+- **Go-forward attribution** — the query that drives the monthly review:
+  ```sql
+  SELECT date_trunc('day',created_at)::date AS day, call_site, model_served,
+         COUNT(*) calls, ROUND(SUM(estimated_usd)::numeric,2) usd,
+         SUM((grounding_enabled)::int) grounded
+  FROM gemini_usage_events WHERE created_at >= now() - interval '30 days'
+  GROUP BY 1,2,3 ORDER BY 1 DESC, usd DESC;
+  ```
+
+## Cheaper extraction: thinking budget, Flash-Lite, open-source
+
+Silver-layer extraction (`extractJobStructure`) is the highest-volume call site (~66% of measured spend in the 2026-05 audit). Levers, in the order we adopted them:
+
+1. **Disable reasoning tokens (adopted).** Extraction is mechanical JSON — no reasoning budget needed. It sets `thinkingConfig: { thinkingBudget: 0 }`; the harness confirms thoughts→0 and per-call cost fell ~72% ($0.0044 → $0.00133) with identical fields (same model). A one-shot degrade retries without the override if a future `gemini-flash-latest` alias rotation rejects budget 0.
+2. **Don't re-extract unchanged jobs (adopted).** The `description_hash` gate fingerprints `normalizeDescriptionForHash(text)` (strips posting dates, applicant counts, requisition IDs, whitespace) so volatile boilerplate no longer flips the hash — ~88% of daily extractions were such re-runs. Legacy raw hashes are bridged in-code on the next scrape (no migration, no re-extraction sweep). Measure with `web/scripts/measure-hash-thrash.ts` (read-only).
+3. **Flash-Lite for extraction (REJECTED 2026-05).** `gemini-flash-lite-latest` is ~4x cheaper but **failed the ≥95% L1 gate**: it disagreed with Flash on `function_category` (e.g. `it-internal-systems`→`engineering-platform-sre-devops`, `sales-account-executives`→`account-management-customer-success`) and `seniority`, and degraded `tech_stack` Jaccard (which powers the company tech panels). Artifacts under `web/scripts/artifacts/`. With (1)+(2) already cutting extraction ~90%, the extra ~$2/mo wasn't worth misclassifying roles. Re-evaluate only if the prompt is hardened for the cheaper tier.
+4. **Open-source / non-Gemini providers (NOT NOW).** At ~20k calls/mo the spread between Flash-Lite (~$6/mo) and the cheapest open-weight option (DeepInfra Gemma-3-4B ~$2/mo) is ~$2–4/mo — against ~0.5–1.5 eng-days to add a second SDK, a telemetry provider field, a pricing entry, and a second vendor in the ingest hot path. Break-even is ~150k–300k calls/mo (8–15x today), and even there the first lever is **Gemini batch mode (−50%, zero new vendor)** for backfills. A non-Gemini provider only earns its keep past ~400k–700k calls/mo (20–40x). Two zero-integration Gemini fallbacks if extraction ever needs to get cheaper: **Gemma-3 on the free tier** of the existing Gemini API (~1k req/day cap; free-tier inputs may train Google — fine for public JD text) and **batch mode**.
 
 ## Quota errors
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -66,11 +66,15 @@ The pure threshold rule is `evaluateCanary({today, rolling}) → { fire, reason 
 
 A GitHub Actions workflow ([`gemini-cost-alarm.yml`](../.github/workflows/gemini-cost-alarm.yml)) runs daily at 14:00 UTC and `curl`s `/api/admin/cost-alarm` with `Authorization: Bearer ${CRON_SECRET}`.
 
-The route:
+The route reads the last 24h of `gemini_usage_events` and fires on **any of three independent tripwires** (pure math in [`web/lib/ai/cost-alarm-eval.ts`](../web/lib/ai/cost-alarm-eval.ts), unit-tested):
 
-1. Sums `estimated_usd` from `gemini_usage_events` over the last 24h.
-2. Compares against `GEMINI_DAILY_USD_THRESHOLD` (default **$50**).
-3. If over threshold, calls `Sentry.captureMessage("[cost-alarm] Daily Gemini spend exceeded $X")` with a `tags: { alarm: "gemini-cost" }` so Sentry alert rules can target it specifically.
+1. **Calibrated USD** — `SUM(estimated_usd)` with the grounded portion scaled by `GROUNDING_CALIBRATION`, vs `GEMINI_DAILY_USD_THRESHOLD` (default **$50**).
+2. **Grounded-call count** — count of `grounding_enabled` events, vs `GEMINI_DAILY_GROUNDED_CALL_THRESHOLD` (default **500**).
+3. **Token volume** — `SUM(total_tokens)`, vs `GEMINI_DAILY_TOKEN_THRESHOLD` (default **15,000,000**).
+
+If any trips, it calls `Sentry.captureMessage("[cost-alarm] Daily Gemini usage tripwire(s): …")` with `tags: { alarm: "gemini-cost", tripwire: "usd+grounded-calls+…" }` so Sentry rules can target it.
+
+**Why three signals:** `estimated_usd` is a model that under-counts the GCP invoice ~2.7x — and most on the grounded calls that drive spikes (the 2026-05 spike never paged: telemetry saw $27 < $50 on a ~$90 day). Grounded-call count and raw token volume come from un-priced SDK fields, so a fan-out spike pages even when the dollar estimate is wrong. See [`AI_HYGIENE.md`](./AI_HYGIENE.md) → "Cost reconciliation".
 
 **Auth note:** the route lives under `/api/admin/**` but is gated by `requireCronSecret`, not `requireAdmin`, because the GH Actions runner has no Supabase session. This is the only intentional exception in the `/api/admin/**` namespace and is called out in [`web/lib/auth/CLAUDE.md`](../web/lib/auth/CLAUDE.md).
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -46,7 +46,12 @@ SENTRY_DSN=
 # Optional. Defaults to VERCEL_ENV ?? "development".
 SENTRY_ENVIRONMENT=
 
-# Daily Gemini spend alarm threshold in USD. /api/admin/cost-alarm sums the
-# last 24h of gemini_usage_events.estimated_usd and fires Sentry.captureMessage
-# when total exceeds this value. Default: 50.
+# Daily Gemini cost alarm. /api/admin/cost-alarm reads the last 24h of
+# gemini_usage_events and fires Sentry.captureMessage if ANY of three
+# independent tripwires trips (USD estimate under-counts grounding ~2.7x, so
+# the count + token wires page even when the dollar number is wrong).
+# Defaults: 50 USD / 500 grounded calls / 15,000,000 tokens. Tune to ~1.5-2x
+# your observed daily norms.
 GEMINI_DAILY_USD_THRESHOLD=
+GEMINI_DAILY_GROUNDED_CALL_THRESHOLD=
+GEMINI_DAILY_TOKEN_THRESHOLD=

--- a/web/app/api/admin/cost-alarm/route.ts
+++ b/web/app/api/admin/cost-alarm/route.ts
@@ -1,10 +1,23 @@
 /**
  * Daily Gemini cost alarm.
  *
- * Triggered by `.github/workflows/gemini-cost-alarm.yml` once per day. Sums
- * the last 24h of `gemini_usage_events.estimated_usd`; if the total exceeds
- * `GEMINI_DAILY_USD_THRESHOLD` (default $50) it fires
- * `Sentry.captureMessage(...)` so the on-call rotation gets paged.
+ * Triggered by `.github/workflows/gemini-cost-alarm.yml` once per day over the
+ * last 24h of `gemini_usage_events`. Fires `Sentry.captureMessage(...)` if ANY
+ * of three independent tripwires trips:
+ *
+ *   1. Calibrated USD   — `SUM(estimated_usd)` with the grounded portion scaled
+ *                          by `GROUNDING_CALIBRATION` (> `GEMINI_DAILY_USD_THRESHOLD`).
+ *   2. Grounded calls   — count of `grounding_enabled` events
+ *                          (> `GEMINI_DAILY_GROUNDED_CALL_THRESHOLD`).
+ *   3. Token volume     — `SUM(total_tokens)`
+ *                          (> `GEMINI_DAILY_TOKEN_THRESHOLD`).
+ *
+ * Why three signals: the May 2026 spike never paged because the alarm summed
+ * only `estimated_usd`, which under-reports the GCP invoice ~2.7x — and most on
+ * exactly the grounded calls that drove the spike. Grounded-call count and raw
+ * token volume are computed from un-priced SDK fields, so a regression in
+ * either pages even when the dollar estimate is wrong. The dollar number is now
+ * one vote of three. Tripwire math lives in `@/lib/ai/cost-alarm-eval` (tested).
  *
  * Auth: `requireCronSecret` — same pattern as `/api/cron/**`. This is the
  * one route under `/api/admin/**` that intentionally does NOT require an
@@ -16,90 +29,74 @@ import { NextRequest, NextResponse } from "next/server";
 import * as Sentry from "@sentry/nextjs";
 import { createAdminClient } from "@/lib/supabase/admin";
 import { requireCronSecret } from "@/lib/auth/guards";
+import {
+  evaluateGeminiUsage,
+  type GeminiUsageRow,
+  type GeminiUsageThresholds,
+} from "@/lib/ai/cost-alarm-eval";
 import { log } from "@/lib/log";
 
 export const maxDuration = 60;
 
+// Defaults are deliberately generous backstops (well above the steady-state
+// daily norm); tune the env vars to ~1.5-2x your observed daily numbers.
 const DEFAULT_THRESHOLD_USD = 50;
+const DEFAULT_GROUNDED_CALL_THRESHOLD = 500;
+const DEFAULT_TOKEN_THRESHOLD = 15_000_000;
 
 export async function GET(req: NextRequest) {
   const denied = requireCronSecret(req);
   if (denied) return denied;
 
-  const thresholdUsd = parseThreshold(process.env.GEMINI_DAILY_USD_THRESHOLD);
+  const thresholds: GeminiUsageThresholds = {
+    usd: parsePositive(process.env.GEMINI_DAILY_USD_THRESHOLD, DEFAULT_THRESHOLD_USD),
+    grounded: parsePositive(
+      process.env.GEMINI_DAILY_GROUNDED_CALL_THRESHOLD,
+      DEFAULT_GROUNDED_CALL_THRESHOLD
+    ),
+    tokens: parsePositive(process.env.GEMINI_DAILY_TOKEN_THRESHOLD, DEFAULT_TOKEN_THRESHOLD),
+  };
   const supabase = createAdminClient();
 
-  // Window: last 24h. Sum estimated_usd from `gemini_usage_events`.
+  // Window: last 24h.
   const windowStart = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
 
   const { data, error } = await supabase
     .from("gemini_usage_events")
-    .select("estimated_usd, call_site, model_served")
+    .select("estimated_usd, call_site, model_served, grounding_enabled, total_tokens")
     .gte("created_at", windowStart);
 
   if (error) {
     log.error({ err: error.message }, "[cost-alarm] query failed");
-    return NextResponse.json(
-      { error: error.message },
-      { status: 500 }
-    );
+    return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  type Row = { estimated_usd: number | string | null; call_site: string; model_served: string };
-  const rows = (data ?? []) as Row[];
+  const rows = (data ?? []) as GeminiUsageRow[];
+  const { metrics, breakdown, tripped } = evaluateGeminiUsage(rows, thresholds);
 
-  let totalUsd = 0;
-  const byCallSite = new Map<string, number>();
-  const byModel = new Map<string, number>();
-  for (const row of rows) {
-    const usd = typeof row.estimated_usd === "string"
-      ? parseFloat(row.estimated_usd)
-      : (row.estimated_usd ?? 0);
-    if (Number.isFinite(usd)) {
-      totalUsd += usd;
-      byCallSite.set(row.call_site, (byCallSite.get(row.call_site) ?? 0) + usd);
-      byModel.set(row.model_served, (byModel.get(row.model_served) ?? 0) + usd);
-    }
-  }
+  log.info({ ...metrics, thresholds }, "[cost-alarm] daily Gemini usage computed");
 
-  const breakdown = {
-    byCallSite: Object.fromEntries(byCallSite),
-    byModel: Object.fromEntries(byModel),
-  };
-
-  log.info(
-    { totalUsd, thresholdUsd, eventCount: rows.length },
-    "[cost-alarm] daily Gemini spend computed"
-  );
-
-  if (totalUsd > thresholdUsd) {
-    const message = `[cost-alarm] Daily Gemini spend exceeded $${thresholdUsd.toFixed(2)} (actual: $${totalUsd.toFixed(2)} over ${rows.length} events)`;
-    log.warn({ totalUsd, thresholdUsd, breakdown }, message);
+  if (tripped.length > 0) {
+    const message = `[cost-alarm] Daily Gemini usage tripwire(s): ${tripped.join(", ")}`;
+    log.warn({ ...metrics, tripped, breakdown }, message);
     Sentry.captureMessage(message, {
       level: "warning",
-      tags: { alarm: "gemini-cost", env: process.env.VERCEL_ENV ?? "development" },
-      extra: { totalUsd, thresholdUsd, breakdown, eventCount: rows.length },
+      tags: {
+        alarm: "gemini-cost",
+        env: process.env.VERCEL_ENV ?? "development",
+        tripwire: tripped.map((t) => t.split(" ")[0]).join("+"),
+      },
+      extra: { ...metrics, tripped, breakdown, thresholds },
     });
 
-    return NextResponse.json({
-      alarm: true,
-      totalUsd,
-      thresholdUsd,
-      eventCount: rows.length,
-      breakdown,
-    });
+    return NextResponse.json({ alarm: true, tripped, ...metrics, thresholds, breakdown });
   }
 
-  return NextResponse.json({
-    alarm: false,
-    totalUsd,
-    thresholdUsd,
-    eventCount: rows.length,
-  });
+  return NextResponse.json({ alarm: false, ...metrics, thresholds });
 }
 
-function parseThreshold(raw: string | undefined): number {
-  if (!raw) return DEFAULT_THRESHOLD_USD;
+function parsePositive(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
   const parsed = parseFloat(raw);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_THRESHOLD_USD;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "2.9.0",
+    "date": "2026-05-30",
+    "changes": [
+      { "type": "improvement", "description": "Lower-cost, fresher job analysis. The AI extraction step that structures each posting no longer spends unnecessary reasoning tokens (a mechanical task that didn't need them), cutting its per-job cost ~70% with no change to the fields you see. Ingestion also stops re-analyzing postings whose content hasn't meaningfully changed — it now ignores volatile boilerplate like posting dates, applicant counts and requisition IDs when deciding whether a description actually changed." },
+      { "type": "fix", "description": "The daily AI-spend alarm is no longer blind to the spikes that matter. It now trips on grounded-search volume and token throughput in addition to the estimated dollar amount, so an unusual cost day pages us even when the dollar estimate under-counts it." }
+    ]
+  },
+  {
     "version": "2.8.0",
     "date": "2026-05-30",
     "changes": [

--- a/web/lib/ai/CLAUDE.md
+++ b/web/lib/ai/CLAUDE.md
@@ -21,7 +21,8 @@ If your call is wrapped by an existing helper that already meters, do not meter 
 
 ## Pricing & cost math
 
-- **`gemini-pricing.ts`** — Per-model token pricing used by the meter and the comparison harness. Update when Google's price list changes. **`estimateUsd` bills reasoning tokens at the output rate** — don't add a separate "thoughts" price column unless Google starts charging differently.
+- **`gemini-pricing.ts`** — Per-model token pricing used by the meter and the comparison harness. Update when Google's price list changes. **`estimateUsd` bills reasoning tokens at the output rate** — don't add a separate "thoughts" price column unless Google starts charging differently. `GROUNDING_CALIBRATION` (default 1, no-op) scales the grounded portion to reconcile against the GCP invoice (telemetry under-counts grounding ~2.7x); set it from a SKU export. See [`docs/AI_HYGIENE.md`](../../../docs/AI_HYGIENE.md) → "Cost reconciliation".
+- **`cost-alarm-eval.ts`** — pure tripwire math for `/api/admin/cost-alarm` (calibrated USD / grounded-call count / token volume). I/O-free + unit-tested; the route does the query + Sentry.
 
 ## Voice directive
 

--- a/web/lib/ai/cost-alarm-eval.test.ts
+++ b/web/lib/ai/cost-alarm-eval.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluateGeminiUsage,
+  type GeminiUsageRow,
+  type GeminiUsageThresholds,
+} from "./cost-alarm-eval";
+
+const THRESHOLDS: GeminiUsageThresholds = { usd: 50, grounded: 500, tokens: 15_000_000 };
+
+function row(over: Partial<GeminiUsageRow>): GeminiUsageRow {
+  return {
+    estimated_usd: 0,
+    call_site: "extractJobStructure",
+    model_served: "gemini-flash-latest",
+    grounding_enabled: false,
+    total_tokens: 0,
+    ...over,
+  };
+}
+
+describe("evaluateGeminiUsage — tripwires", () => {
+  it("does not trip when every signal is under threshold", () => {
+    const rows = [row({ estimated_usd: 10, total_tokens: 1_000_000 })];
+    const { tripped } = evaluateGeminiUsage(rows, THRESHOLDS);
+    expect(tripped).toEqual([]);
+  });
+
+  it("trips ONLY the USD wire when calibrated spend exceeds the threshold", () => {
+    const rows = [row({ estimated_usd: 60, total_tokens: 1_000 })];
+    const { tripped } = evaluateGeminiUsage(rows, THRESHOLDS);
+    expect(tripped).toHaveLength(1);
+    expect(tripped[0]).toContain("usd");
+  });
+
+  it("trips ONLY the grounded-call wire when grounded count exceeds the threshold", () => {
+    // 501 cheap grounded calls: tiny $, tiny tokens, but count is over.
+    const rows = Array.from({ length: 501 }, () =>
+      row({ estimated_usd: 0.001, grounding_enabled: true, total_tokens: 10 })
+    );
+    const { tripped, metrics } = evaluateGeminiUsage(rows, THRESHOLDS);
+    expect(metrics.groundedCalls).toBe(501);
+    expect(tripped).toHaveLength(1);
+    expect(tripped[0]).toContain("grounded-calls");
+  });
+
+  it("trips ONLY the token wire when token volume exceeds the threshold", () => {
+    const rows = [row({ estimated_usd: 1, total_tokens: 16_000_000 })];
+    const { tripped } = evaluateGeminiUsage(rows, THRESHOLDS);
+    expect(tripped).toHaveLength(1);
+    expect(tripped[0]).toContain("tokens");
+  });
+
+  it("can trip multiple wires at once", () => {
+    const rows = [
+      row({ estimated_usd: 60, grounding_enabled: true, total_tokens: 16_000_000 }),
+      ...Array.from({ length: 600 }, () => row({ grounding_enabled: true })),
+    ];
+    const { tripped } = evaluateGeminiUsage(rows, THRESHOLDS);
+    expect(tripped.map((t) => t.split(" ")[0]).sort()).toEqual([
+      "grounded-calls",
+      "tokens",
+      "usd",
+    ]);
+  });
+
+  it("parses string estimated_usd and tolerates null usd/tokens", () => {
+    const rows = [
+      row({ estimated_usd: "12.50" }),
+      row({ estimated_usd: null, total_tokens: null }),
+    ];
+    const { metrics } = evaluateGeminiUsage(rows, THRESHOLDS);
+    expect(metrics.totalUsd).toBeCloseTo(12.5, 6);
+    expect(metrics.eventCount).toBe(2);
+  });
+
+  it("calibratedUsd equals totalUsd while the multiplier is the default no-op", () => {
+    const rows = [
+      row({ estimated_usd: 5, grounding_enabled: true }),
+      row({ estimated_usd: 7, grounding_enabled: false }),
+    ];
+    const { metrics } = evaluateGeminiUsage(rows, THRESHOLDS);
+    expect(metrics.calibratedUsd).toBeCloseTo(metrics.totalUsd, 6);
+    expect(metrics.totalUsd).toBeCloseTo(12, 6);
+  });
+});

--- a/web/lib/ai/cost-alarm-eval.ts
+++ b/web/lib/ai/cost-alarm-eval.ts
@@ -1,0 +1,98 @@
+/**
+ * Pure evaluation for the daily Gemini cost alarm (`/api/admin/cost-alarm`).
+ *
+ * Kept I/O-free and separate from the route so the tripwire logic is unit-
+ * testable without mocking Supabase / Sentry / the cron guard. The route does
+ * the query + Sentry side effects; this module does the math.
+ */
+
+import { GROUNDING_CALIBRATION } from "@/lib/ai/gemini-pricing";
+
+export interface GeminiUsageRow {
+  estimated_usd: number | string | null;
+  call_site: string;
+  model_served: string;
+  grounding_enabled: boolean | null;
+  total_tokens: number | null;
+}
+
+export interface GeminiUsageThresholds {
+  usd: number;
+  grounded: number;
+  tokens: number;
+}
+
+export interface GeminiUsageEvaluation {
+  metrics: {
+    totalUsd: number;
+    calibratedUsd: number;
+    groundedCalls: number;
+    totalTokens: number;
+    eventCount: number;
+  };
+  breakdown: {
+    byCallSite: Record<string, number>;
+    byModel: Record<string, number>;
+  };
+  /** Human-readable descriptions of every tripwire that exceeded its threshold. */
+  tripped: string[];
+}
+
+/**
+ * Compute the three independent cost signals over a 24h `gemini_usage_events`
+ * row set and report which tripwires (if any) exceeded their threshold:
+ *
+ *   1. Calibrated USD — grounded portion scaled by `GROUNDING_CALIBRATION`.
+ *   2. Grounded calls — count of `grounding_enabled` rows.
+ *   3. Token volume   — `SUM(total_tokens)`.
+ *
+ * Signals 2 and 3 come from un-priced SDK fields, so they page even when the
+ * dollar estimate under-reports (the failure mode that hid the May 2026 spike).
+ */
+export function evaluateGeminiUsage(
+  rows: GeminiUsageRow[],
+  thresholds: GeminiUsageThresholds
+): GeminiUsageEvaluation {
+  let totalUsd = 0; // raw, as recorded
+  let calibratedUsd = 0; // grounded portion scaled by GROUNDING_CALIBRATION
+  let groundedCalls = 0;
+  let totalTokens = 0;
+  const byCallSite = new Map<string, number>();
+  const byModel = new Map<string, number>();
+
+  for (const row of rows) {
+    const usd = typeof row.estimated_usd === "string"
+      ? parseFloat(row.estimated_usd)
+      : (row.estimated_usd ?? 0);
+    if (Number.isFinite(usd)) {
+      totalUsd += usd;
+      calibratedUsd += row.grounding_enabled ? usd * GROUNDING_CALIBRATION : usd;
+      byCallSite.set(row.call_site, (byCallSite.get(row.call_site) ?? 0) + usd);
+      byModel.set(row.model_served, (byModel.get(row.model_served) ?? 0) + usd);
+    }
+    if (row.grounding_enabled) groundedCalls += 1;
+    if (typeof row.total_tokens === "number" && Number.isFinite(row.total_tokens)) {
+      totalTokens += row.total_tokens;
+    }
+  }
+
+  const tripped: string[] = [];
+  if (calibratedUsd > thresholds.usd) {
+    tripped.push(`usd ($${calibratedUsd.toFixed(2)} > $${thresholds.usd.toFixed(2)})`);
+  }
+  if (groundedCalls > thresholds.grounded) {
+    tripped.push(`grounded-calls (${groundedCalls} > ${thresholds.grounded})`);
+  }
+  if (totalTokens > thresholds.tokens) {
+    tripped.push(`tokens (${totalTokens.toLocaleString()} > ${thresholds.tokens.toLocaleString()})`);
+  }
+
+  return {
+    metrics: { totalUsd, calibratedUsd, groundedCalls, totalTokens, eventCount: rows.length },
+    breakdown: {
+      byCallSite: Object.fromEntries(byCallSite),
+      byModel: Object.fromEntries(byModel),
+    },
+    tripped,
+  };
+}

--- a/web/lib/ai/gemini-pricing.test.ts
+++ b/web/lib/ai/gemini-pricing.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { estimateUsd, GROUNDING_PER_REQUEST_USD } from "./gemini-pricing";
+import { estimateUsd, GROUNDING_PER_REQUEST_USD, GROUNDING_CALIBRATION } from "./gemini-pricing";
 
 describe("estimateUsd — thinking tokens (Gemini 2.5)", () => {
   it("bills thinking tokens at the output rate for Pro", () => {
@@ -57,5 +57,17 @@ describe("estimateUsd — thinking tokens (Gemini 2.5)", () => {
       groundingEnabled: true,
     });
     expect(usd).toBe(0);
+  });
+
+  it("grounding calibration defaults to a no-op (=1) so existing estimates are unchanged", () => {
+    // If this fails, someone changed the active multiplier without updating the
+    // assertions above — make that deliberate, not accidental.
+    expect(GROUNDING_CALIBRATION).toBe(1);
+    const usd = estimateUsd("gemini-pro-latest", {
+      inputTokens: 0,
+      outputTokens: 0,
+      groundingEnabled: true,
+    });
+    expect(usd).toBeCloseTo(GROUNDING_PER_REQUEST_USD * GROUNDING_CALIBRATION, 6);
   });
 });

--- a/web/lib/ai/gemini-pricing.ts
+++ b/web/lib/ai/gemini-pricing.ts
@@ -49,6 +49,39 @@ export const GEMINI_PRICING: Record<string, ModelRates> = {
 export const GROUNDING_PER_REQUEST_USD = 0.035;
 
 /**
+ * Grounding calibration multiplier.
+ *
+ * `GROUNDING_PER_REQUEST_USD` models grounding as a flat per-request surcharge,
+ * but Google bills grounding-search fan-out (one grounded request can issue
+ * several search queries) plus search-injected context tokens that our
+ * `input_tokens` under-reports. A 2026-05 reconciliation found telemetry
+ * (`SUM(estimated_usd)`) under-counted the GCP invoice ~2.7x, concentrated on
+ * the grounded Pro path (`analyzeJobAdvanced`, `performDeepResearch`).
+ *
+ * This defaults to 1 (no-op — keeps `estimateUsd` totals and existing tests
+ * unchanged). Set it from a clean GCP SKU export:
+ *   GROUNDING_CALIBRATION ≈ (invoice grounding $) / (telemetry grounding $)
+ * over the same window. The cost-alarm route also tripwires on grounded-call
+ * COUNT independently of this estimate, so a fan-out spike pages even at 1.
+ *
+ * See docs/AI_HYGIENE.md → "Cost reconciliation".
+ */
+export const GROUNDING_CALIBRATION = 1;
+
+/**
+ * Provenance for the calibration above — the audit that motivated it, recorded
+ * in code so the number isn't tribal memory. The active multiplier stays 1
+ * until a SKU-level export isolates the grounding component of the gap.
+ */
+export const COST_CALIBRATION_NOTE = {
+  observedOn: "2026-05-30",
+  window: "2026-05-01..2026-05-30",
+  gcpUsd: 178.75,
+  telemetryUsd: 66.09,
+  ratio: 2.71,
+} as const;
+
+/**
  * Rough USD estimate for a single Gemini call. Returns 0 for unknown models
  * (callers should detect this via `isPricedModel`).
  *
@@ -72,7 +105,9 @@ export function estimateUsd(
   const inputCost = (opts.inputTokens / 1_000_000) * rates.inputPerM;
   const outputCost = (opts.outputTokens / 1_000_000) * rates.outputPerM;
   const thoughtsCost = ((opts.thoughtsTokens ?? 0) / 1_000_000) * rates.outputPerM;
-  const groundingCost = opts.groundingEnabled ? GROUNDING_PER_REQUEST_USD : 0;
+  const groundingCost = opts.groundingEnabled
+    ? GROUNDING_PER_REQUEST_USD * GROUNDING_CALIBRATION
+    : 0;
   return inputCost + outputCost + thoughtsCost + groundingCost;
 }
 

--- a/web/lib/analysis/CLAUDE.md
+++ b/web/lib/analysis/CLAUDE.md
@@ -6,7 +6,7 @@ This directory holds the AI-driven analysis modules. Some are on the live ingest
 
 These run for every new job posting after `collect`:
 
-- **`structure.ts`** — `extractJobStructure` (Flash). Pulls structured fields out of the raw description. Called from `web/lib/jobs/processor.ts` via `extractAndUpdateStructure`, gated by `description_hash` to skip unchanged descriptions.
+- **`structure.ts`** — `extractJobStructure` (Flash, `thinkingBudget: 0` — reasoning tokens are pure waste on mechanical JSON extraction; ~72% per-call cost cut). Pulls structured fields out of the raw description. Called from `web/lib/jobs/processor.ts` via `extractAndUpdateStructure`, gated by a **normalized** `description_hash` (`normalizeDescriptionForHash` strips volatile boilerplate so unchanged postings skip the call). Evaluated against Flash-Lite in 2026-05 and **kept on Flash** (failed the ≥95% L1 gate).
 - **`advanced-strategic.ts`** — `analyzeJobAdvanced` (Pro + grounded). The single grounded call per job. Phase 3 dropped the duplicate `performWebSearch` pre-fetch; the main call already has `googleSearch` enabled. Callers that want shared grounding pass `webSearchContext` explicitly.
 
 ## Backfill / off-path (do not wire into ingestion)

--- a/web/lib/analysis/structure.ts
+++ b/web/lib/analysis/structure.ts
@@ -77,15 +77,24 @@ interface ExtractJobStructureOptions {
   retryCount?: number;
   /** Optional observer for token/cost usage. Production default is undefined (no-op). */
   onUsage?: OnUsage;
+  /**
+   * Disable Gemini 2.5 reasoning ("thinking") tokens for this extraction.
+   * Defaults to true — silver-layer extraction is a mechanical JSON task, so
+   * reasoning tokens (~75% of per-call cost, billed at the output rate) are pure
+   * waste. Flipped to false only by the internal one-shot degrade when the active
+   * model alias rejects `thinkingBudget: 0`.
+   */
+  disableThinking?: boolean;
 }
 
 function resolveExtractOptions(
   options?: number | ExtractJobStructureOptions
-): { config: JobStructureAiConfig; retryCount: number; onUsage?: OnUsage } {
+): { config: JobStructureAiConfig; retryCount: number; onUsage?: OnUsage; disableThinking: boolean } {
   if (typeof options === "number") {
     return {
       config: DEFAULT_JOB_STRUCTURE_AI_CONFIG,
       retryCount: options,
+      disableThinking: true,
     };
   }
 
@@ -93,6 +102,7 @@ function resolveExtractOptions(
     config: options?.config ?? DEFAULT_JOB_STRUCTURE_AI_CONFIG,
     retryCount: options?.retryCount ?? 0,
     onUsage: options?.onUsage,
+    disableThinking: options?.disableThinking ?? true,
   };
 }
 
@@ -127,7 +137,7 @@ export async function extractJobStructure(
   rawDepartment?: string | null,
   options?: number | ExtractJobStructureOptions
 ): Promise<JobStructureForDB | null> {
-  const { config, retryCount, onUsage } = resolveExtractOptions(options);
+  const { config, retryCount, onUsage, disableThinking } = resolveExtractOptions(options);
   const key = process.env.GEMINI_API_KEY;
   if (!key) {
     log.error("GEMINI_API_KEY not configured");
@@ -151,15 +161,27 @@ export async function extractJobStructure(
     const genAI = new GoogleGenerativeAI(key);
 
     // Use Gemini Flash with JSON mode for guaranteed structured output
+    const generationConfig: NonNullable<
+      Parameters<typeof genAI.getGenerativeModel>[0]["generationConfig"]
+    > = {
+      temperature: config.temperature,
+      // Stage 1 should return a compact JSON payload. Cap output size to reduce
+      // malformed/truncated responses even if the saved runtime config is overly generous.
+      maxOutputTokens: effectiveMaxOutputTokens,
+      responseMimeType: "application/json",
+    };
+    // thinkingBudget:0 disables Gemini 2.5 reasoning tokens. Extraction is a
+    // mechanical JSON task; reasoning was ~75% of per-call cost (billed at the
+    // output rate) for zero quality gain. The field is runtime-supported but
+    // missing from @google/generative-ai@0.24.1's GenerationConfig type, so we
+    // attach it past the typing gap (same approach as lib/ai/embeddings.ts).
+    if (disableThinking) {
+      (generationConfig as Record<string, unknown>).thinkingConfig = { thinkingBudget: 0 };
+    }
+
     const model = genAI.getGenerativeModel({
       model: config.model,
-      generationConfig: {
-        temperature: config.temperature,
-        // Stage 1 should return a compact JSON payload. Cap output size to reduce
-        // malformed/truncated responses even if the saved runtime config is overly generous.
-        maxOutputTokens: effectiveMaxOutputTokens,
-        responseMimeType: "application/json",
-      },
+      generationConfig,
     });
 
     const _startMs = Date.now();
@@ -370,7 +392,32 @@ export async function extractJobStructure(
 
     // Handle other errors (API errors, etc.)
     log.error({ err: error }, `Job structure extraction error for "${jobTitle}":`);
-    
+
+    // One-shot degrade: if the active model alias rejects `thinkingBudget: 0`
+    // (e.g. a future floating-alias rotation to a thinking-only variant), retry
+    // once WITHOUT the thinking override. Independent of the transient retry
+    // budget below, so the blast radius is one paid-thoughts call instead of
+    // returning null for every job until someone notices.
+    if (disableThinking && error instanceof Error) {
+      const m = error.message.toLowerCase();
+      if (
+        m.includes("thinking") ||
+        m.includes("budget") ||
+        m.includes("invalid_argument") ||
+        m.includes("invalid argument")
+      ) {
+        log.warn(
+          `thinkingBudget:0 rejected for "${jobTitle}" — retrying once without it. Error: ${error.message}`
+        );
+        return extractJobStructure(jobTitle, description, rawDepartment, {
+          config,
+          retryCount,
+          onUsage,
+          disableThinking: false,
+        });
+      }
+    }
+
     // Retry logic for API errors (rate limits, network issues, etc.)
     if (retryCount < 2 && error instanceof Error) {
       const errorMessage = error.message.toLowerCase();

--- a/web/lib/jobs/processor.test.ts
+++ b/web/lib/jobs/processor.test.ts
@@ -222,6 +222,93 @@ describe("runIngestStage description_hash gate", () => {
 
     expect(extractJobStructureMock).toHaveBeenCalledTimes(1);
   });
+
+  it("skips extraction when only volatile boilerplate (posting date) changed", async () => {
+    // Same substance, different posting date — normalizes identically, so the
+    // normalized hash matches and the Gemini call is skipped (the thrash fix).
+    const { runIngestStage, normalizeDescriptionForHash } = await import("./processor");
+    const baseWithDate = `${DESCRIPTION} Posted 3 days ago.`;
+    const churnedDate = `${DESCRIPTION} Posted 19 days ago.`;
+    expect(normalizeDescriptionForHash(baseWithDate)).toBe(
+      normalizeDescriptionForHash(churnedDate)
+    );
+    const normalizedHash = createHash("sha1")
+      .update(normalizeDescriptionForHash(baseWithDate))
+      .digest("hex");
+    existingRows = [
+      {
+        id: "existing-job-1",
+        external_id: FIXTURE_JOB.external_id,
+        description_hash: normalizedHash,
+        company_id: FIXTURE_COMPANY.id,
+      },
+    ];
+
+    const churnedJob = { ...FIXTURE_JOB, description_text: churnedDate };
+    await runIngestStage("task-churn", FIXTURE_COMPANY as never, [churnedJob] as never);
+
+    expect(extractJobStructureMock).toHaveBeenCalledTimes(0);
+  });
+
+  it("runs extraction when the substance of the description changes", async () => {
+    const { runIngestStage, normalizeDescriptionForHash } = await import("./processor");
+    const normalizedHash = createHash("sha1")
+      .update(normalizeDescriptionForHash(`${DESCRIPTION} Posted 3 days ago.`))
+      .digest("hex");
+    existingRows = [
+      {
+        id: "existing-job-1",
+        external_id: FIXTURE_JOB.external_id,
+        description_hash: normalizedHash,
+        company_id: FIXTURE_COMPANY.id,
+      },
+    ];
+
+    const changedJob = {
+      ...FIXTURE_JOB,
+      description_text: "We now seek a Staff Data Scientist for fraud modeling. Posted 3 days ago.",
+    };
+    await runIngestStage("task-substance", FIXTURE_COMPANY as never, [changedJob] as never);
+
+    expect(extractJobStructureMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("normalizeDescriptionForHash", () => {
+  it("collapses whitespace and case so re-rendered text fingerprints identically", async () => {
+    const { normalizeDescriptionForHash } = await import("./processor");
+    expect(normalizeDescriptionForHash("Hello   World\n\nFoo")).toBe(
+      normalizeDescriptionForHash("hello world foo")
+    );
+  });
+
+  it("ignores churning posting dates", async () => {
+    const { normalizeDescriptionForHash } = await import("./processor");
+    expect(normalizeDescriptionForHash("Build payments infra. Posted 3 days ago.")).toBe(
+      normalizeDescriptionForHash("Build payments infra. Posted 47 days ago.")
+    );
+  });
+
+  it("ignores churning applicant counts", async () => {
+    const { normalizeDescriptionForHash } = await import("./processor");
+    expect(normalizeDescriptionForHash("Join the risk team. 5 applicants.")).toBe(
+      normalizeDescriptionForHash("Join the risk team. 250 applicants.")
+    );
+  });
+
+  it("ignores churning requisition IDs", async () => {
+    const { normalizeDescriptionForHash } = await import("./processor");
+    expect(normalizeDescriptionForHash("Senior role JR-0012345 in Toronto.")).toBe(
+      normalizeDescriptionForHash("Senior role JR-0067890 in Toronto.")
+    );
+  });
+
+  it("still flips when the substance changes", async () => {
+    const { normalizeDescriptionForHash } = await import("./processor");
+    expect(normalizeDescriptionForHash("Senior Backend Engineer")).not.toBe(
+      normalizeDescriptionForHash("Staff Data Scientist")
+    );
+  });
 });
 
 describe("runIngestStage companySlugOverride routing", () => {

--- a/web/lib/jobs/processor.ts
+++ b/web/lib/jobs/processor.ts
@@ -13,13 +13,54 @@ import { createHash } from "crypto";
 import { log } from "@/lib/log";
 
 /**
- * SHA-1 hex digest of a job description. Used as a cheap content fingerprint
- * so the ingestion pipeline can skip `extractAndUpdateStructure` when a
- * scraped description matches what we already stored. Matches the SQL
- * `encode(digest(description_text, 'sha1'), 'hex')` used by the backfill
- * migration so hashes produced here and in-database are interchangeable.
+ * Normalize a job description before fingerprinting so the change-detection
+ * hash flips on substance, not on volatile boilerplate. Incumbent ATS pages
+ * (Workday / Phenom) re-render with churning posting dates, applicant counts,
+ * requisition IDs and whitespace that flipped a raw SHA-1 on every scrape and
+ * forced a needless Gemini re-extraction — ~88% of daily extractions in the
+ * 2026-05 cost audit. Pure + deterministic. Only the *hash input* is
+ * normalized; the raw `description_text` is still stored and fed to extraction
+ * unchanged, so extracted field quality is unaffected.
+ */
+export function normalizeDescriptionForHash(description: string): string {
+  return description
+    .toLowerCase()
+    // Posting dates: "posted 3 days ago", "posted today", "updated yesterday",
+    // "posted on 2026-05-21", and bare ISO dates.
+    .replace(/(?:posted|updated)(?:\s+on)?\s+(?:[0-9]+\+?\s+days?\s+ago|today|yesterday)/g, " ")
+    .replace(/\b\d{4}-\d{2}-\d{2}\b/g, " ")
+    // Applicant counters: "27 applicants", "over 200 applicants", "be an early applicant".
+    .replace(/(?:over\s+)?[0-9,]+\+?\s+applicants?/g, " ")
+    .replace(/be an early applicant/g, " ")
+    // Requisition / job IDs: "R-12345", "JR0012345", "req id: 558231", "requisition #4471".
+    .replace(/\b(?:r-|jr-?|req(?:uisition)?[\s#:]*(?:id|no\.?)?[\s#:]*)[0-9]{3,}\b/g, " ")
+    // URL tracking params that re-roll per render.
+    .replace(/[?&](?:utm_[a-z]+|gh_src|src|ref|trackid)=[^\s&]*/g, " ")
+    // Collapse whitespace last so the removals above don't leave ragged gaps.
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Normalized SHA-1 content fingerprint for the `description_hash` gate: it
+ * changes only when the substance of a description changes (see
+ * `normalizeDescriptionForHash`), so unchanged postings skip the Gemini
+ * extraction call. Legacy rows hold a RAW (un-normalized) SHA-1 from the
+ * earlier gate / SQL backfill; the gate bridges them on the next scrape via
+ * `rawDescriptionHash` without re-extracting, so no migration or re-extraction
+ * sweep is needed.
  */
 function hashDescription(description: string): string {
+  return createHash("sha1").update(normalizeDescriptionForHash(description)).digest("hex");
+}
+
+/**
+ * Raw (un-normalized) SHA-1 — the pre-normalization fingerprint. Used only to
+ * recognize a legacy stored hash during the one-time transition to normalized
+ * fingerprints: if the current text is byte-identical to what produced the
+ * stored hash, its raw digest still matches and we treat the row as unchanged.
+ */
+function rawDescriptionHash(description: string): string {
   return createHash("sha1").update(description).digest("hex");
 }
 
@@ -317,15 +358,25 @@ export async function runIngestStage(
       };
 
       const existingEntry = existingByCompany.get(targetCompanyId)?.get(job.external_id);
-      // Content fingerprint for the description_hash gate (Phase 2). A null
+      // Normalized content fingerprint for the description_hash gate. A null
       // stored hash is treated as "changed" so the first scrape after deploy
-      // still populates everything, matching the intent of the SQL backfill.
+      // still populates everything. `rawHash` is the pre-normalization digest,
+      // used only as the legacy-row transition bridge below.
       const newDescriptionHash = row.description_text ? hashDescription(row.description_text) : null;
+      const rawHash = row.description_text ? rawDescriptionHash(row.description_text) : null;
 
       if (existingEntry) {
         const existingId = existingEntry.id;
+        // Skip extraction unless the *normalized* content changed. The third
+        // clause is the one-time transition bridge: a legacy row stores a RAW
+        // SHA-1, so when the current text is byte-identical to what we last
+        // saw, its raw digest still matches the stored value — treat that as
+        // unchanged and let the write below migrate the row to the normalized
+        // hash. No re-extraction sweep, no SQL/TS-parity migration needed.
         const descriptionChanged =
-          newDescriptionHash !== null && newDescriptionHash !== existingEntry.descriptionHash;
+          newDescriptionHash !== null &&
+          newDescriptionHash !== existingEntry.descriptionHash &&
+          rawHash !== existingEntry.descriptionHash;
         // Update existing job
         // Note: location will be updated by extractAndUpdateStructure with validated/AI-extracted value
         // For now, validate scraper location and set to null if invalid (will be replaced by AI extraction)

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/scripts/artifacts/baseline-extract-structure-cd6c3fc.json
+++ b/web/scripts/artifacts/baseline-extract-structure-cd6c3fc.json
@@ -1,0 +1,1411 @@
+{
+  "scenario": "extract-structure",
+  "mode": "baseline",
+  "variant": "default",
+  "gitSha": "cd6c3fc",
+  "generatedAt": "2026-05-30T22:08:21.410Z",
+  "fixtureFile": "/Users/tscheidt/fintech_insights/fintech_insights/web/scripts/fixtures/gemini-sample-jobs.json",
+  "fixtureCount": 24,
+  "processedCount": 24,
+  "totals": {
+    "calls": 24,
+    "inputTokens": 55700,
+    "outputTokens": 6083,
+    "cachedTokens": 0,
+    "totalTokens": 61783,
+    "estimatedUsd": 0.031918,
+    "avgLatencyMs": 1839
+  },
+  "byCallSite": {
+    "extractJobStructure": {
+      "calls": 24,
+      "inputTokens": 55700,
+      "outputTokens": 6083,
+      "totalTokens": 61783,
+      "estimatedUsd": 0.0319175,
+      "avgLatencyMs": 1839,
+      "modelsServed": [
+        "gemini-flash-latest"
+      ]
+    }
+  },
+  "perJob": [
+    {
+      "jobId": "645839c0-151d-4404-8d8f-940ea48f368a",
+      "title": "ServiceNow Engineer",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2430,
+          "outputTokens": 257,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2687,
+          "estimatedUsd": 0.0013714999999999999,
+          "latencyMs": 1910,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "ServiceNow Engineer",
+            "jobId": "645839c0-151d-4404-8d8f-940ea48f368a"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Equitable Bank is seeking a ServiceNow Engineer to join its ServiceNow Centre of Excellence. The role focuses on designing, developing, and supporting ServiceNow applications, workflows, and integrations using JavaScript, web technologies, and APIs.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "ServiceNow",
+          "JavaScript",
+          "HTML",
+          "CSS",
+          "REST",
+          "SOAP",
+          "XML",
+          "JSON"
+        ],
+        "keywords": [
+          "ServiceNow Development",
+          "Workflows",
+          "UI Policies",
+          "Business Rules",
+          "Client Scripts",
+          "API Integrations",
+          "Release Management",
+          "Production Support",
+          "Quality Assurance",
+          "Digital Banking"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "it-internal-systems",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "4aef361c-d770-4eef-8a5a-be0515eaf62d",
+      "title": "Senior Estates and Trust Coordinator",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2206,
+          "outputTokens": 202,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2408,
+          "estimatedUsd": 0.0011668,
+          "latencyMs": 1584,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Estates and Trust Coordinator",
+            "jobId": "4aef361c-d770-4eef-8a5a-be0515eaf62d"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Equitable Bank is seeking a Senior Estates and Trust Coordinator to oversee the administration of assigned trust files, manage new business onboarding, and coordinate with trust officers. The role involves analyzing CRM data, ensuring compliance with service standards, and supporting marketing initiatives.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Trust and Estate administration",
+          "CRM",
+          "compliance",
+          "client onboarding",
+          "reporting",
+          "financial services",
+          "STEP Certificate"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "business-operations",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "9af5a8d4-c15e-490c-b2a6-6f34d804e1b9",
+      "title": "Senior Backend Engineer (CARE Pod)",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2327,
+          "outputTokens": 236,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2563,
+          "estimatedUsd": 0.0012881,
+          "latencyMs": 1679,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Backend Engineer (CARE Pod)",
+            "jobId": "9af5a8d4-c15e-490c-b2a6-6f34d804e1b9"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Equitable Bank is hiring a Senior Backend Engineer for its CARE Pod to design and build agentic backend systems, workflow orchestrations, and evaluation harnesses. The role focuses on automating back-office workflows and customer-facing support experiences safely and observably.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "agentic workflows",
+          "workflow engines",
+          "agent orchestration",
+          "tool-calling systems",
+          "evaluation frameworks",
+          "service design",
+          "async workflows",
+          "observability",
+          "trunk-based development",
+          "digital banking",
+          "back-office automation"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-backend",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "5add9237-0247-4579-ba5f-38199b5dad8c",
+      "title": "Senior People Partner",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2444,
+          "outputTokens": 265,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2709,
+          "estimatedUsd": 0.0013957,
+          "latencyMs": 1803,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior People Partner",
+            "jobId": "5add9237-0247-4579-ba5f-38199b5dad8c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is hiring a Senior People Partner to transition its HR function into a modern People Enablement model. The role involves strategic partnership with managers on org design and performance, streamlining People Ops workflows using AI, and managing HR systems and compliance across Canada and the US.",
+        "seniority_level": "senior",
+        "salary_min": 130000,
+        "salary_max": 160000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "BambooHR"
+        ],
+        "keywords": [
+          "people business partnering",
+          "people operations",
+          "organizational design",
+          "performance management",
+          "succession planning",
+          "compensation",
+          "employee lifecycle",
+          "compliance",
+          "benefits",
+          "immigration"
+        ],
+        "standardized_department": "HR",
+        "function_category": "people-ops-hr",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "a67a3e67-354b-40dc-abfc-c10b6318bfe5",
+      "title": "Senior Manager, Financial Risk",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2338,
+          "outputTokens": 302,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2640,
+          "estimatedUsd": 0.0014564,
+          "latencyMs": 2047,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Manager, Financial Risk",
+            "jobId": "a67a3e67-354b-40dc-abfc-c10b6318bfe5"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Senior Manager, Financial Risk Strategy & Analytics to lead key risk management initiatives, including delinquency forecasting, ECL calculations, and stress testing. The role bridges technical analysis and strategic leadership, managing a team of analysts and collaborating with Finance, Product, and Data teams.",
+        "seniority_level": "senior",
+        "salary_min": 150000,
+        "salary_max": 190000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "SQL",
+          "Python",
+          "SAS"
+        ],
+        "keywords": [
+          "financial risk management",
+          "credit risk analytics",
+          "loss forecasting",
+          "treasury risk",
+          "IFRS 9",
+          "Expected Credit Loss",
+          "stress testing",
+          "liquidity risk",
+          "market risk",
+          "Asset Liability Management",
+          "portfolio monitoring",
+          "capital planning",
+          "economic forecasting"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "risk-management",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "e64cce30-4b02-42c6-83a3-a22cc989f667",
+      "title": "Director, Financial Risk",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2313,
+          "outputTokens": 245,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2558,
+          "estimatedUsd": 0.0013064,
+          "latencyMs": 1703,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Director, Financial Risk",
+            "jobId": "e64cce30-4b02-42c6-83a3-a22cc989f667"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is hiring a Director, Financial Risk to lead its credit and non-credit financial risk management functions. This remote-first role oversees risk appetite frameworks, loss forecasting, IFRS 9 provisioning, and portfolio monitoring while collaborating across Product, Finance, and Data teams.",
+        "seniority_level": "executive",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Credit Risk",
+          "Financial Risk Management",
+          "Market Risk",
+          "Liquidity Risk",
+          "IFRS 9",
+          "Expected Credit Loss",
+          "Stress Testing",
+          "Portfolio Monitoring",
+          "Model Risk Management",
+          "Decision Governance",
+          "Risk Appetite",
+          "Credit Policy",
+          "Data Stewardship"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "risk-management",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "025a033e-94e6-4dd5-97c2-d800ce743bb8",
+      "title": "Banking Advisor",
+      "companySlug": "bnc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2066,
+          "outputTokens": 236,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2302,
+          "estimatedUsd": 0.0012098,
+          "latencyMs": 1857,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Banking Advisor",
+            "jobId": "025a033e-94e6-4dd5-97c2-d800ce743bb8"
+          }
+        }
+      ],
+      "output": {
+        "summary": "National Bank is hiring a Banking Advisor in Longueuil to provide personalized financial advice and solutions to personal and small business clients. The role involves managing mortgage renewals, investments, and estate planning, with a requirement to obtain a mutual fund representative licence.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Personal Banking",
+          "Investments",
+          "Mortgage Lending",
+          "Small Business",
+          "Advisory Services",
+          "Mutual Funds",
+          "Personal Financing",
+          "Insurance",
+          "Estate Planning",
+          "Risk Management",
+          "Compliance"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": {
+          "city": "Longueuil",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Longueuil, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "763200a2-89d6-4a37-83e8-eaa028abf273",
+      "title": "Banking Advisor Jobs for Indigenous People",
+      "companySlug": "bnc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2279,
+          "outputTokens": 248,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2527,
+          "estimatedUsd": 0.0013037,
+          "latencyMs": 1657,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Banking Advisor Jobs for Indigenous People",
+            "jobId": "763200a2-89d6-4a37-83e8-eaa028abf273"
+          }
+        }
+      ],
+      "output": {
+        "summary": "National Bank is hiring Banking Advisors in Quebec to provide personalized financial advisory, investment, and transactional solutions. This inclusive initiative specifically encourages applications from individuals identifying as Indigenous (First Nations, Métis, and Inuit).",
+        "seniority_level": "junior",
+        "salary_min": 38958,
+        "salary_max": null,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "Personal Banking",
+          "Advisory Services",
+          "Investments",
+          "Mutual Funds",
+          "Personal Financing",
+          "Customer Relationship Management",
+          "Compliance",
+          "Risk Management",
+          "Client Education",
+          "Cash Management"
+        ],
+        "standardized_department": "Support",
+        "function_category": "customer-support-cx",
+        "location_structured": {
+          "city": "Montreal",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Montreal, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "0dd79afa-9afa-47cd-90fb-fc0fc2c6a665",
+      "title": "Banking Advisor",
+      "companySlug": "bnc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2003,
+          "outputTokens": 226,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2229,
+          "estimatedUsd": 0.0011659,
+          "latencyMs": 1742,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Banking Advisor",
+            "jobId": "0dd79afa-9afa-47cd-90fb-fc0fc2c6a665"
+          }
+        }
+      ],
+      "output": {
+        "summary": "National Bank is seeking a Banking Advisor in Sorel-Tracy to provide advisory services and personal banking solutions. The role involves helping clients with banking applications, resolving complex situations, and collaborating with specialists in credit, mortgages, and investments.",
+        "seniority_level": "junior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "personal banking",
+          "advisory services",
+          "customer service",
+          "compliance",
+          "risk management",
+          "credit",
+          "mortgage financing",
+          "investment",
+          "digital literacy",
+          "client satisfaction"
+        ],
+        "standardized_department": "Support",
+        "function_category": "customer-support-cx",
+        "location_structured": {
+          "city": "Sorel-Tracy",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Sorel-Tracy, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "9a297c56-b3ba-47fa-9393-01a4f3b1d951",
+      "title": "Sales Representative - Southgate Mall",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2386,
+          "outputTokens": 236,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2622,
+          "estimatedUsd": 0.0013058000000000002,
+          "latencyMs": 1732,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Sales Representative - Southgate Mall",
+            "jobId": "9a297c56-b3ba-47fa-9393-01a4f3b1d951"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is hiring Sales Representatives to drive customer acquisition for the Neo Credit card and Neo Money account. Operating at various activation events like malls and campuses, representatives will engage directly with customers and earn an hourly wage plus uncapped commission.",
+        "seniority_level": "junior",
+        "salary_min": 20,
+        "salary_max": 36,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "direct sales",
+          "customer acquisition",
+          "credit cards",
+          "retail sales",
+          "event marketing",
+          "promotions",
+          "commission sales"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": {
+          "city": "Edmonton",
+          "state": "Alberta",
+          "country": "Canada",
+          "formatted": "Southgate Mall, Edmonton, Alberta, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "96a9b880-5540-42a4-b7ec-388280623af6",
+      "title": "Director, Marketing Analytics",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2345,
+          "outputTokens": 232,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2577,
+          "estimatedUsd": 0.0012835,
+          "latencyMs": 1951,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Director, Marketing Analytics",
+            "jobId": "96a9b880-5540-42a4-b7ec-388280623af6"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is hiring a Director of Marketing Analytics to build and consolidate its marketing analytics function from the ground up. Reporting to the CMO, this hands-on leader will leverage Snowflake and SQL to optimize channel performance, attribution, and budget allocation for a rapidly growing consumer fintech.",
+        "seniority_level": "executive",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Snowflake"
+        ],
+        "keywords": [
+          "marketing analytics",
+          "growth analytics",
+          "attribution",
+          "acquisition costs",
+          "channel efficiency",
+          "B2C",
+          "consumer tech",
+          "budget allocation",
+          "data-driven decisions"
+        ],
+        "standardized_department": "Marketing",
+        "function_category": "marketing-growth-performance",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "eb3e9b33-7ca4-4ed7-9b6d-3e46494280d0",
+      "title": " Représentant des ventes - Laval ",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2363,
+          "outputTokens": 219,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2582,
+          "estimatedUsd": 0.0012564,
+          "latencyMs": 1781,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": " Représentant des ventes - Laval ",
+            "jobId": "eb3e9b33-7ca4-4ed7-9b6d-3e46494280d0"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is hiring motivated Sales Representatives in Laval to drive customer acquisition for the Neo credit card, Neo Money account, and other financial products through promotional events and retail partnerships.",
+        "seniority_level": "junior",
+        "salary_min": 20,
+        "salary_max": 36,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "direct sales",
+          "customer acquisition",
+          "credit cards",
+          "retail sales",
+          "promotional events",
+          "bilingual english french"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": {
+          "city": "Laval",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Laval, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "492f71bc-ab2d-447e-a076-5affe0038756",
+      "title": "Third Party Risk and Vendor Management Officer",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2336,
+          "outputTokens": 259,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2595,
+          "estimatedUsd": 0.0013483000000000002,
+          "latencyMs": 1800,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Third Party Risk and Vendor Management Officer",
+            "jobId": "492f71bc-ab2d-447e-a076-5affe0038756"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade Financial Group is hiring a Third Party Risk and Vendor Management Officer to support the development and execution of a centralized Third Party Risk Management Framework (TPRMF) for Questbank, ensuring alignment with Canadian regulatory expectations and OSFI B-10 guidelines.",
+        "seniority_level": "mid",
+        "salary_min": 70000,
+        "salary_max": 95000,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "Third Party Risk Management",
+          "TPRM",
+          "OSFI B-10",
+          "Vendor Management",
+          "Risk Assessment",
+          "Due Diligence",
+          "Regulatory Compliance",
+          "Risk Mitigation",
+          "Governance",
+          "First Line of Defence"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "risk-management",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "afb62032-c97d-492f-a9f2-fbbcd65dc103",
+      "title": "Analyst, Mutual Fund, Security Master and Physical Securities (Contract)",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2399,
+          "outputTokens": 304,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2703,
+          "estimatedUsd": 0.0014797,
+          "latencyMs": 2049,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Analyst, Mutual Fund, Security Master and Physical Securities (Contract)",
+            "jobId": "afb62032-c97d-492f-a9f2-fbbcd65dc103"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade Financial Group is hiring a contract Analyst for Mutual Fund, Security Master, and Physical Securities. The role is responsible for clearing operations, physical security processing, mutual fund reconciliation, and security master maintenance in a hybrid environment.",
+        "seniority_level": "mid",
+        "salary_min": 60000,
+        "salary_max": 65000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "Broadridge",
+          "Fundserv",
+          "CDS",
+          "DTC",
+          "APEX"
+        ],
+        "keywords": [
+          "Mutual Funds",
+          "Security Master",
+          "Physical Securities",
+          "Reconciliation",
+          "Clearing Operations",
+          "Precious Metals",
+          "Bonds",
+          "GICs",
+          "Exempt Market Products",
+          "DRS",
+          "DWAC",
+          "Transfer Agents",
+          "Audit"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "customer-operations",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "7ddca5ee-2708-4120-a8b9-fa703115d899",
+      "title": "Head of Marketing - Questbank",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2290,
+          "outputTokens": 205,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2495,
+          "estimatedUsd": 0.0011995,
+          "latencyMs": 1735,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Head of Marketing - Questbank",
+            "jobId": "7ddca5ee-2708-4120-a8b9-fa703115d899"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questbank is hiring a Head of Marketing to lead the end-to-end vision, strategic planning, and performance of its B2B marketing programs. The role focuses on defining go-to-market and growth strategies for third-party distribution channels, mortgage brokers, and financial advisors.",
+        "seniority_level": "executive",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "B2B marketing",
+          "go-to-market strategy",
+          "mortgage brokers",
+          "financial advisors",
+          "B2B2C",
+          "lifecycle marketing",
+          "lead generation",
+          "brand positioning",
+          "partner marketing",
+          "marketing budget management"
+        ],
+        "standardized_department": "Marketing",
+        "function_category": "marketing-product-brand",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "70658554-12d3-4e79-884d-b98cec3fa40a",
+      "title": "Clearing & Custody Wealth Management Banker",
+      "companySlug": "rbc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2347,
+          "outputTokens": 306,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2653,
+          "estimatedUsd": 0.0014691,
+          "latencyMs": 1947,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Clearing & Custody Wealth Management Banker",
+            "jobId": "70658554-12d3-4e79-884d-b98cec3fa40a"
+          }
+        }
+      ],
+      "output": {
+        "summary": "RBC is seeking an experienced sales professional to drive its Banking and Lending business within the US Wealth Management Clearing & Custody channel. The role focuses on expanding cash management and lending solutions among Broker-Dealers and Registered Investment Advisors.",
+        "seniority_level": "senior",
+        "salary_min": 90000,
+        "salary_max": 200000,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Wealth Management",
+          "Lending",
+          "Cash Management",
+          "Broker-Dealers",
+          "Registered Investment Advisors",
+          "Securities-Based Loans",
+          "Business Development",
+          "Risk Management",
+          "Series 7",
+          "Series 63",
+          "SIE",
+          "Collateral Management",
+          "Credit Analysis",
+          "Loan Origination",
+          "Retail Banking"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "business-development-partnerships",
+        "location_structured": {
+          "city": "New York",
+          "state": "New York",
+          "country": "United States of America",
+          "formatted": "New York, New York, United States of America"
+        }
+      }
+    },
+    {
+      "jobId": "f6357a87-6877-4a5e-8371-4a95d507693c",
+      "title": "Senior Network Analyst",
+      "companySlug": "rbc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2430,
+          "outputTokens": 350,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2780,
+          "estimatedUsd": 0.001604,
+          "latencyMs": 2150,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Network Analyst",
+            "jobId": "f6357a87-6877-4a5e-8371-4a95d507693c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "RBC is seeking a Senior Network Analyst to join its SRE Network Operations team. The role focuses on providing technical support, incident management, and troubleshooting for RBC's wired, wireless, and SD-WAN infrastructure using industry-leading network management tools.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Cisco",
+          "Aruba",
+          "Silver Peak",
+          "ServiceNow",
+          "Python",
+          "Ansible",
+          "Infoblox",
+          "Wireshark",
+          "CA Spectrum",
+          "NetMRI",
+          "SecureCRT",
+          "nGenius",
+          "ClearPass Policy Manager",
+          "AirWave",
+          "Cisco DNAC",
+          "Cisco Viptela"
+        ],
+        "keywords": [
+          "SD-WAN",
+          "Network Operations",
+          "SRE",
+          "BGP",
+          "OSPF",
+          "MPLS",
+          "Wireless Network",
+          "Incident Management",
+          "CCNP",
+          "CCNA",
+          "CCIE",
+          "ITIL"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-platform-sre-devops",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "2c0ddecd-ae50-4e65-8a43-6e2c585416e3",
+      "title": "2026 CFO, Data Governance Summer Analyst (4 Months)",
+      "companySlug": "rbc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2341,
+          "outputTokens": 242,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2583,
+          "estimatedUsd": 0.0013073,
+          "latencyMs": 1638,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "2026 CFO, Data Governance Summer Analyst (4 Months)",
+            "jobId": "2c0ddecd-ae50-4e65-8a43-6e2c585416e3"
+          }
+        }
+      ],
+      "output": {
+        "summary": "RBC is seeking a Data Governance Summer Analyst for a 4-month co-op term within the Office of the CFO. The role supports data management, quality, and governance initiatives by maintaining data dictionaries, mapping data flows, and collaborating with technical and business stakeholders.",
+        "seniority_level": "intern",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Tableau"
+        ],
+        "keywords": [
+          "Data Governance",
+          "Data Management",
+          "Data Quality",
+          "Metadata",
+          "Data Dictionaries",
+          "Data Flows",
+          "Financial Data",
+          "Data Stewardship",
+          "Business Analytics",
+          "Information Management"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "data-analytics-bi",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "4a410d00-c43c-49c8-95b1-407cdfad1cee",
+      "title": "Senior Manager, External Communications &amp; Community Investment - 18-month contract - Tangerine",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2296,
+          "outputTokens": 189,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2485,
+          "estimatedUsd": 0.0011613,
+          "latencyMs": 1534,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Manager, External Communications &amp; Community Investment - 18-month contract - Tangerine",
+            "jobId": "4a410d00-c43c-49c8-95b1-407cdfad1cee"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is hiring a Senior Manager for External Communications & Community Investment on an 18-month contract. This role leads external communications, media relations, and corporate social responsibility (CSR) initiatives to strengthen Tangerine's brand and reputation.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "external communications",
+          "community investment",
+          "corporate social responsibility",
+          "media relations",
+          "crisis communications",
+          "reputational risk",
+          "public relations",
+          "stakeholder management",
+          "brand strategy",
+          "corporate affairs"
+        ],
+        "standardized_department": "Marketing",
+        "function_category": "marketing-product-brand",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "ecdfc114-788a-45ca-a90e-3b1631c33fb4",
+      "title": "Senior Database Administrator",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2286,
+          "outputTokens": 254,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2540,
+          "estimatedUsd": 0.0013208,
+          "latencyMs": 1775,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Database Administrator",
+            "jobId": "ecdfc114-788a-45ca-a90e-3b1631c33fb4"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is seeking a Senior Database Administrator to design, install, monitor, and performance-tune databases. This role is responsible for ensuring high availability, disaster recovery, and data integrity across Oracle, Redis, and GCP database environments.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Oracle",
+          "Redis",
+          "Qlik Replicate",
+          "AlloyDB",
+          "Google Cloud SQL",
+          "Terraform",
+          "GCP",
+          "SQL",
+          "Unix",
+          "Linux"
+        ],
+        "keywords": [
+          "database administration",
+          "disaster recovery",
+          "data migration",
+          "performance tuning",
+          "multi-tenant architecture",
+          "data encryption",
+          "NoSQL",
+          "in-memory data store",
+          "capacity management",
+          "database security"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-platform-sre-devops",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "6a5cba55-4879-4046-b5e8-4bc97d73e198",
+      "title": "Sr DevOps Specialist, Tools and Administration - Tangerine",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2287,
+          "outputTokens": 335,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2622,
+          "estimatedUsd": 0.0015236,
+          "latencyMs": 2322,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Sr DevOps Specialist, Tools and Administration - Tangerine",
+            "jobId": "6a5cba55-4879-4046-b5e8-4bc97d73e198"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is seeking a Senior DevOps Specialist to lead cloud migration, CI/CD pipeline automation, and DevOps tool administration for its Java-based enterprise applications. The role involves managing infrastructure for over 800 users, optimizing Google Cloud environments, and implementing robust release automation.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Google Cloud Platform",
+          "Kubernetes",
+          "Terraform",
+          "Jenkins",
+          "GitHub Actions",
+          "GitHub",
+          "Git",
+          "Artifactory",
+          "SonarQube",
+          "Crowd",
+          "Groovy",
+          "JavaScript",
+          "Bash",
+          "Java"
+        ],
+        "keywords": [
+          "DevOps",
+          "CI/CD",
+          "Cloud Migration",
+          "Infrastructure as Code",
+          "Release Automation",
+          "Containerization",
+          "Systems Administration",
+          "High Availability",
+          "Disaster Recovery",
+          "Application Modernization",
+          "AIOps",
+          "Scripting"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-platform-sre-devops",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "a9ad7dc0-9fe1-483e-bb62-712bc980ca5c",
+      "title": "Specialist, Derivatives Risk Remediation",
+      "companySlug": "wealthsimple",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2427,
+          "outputTokens": 236,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2663,
+          "estimatedUsd": 0.0013181,
+          "latencyMs": 2025,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Specialist, Derivatives Risk Remediation",
+            "jobId": "a9ad7dc0-9fe1-483e-bb62-712bc980ca5c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Wealthsimple is hiring a Specialist for its Derivative Risk Remediation team to monitor and mitigate retail derivative exposures. The role sits within Credit Risk Operations and involves executing option liquidations, managing margin requirements, and building risk monitoring tools.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Python",
+          "Oracle DB",
+          "ICE",
+          "FactSet",
+          "Preset",
+          "Apache Superset"
+        ],
+        "keywords": [
+          "derivatives operations",
+          "credit risk",
+          "margin operations",
+          "option strategies",
+          "option assignment",
+          "CIRO IDPC",
+          "risk remediation",
+          "market risk",
+          "regulatory compliance",
+          "collateral management",
+          "futures",
+          "corporate actions"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "risk-management",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "c1f15941-82a8-426c-933a-d2c7c42f2d9b",
+      "title": "Senior Analyst, Quantitative Research",
+      "companySlug": "wealthsimple",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2336,
+          "outputTokens": 242,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2578,
+          "estimatedUsd": 0.0013058,
+          "latencyMs": 1831,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Analyst, Quantitative Research",
+            "jobId": "c1f15941-82a8-426c-933a-d2c7c42f2d9b"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Wealthsimple is hiring a Senior Analyst, Quantitative Research to design, build, and validate portfolio optimization models, factor frameworks, and risk analytics. This role bridges quantitative research and production, collaborating with Engineering to operationalize models for a large retail client base.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Python",
+          "pandas",
+          "NumPy",
+          "statsmodels"
+        ],
+        "keywords": [
+          "quantitative research",
+          "portfolio optimization",
+          "factor investing",
+          "risk analytics",
+          "asset allocation",
+          "backtesting",
+          "financial time series",
+          "risk models",
+          "stress testing",
+          "wealth management"
+        ],
+        "standardized_department": "Product",
+        "function_category": "data-science",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "286a62b4-5991-4eb8-897d-819faae319e2",
+      "title": "Senior Software Developer, Ledger",
+      "companySlug": "wealthsimple",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-latest",
+          "modelServed": "gemini-flash-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2425,
+          "outputTokens": 257,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2682,
+          "estimatedUsd": 0.0013700000000000001,
+          "latencyMs": 1879,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Software Developer, Ledger",
+            "jobId": "286a62b4-5991-4eb8-897d-819faae319e2"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Wealthsimple is hiring a Senior Software Developer to own and evolve its core ledger infrastructure. The role involves designing high-throughput, double-entry accounting systems using Java and Kotlin in a microservices architecture, collaborating closely with Finance and Compliance teams.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Java",
+          "Kotlin",
+          "Kafka",
+          "React",
+          "Oracle EBS"
+        ],
+        "keywords": [
+          "ledger",
+          "double-entry accounting",
+          "relational databases",
+          "event-driven architecture",
+          "stream processing",
+          "event-sourced",
+          "append-only ledger",
+          "reconciliation",
+          "audit trails",
+          "compliance reporting",
+          "agentic workflows"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-backend",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    }
+  ]
+}

--- a/web/scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-cd6c3fc.json
+++ b/web/scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-cd6c3fc.json
@@ -1,0 +1,1392 @@
+{
+  "scenario": "extract-structure",
+  "mode": "baseline",
+  "variant": "default",
+  "gitSha": "cd6c3fc",
+  "generatedAt": "2026-05-30T22:09:40.672Z",
+  "fixtureFile": "/Users/tscheidt/fintech_insights/fintech_insights/web/scripts/fixtures/gemini-sample-jobs.json",
+  "fixtureCount": 24,
+  "processedCount": 24,
+  "totals": {
+    "calls": 24,
+    "inputTokens": 55700,
+    "outputTokens": 5880,
+    "cachedTokens": 0,
+    "totalTokens": 61580,
+    "estimatedUsd": 0.007922,
+    "avgLatencyMs": 1415
+  },
+  "byCallSite": {
+    "extractJobStructure": {
+      "calls": 24,
+      "inputTokens": 55700,
+      "outputTokens": 5880,
+      "totalTokens": 61580,
+      "estimatedUsd": 0.007922000000000002,
+      "avgLatencyMs": 1415,
+      "modelsServed": [
+        "gemini-flash-lite-latest"
+      ]
+    }
+  },
+  "perJob": [
+    {
+      "jobId": "645839c0-151d-4404-8d8f-940ea48f368a",
+      "title": "ServiceNow Engineer",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2430,
+          "outputTokens": 254,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2684,
+          "estimatedUsd": 0.00034460000000000003,
+          "latencyMs": 1535,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "ServiceNow Engineer",
+            "jobId": "645839c0-151d-4404-8d8f-940ea48f368a"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Equitable Bank is seeking a ServiceNow Engineer to join their Centre of Excellence. You will be responsible for designing, developing, and maintaining ServiceNow applications, workflows, and integrations to support the bank's digital banking operations.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "ServiceNow",
+          "JavaScript",
+          "HTML",
+          "CSS",
+          "REST",
+          "SOAP",
+          "XML",
+          "JSON"
+        ],
+        "keywords": [
+          "ServiceNow Development",
+          "Workflow Automation",
+          "System Integration",
+          "Application Design",
+          "Technical Support",
+          "Quality Assurance",
+          "Release Management",
+          "Business Requirements",
+          "Banking"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-platform-sre-devops",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "4aef361c-d770-4eef-8a5a-be0515eaf62d",
+      "title": "Senior Estates and Trust Coordinator",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2206,
+          "outputTokens": 208,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2414,
+          "estimatedUsd": 0.0003038,
+          "latencyMs": 1217,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Estates and Trust Coordinator",
+            "jobId": "4aef361c-d770-4eef-8a5a-be0515eaf62d"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Senior Estates and Trust Coordinator will oversee the administration of trust files, manage new business onboarding, and perform data analysis within CRM platforms. This role ensures compliance with service standards and supports internal leadership through quarterly and annual reporting.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Trust and Estates",
+          "CRM",
+          "Data Analysis",
+          "Compliance",
+          "Client Onboarding",
+          "Financial Services",
+          "Reporting",
+          "Administration",
+          "STEP Certificate"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "customer-operations",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "9af5a8d4-c15e-490c-b2a6-6f34d804e1b9",
+      "title": "Senior Backend Engineer (CARE Pod)",
+      "companySlug": "eq-bank",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2327,
+          "outputTokens": 236,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2563,
+          "estimatedUsd": 0.00032710000000000004,
+          "latencyMs": 1534,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Backend Engineer (CARE Pod)",
+            "jobId": "9af5a8d4-c15e-490c-b2a6-6f34d804e1b9"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Senior Backend Engineer will join the CARE Pod to build and productionize agentic workflows and back-office automation systems. The role focuses on creating observable, deterministic AI integrations and robust service contracts to support digital banking operations at Equitable Bank.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "agentic workflows",
+          "backend engineering",
+          "distributed systems",
+          "observability",
+          "API contracts",
+          "workflow orchestration",
+          "back-office automation",
+          "data privacy",
+          "service design",
+          "event-driven architecture",
+          "digital banking",
+          "regression testing"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-backend",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "5add9237-0247-4579-ba5f-38199b5dad8c",
+      "title": "Senior People Partner",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2444,
+          "outputTokens": 218,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2662,
+          "estimatedUsd": 0.00033160000000000004,
+          "latencyMs": 1333,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior People Partner",
+            "jobId": "5add9237-0247-4579-ba5f-38199b5dad8c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Senior People Partner to drive their People Enablement strategy. This role focuses on organizational design, performance management, and scaling HR operations using AI-integrated workflows within a remote-first, high-autonomy environment.",
+        "seniority_level": "senior",
+        "salary_min": 110000,
+        "salary_max": 160000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "BambooHR"
+        ],
+        "keywords": [
+          "People Enablement",
+          "HR Operations",
+          "Organizational Design",
+          "Performance Management",
+          "Compensation Strategy",
+          "Employee Lifecycle",
+          "Compliance",
+          "AI-integrated workflows"
+        ],
+        "standardized_department": "HR",
+        "function_category": "people-ops-hr",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "a67a3e67-354b-40dc-abfc-c10b6318bfe5",
+      "title": "Senior Manager, Financial Risk",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2338,
+          "outputTokens": 253,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2591,
+          "estimatedUsd": 0.000335,
+          "latencyMs": 1324,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Manager, Financial Risk",
+            "jobId": "a67a3e67-354b-40dc-abfc-c10b6318bfe5"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Senior Manager, Financial Risk Strategy & Analytics to lead credit risk modeling, stress testing, and liquidity risk management. This role bridges technical analytics with strategic leadership to ensure portfolio resilience and regulatory compliance.",
+        "seniority_level": "senior",
+        "salary_min": 150000,
+        "salary_max": 190000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "SQL",
+          "Python",
+          "SAS"
+        ],
+        "keywords": [
+          "Financial Risk Management",
+          "Retail Credit Risk",
+          "Loss Forecasting",
+          "IFRS 9",
+          "ECL",
+          "Stress Testing",
+          "Liquidity Risk",
+          "Market Risk",
+          "ALM",
+          "Capital Planning",
+          "Portfolio Monitoring",
+          "Anomaly Detection",
+          "Data Strategy"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "risk-management",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "e64cce30-4b02-42c6-83a3-a22cc989f667",
+      "title": "Director, Financial Risk",
+      "companySlug": "koho",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2313,
+          "outputTokens": 210,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2523,
+          "estimatedUsd": 0.0003153,
+          "latencyMs": 1205,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Director, Financial Risk",
+            "jobId": "e64cce30-4b02-42c6-83a3-a22cc989f667"
+          }
+        }
+      ],
+      "output": {
+        "summary": "KOHO is seeking a Director of Financial Risk to lead strategy, analytics, and governance for credit, market, and liquidity risk. This role involves managing cross-functional teams to oversee IFRS 9 provisioning, stress testing, and risk appetite frameworks.",
+        "seniority_level": "executive",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Financial Risk",
+          "Credit Risk",
+          "Market Risk",
+          "Liquidity Risk",
+          "IFRS 9",
+          "Stress Testing",
+          "Risk Appetite",
+          "Model Risk Management",
+          "Provisioning",
+          "Portfolio Monitoring",
+          "Data Stewardship",
+          "Capital Planning",
+          "Anomaly Detection",
+          "Governance"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "risk-management",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "025a033e-94e6-4dd5-97c2-d800ce743bb8",
+      "title": "Banking Advisor",
+      "companySlug": "bnc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2066,
+          "outputTokens": 230,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2296,
+          "estimatedUsd": 0.00029860000000000005,
+          "latencyMs": 1466,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Banking Advisor",
+            "jobId": "025a033e-94e6-4dd5-97c2-d800ce743bb8"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Banking Advisor will provide personalized financial advice to personal and small business clients at National Bank. The role focuses on investment, mortgage, and insurance solutions while ensuring compliance and high client satisfaction in a branch-based environment.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Personal Banking",
+          "Small Business Banking",
+          "Mutual Funds",
+          "Mortgage Lending",
+          "Insurance",
+          "Estate Planning",
+          "Financial Advisory",
+          "Compliance",
+          "Risk Management",
+          "Client Relations",
+          "Investment Services"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "account-management-customer-success",
+        "location_structured": {
+          "city": "Longueuil",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Longueuil, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "763200a2-89d6-4a37-83e8-eaa028abf273",
+      "title": "Banking Advisor Jobs for Indigenous People",
+      "companySlug": "bnc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2279,
+          "outputTokens": 264,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2543,
+          "estimatedUsd": 0.00033350000000000003,
+          "latencyMs": 1384,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Banking Advisor Jobs for Indigenous People",
+            "jobId": "763200a2-89d6-4a37-83e8-eaa028abf273"
+          }
+        }
+      ],
+      "output": {
+        "summary": "National Bank is seeking a Banking Advisor to provide personalized financial services, including investment and credit solutions, to clients. This role focuses on building lasting client relationships and requires a commitment to diversity and inclusion.",
+        "seniority_level": "junior",
+        "salary_min": 19,
+        "salary_max": 19,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "Personal Banking",
+          "Investments",
+          "Mutual Fund Representative",
+          "Credit",
+          "Mortgage Financing",
+          "Customer Relationship Management",
+          "Compliance",
+          "Risk Management",
+          "Advisory Services",
+          "Cash Management",
+          "Client Education",
+          "Diversity & Inclusion"
+        ],
+        "standardized_department": "Customer Success",
+        "function_category": "customer-support-cx",
+        "location_structured": {
+          "city": "Montreal",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Montreal, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "0dd79afa-9afa-47cd-90fb-fc0fc2c6a665",
+      "title": "Banking Advisor",
+      "companySlug": "bnc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2003,
+          "outputTokens": 205,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2208,
+          "estimatedUsd": 0.00028230000000000003,
+          "latencyMs": 1283,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Banking Advisor",
+            "jobId": "0dd79afa-9afa-47cd-90fb-fc0fc2c6a665"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Banking Advisor provides personalized financial services and transaction support to branch clients. This role focuses on building lasting relationships, resolving complex client needs, and ensuring adherence to compliance and risk management standards.",
+        "seniority_level": "junior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Personal Banking",
+          "Customer Service",
+          "Advisory Services",
+          "Compliance",
+          "Risk Management",
+          "Relationship Management",
+          "Financial Services",
+          "Digital Literacy"
+        ],
+        "standardized_department": "Support",
+        "function_category": "customer-support",
+        "location_structured": {
+          "city": "Sorel-Tracy",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Sorel-Tracy, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "9a297c56-b3ba-47fa-9393-01a4f3b1d951",
+      "title": "Sales Representative - Southgate Mall",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2386,
+          "outputTokens": 257,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2643,
+          "estimatedUsd": 0.00034140000000000006,
+          "latencyMs": 1419,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Sales Representative - Southgate Mall",
+            "jobId": "9a297c56-b3ba-47fa-9393-01a4f3b1d951"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is seeking a Sales Representative to drive customer acquisition for credit and money products at various retail and community activation events. This role involves direct consumer engagement, real-time performance tracking via the Neo App, and an uncapped commission-based compensation model.",
+        "seniority_level": "junior",
+        "salary_min": 74880,
+        "salary_max": 74880,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "Neo App"
+        ],
+        "keywords": [
+          "Direct Sales",
+          "Customer Acquisition",
+          "Retail Sales",
+          "Financial Products",
+          "Field Marketing",
+          "Lead Generation",
+          "Consumer Banking"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": {
+          "city": "Southgate Mall",
+          "state": "Alberta",
+          "country": "Canada",
+          "formatted": "Southgate Mall, Edmonton, Alberta, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "96a9b880-5540-42a4-b7ec-388280623af6",
+      "title": "Director, Marketing Analytics",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2345,
+          "outputTokens": 221,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2566,
+          "estimatedUsd": 0.0003229,
+          "latencyMs": 1475,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Director, Marketing Analytics",
+            "jobId": "96a9b880-5540-42a4-b7ec-388280623af6"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is seeking a Director of Marketing Analytics to build and lead their marketing analytics function. This role focuses on optimizing marketing spend through data-driven insights, attribution modeling, and cross-functional collaboration in a high-growth B2C fintech environment.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Snowflake"
+        ],
+        "keywords": [
+          "Marketing Analytics",
+          "Growth Analytics",
+          "B2C",
+          "Attribution",
+          "Customer Acquisition",
+          "Budget Allocation",
+          "Data Strategy",
+          "Consumer Tech"
+        ],
+        "standardized_department": "Marketing",
+        "function_category": "marketing-growth-performance",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "eb3e9b33-7ca4-4ed7-9b6d-3e46494280d0",
+      "title": " Représentant des ventes - Laval ",
+      "companySlug": "neo-financial",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2363,
+          "outputTokens": 245,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2608,
+          "estimatedUsd": 0.00033430000000000005,
+          "latencyMs": 1389,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": " Représentant des ventes - Laval ",
+            "jobId": "eb3e9b33-7ca4-4ed7-9b6d-3e46494280d0"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Neo Financial is seeking a motivated Sales Representative in Laval to drive customer acquisition for their credit card and Neo Money products. This role involves field-based promotional activities with a performance-based compensation structure including hourly pay and uncapped commissions.",
+        "seniority_level": "junior",
+        "salary_min": 20,
+        "salary_max": 36,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "Direct Sales",
+          "Customer Acquisition",
+          "Field Sales",
+          "Financial Products",
+          "Retail Sales",
+          "Promotional Events",
+          "Credit Cards",
+          "Neo Money"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "sales-account-executives",
+        "location_structured": {
+          "city": "Laval",
+          "state": "Quebec",
+          "country": "Canada",
+          "formatted": "Laval, Quebec, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "492f71bc-ab2d-447e-a076-5affe0038756",
+      "title": "Third Party Risk and Vendor Management Officer",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2336,
+          "outputTokens": 264,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2600,
+          "estimatedUsd": 0.0003392,
+          "latencyMs": 1366,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Third Party Risk and Vendor Management Officer",
+            "jobId": "492f71bc-ab2d-447e-a076-5affe0038756"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade Financial Group is seeking a Third Party Risk and Vendor Management Officer to support the development and execution of a centralized TPRM framework. This role involves managing vendor risk assessments, ensuring regulatory compliance with OSFI B-10, and bridging business needs with technical platform requirements.",
+        "seniority_level": "mid",
+        "salary_min": 70000,
+        "salary_max": 95000,
+        "salary_currency": "CAD",
+        "tech_stack": [],
+        "keywords": [
+          "Third Party Risk Management",
+          "Vendor Management",
+          "OSFI B-10",
+          "Risk Frameworks",
+          "Regulatory Compliance",
+          "Due Diligence",
+          "Risk Assessment",
+          "Vendor Review",
+          "Business Analysis",
+          "Stakeholder Management"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "risk-management",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "Canada"
+        }
+      }
+    },
+    {
+      "jobId": "afb62032-c97d-492f-a9f2-fbbcd65dc103",
+      "title": "Analyst, Mutual Fund, Security Master and Physical Securities (Contract)",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2399,
+          "outputTokens": 297,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2696,
+          "estimatedUsd": 0.00035870000000000005,
+          "latencyMs": 1704,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Analyst, Mutual Fund, Security Master and Physical Securities (Contract)",
+            "jobId": "afb62032-c97d-492f-a9f2-fbbcd65dc103"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questrade is seeking a contract Analyst to manage mutual fund clearing, security master maintenance, and physical securities processing. The role involves reconciling trade breaks, managing precious metals administration, and coordinating with third-party depositories like CDS and DTC.",
+        "seniority_level": "mid",
+        "salary_min": 60000,
+        "salary_max": 65000,
+        "salary_currency": "CAD",
+        "tech_stack": [
+          "Broadridge",
+          "Fundserv"
+        ],
+        "keywords": [
+          "Mutual Funds",
+          "Security Master",
+          "Clearing and Settlement",
+          "Reconciliation",
+          "Physical Securities",
+          "Precious Metals",
+          "GIC",
+          "Exempt Market Products",
+          "CDS",
+          "DTC",
+          "APEX",
+          "DRS",
+          "DWAC",
+          "Back Office Operations"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "customer-operations",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "7ddca5ee-2708-4120-a8b9-fa703115d899",
+      "title": "Head of Marketing - Questbank",
+      "companySlug": "questrade",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2290,
+          "outputTokens": 216,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2506,
+          "estimatedUsd": 0.0003154,
+          "latencyMs": 1281,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Head of Marketing - Questbank",
+            "jobId": "7ddca5ee-2708-4120-a8b9-fa703115d899"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Questbank is seeking a Head of Marketing to lead B2B growth strategies, focusing on third-party distribution channels and intermediary networks. This strategic role involves managing marketing budgets, driving customer acquisition, and overseeing the rollout of B2B digital platforms.",
+        "seniority_level": "executive",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "B2B marketing",
+          "go-to-market strategy",
+          "growth marketing",
+          "customer acquisition",
+          "lifecycle marketing",
+          "marketing automation",
+          "financial services",
+          "mortgage industry",
+          "banking",
+          "brand positioning",
+          "ROI analysis",
+          "regulatory compliance",
+          "stakeholder management",
+          "partner management"
+        ],
+        "standardized_department": "Marketing",
+        "function_category": "marketing-product-brand",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "70658554-12d3-4e79-884d-b98cec3fa40a",
+      "title": "Clearing & Custody Wealth Management Banker",
+      "companySlug": "rbc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2347,
+          "outputTokens": 293,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2640,
+          "estimatedUsd": 0.00035190000000000004,
+          "latencyMs": 1480,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Clearing & Custody Wealth Management Banker",
+            "jobId": "70658554-12d3-4e79-884d-b98cec3fa40a"
+          }
+        }
+      ],
+      "output": {
+        "summary": "RBC is seeking a sales professional to drive banking and lending solutions within the Clearing & Custody channel. The role focuses on business development with Broker-Dealers and RIAs, managing product adoption, and ensuring compliance in cash management and securities-based lending.",
+        "seniority_level": "senior",
+        "salary_min": 90000,
+        "salary_max": 200000,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "Wealth Management",
+          "Clearing & Custody",
+          "Broker-Dealer",
+          "Registered Investment Advisor",
+          "Securities-Based Lending",
+          "Cash Management",
+          "Business Development",
+          "Series 7",
+          "Series 63",
+          "SIE",
+          "Risk Management",
+          "Compliance"
+        ],
+        "standardized_department": "Sales",
+        "function_category": "business-development-partnerships",
+        "location_structured": {
+          "city": "New York",
+          "state": "New York",
+          "country": "United States of America",
+          "formatted": "New York, New York, United States of America"
+        }
+      }
+    },
+    {
+      "jobId": "f6357a87-6877-4a5e-8371-4a95d507693c",
+      "title": "Senior Network Analyst",
+      "companySlug": "rbc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2430,
+          "outputTokens": 331,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2761,
+          "estimatedUsd": 0.0003754,
+          "latencyMs": 1490,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Network Analyst",
+            "jobId": "f6357a87-6877-4a5e-8371-4a95d507693c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Senior Network Analyst will join the SRE Network Operations team to support, triage, and maintain enterprise wired and wireless network infrastructure. The role involves incident management, implementation planning, and troubleshooting for a large-scale financial services environment.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Cisco",
+          "Aruba",
+          "Silver Peak",
+          "ServiceNow",
+          "CA Spectrum",
+          "NetMRI",
+          "Infoblox",
+          "NetScout nGenius",
+          "Wireshark",
+          "Python",
+          "Ansible",
+          "Cisco DNAC",
+          "Cisco Viptela"
+        ],
+        "keywords": [
+          "Network Operations",
+          "SRE",
+          "SD-WAN",
+          "Incident Management",
+          "Routing",
+          "Switching",
+          "Wireless",
+          "BGP",
+          "OSPF",
+          "MPLS",
+          "VPLS",
+          "Automation",
+          "Production Support"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-platform-sre-devops",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "2c0ddecd-ae50-4e65-8a43-6e2c585416e3",
+      "title": "2026 CFO, Data Governance Summer Analyst (4 Months)",
+      "companySlug": "rbc",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2341,
+          "outputTokens": 225,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2566,
+          "estimatedUsd": 0.0003241,
+          "latencyMs": 1377,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "2026 CFO, Data Governance Summer Analyst (4 Months)",
+            "jobId": "2c0ddecd-ae50-4e65-8a43-6e2c585416e3"
+          }
+        }
+      ],
+      "output": {
+        "summary": "RBC is seeking a Data Governance Summer Analyst to support data management, quality, and governance initiatives. The role involves maintaining data dictionaries, mapping data flows, and collaborating with technical teams to ensure financial data accuracy.",
+        "seniority_level": "intern",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Tableau"
+        ],
+        "keywords": [
+          "Data Governance",
+          "Data Management",
+          "Data Quality",
+          "Metadata",
+          "Data Stewardship",
+          "Financial Statement Analysis",
+          "Data Dictionaries",
+          "Data Flows",
+          "Requirements Analysis"
+        ],
+        "standardized_department": "Finance",
+        "function_category": "data-analytics-bi",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "4a410d00-c43c-49c8-95b1-407cdfad1cee",
+      "title": "Senior Manager, External Communications &amp; Community Investment - 18-month contract - Tangerine",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2296,
+          "outputTokens": 200,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2496,
+          "estimatedUsd": 0.0003096,
+          "latencyMs": 1331,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Manager, External Communications &amp; Community Investment - 18-month contract - Tangerine",
+            "jobId": "4a410d00-c43c-49c8-95b1-407cdfad1cee"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is seeking a Senior Manager for an 18-month contract to lead external communications and community investment. This role focuses on driving brand reputation, media relations, crisis management, and CSR initiatives aligned with the bank's Project Forward mandate.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [],
+        "keywords": [
+          "external communications",
+          "corporate social responsibility",
+          "media relations",
+          "reputation management",
+          "crisis communications",
+          "community investment",
+          "stakeholder management",
+          "brand strategy",
+          "thought leadership",
+          "project management",
+          "CSR",
+          "public relations"
+        ],
+        "standardized_department": "Marketing",
+        "function_category": "marketing-product-brand",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "ecdfc114-788a-45ca-a90e-3b1631c33fb4",
+      "title": "Senior Database Administrator",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2286,
+          "outputTokens": 255,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2541,
+          "estimatedUsd": 0.0003306,
+          "latencyMs": 1753,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Database Administrator",
+            "jobId": "ecdfc114-788a-45ca-a90e-3b1631c33fb4"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Senior Database Administrator will design, maintain, and optimize database systems to ensure high availability and performance. This role focuses on Oracle database administration, disaster recovery, and supporting infrastructure projects within a collaborative IT environment.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Oracle",
+          "Redis",
+          "GCP",
+          "AlloyDB",
+          "Cloud SQL",
+          "Qlik Replicate",
+          "Terraform",
+          "Linux",
+          "Unix"
+        ],
+        "keywords": [
+          "Database Administration",
+          "Disaster Recovery",
+          "Performance Tuning",
+          "High Availability",
+          "Data Migration",
+          "Capacity Management",
+          "SQL",
+          "Database Architecture",
+          "Encryption",
+          "TDE",
+          "RMAN",
+          "Data Guard",
+          "Multi-tenant Architecture"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-platform-sre-devops",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "6a5cba55-4879-4046-b5e8-4bc97d73e198",
+      "title": "Sr DevOps Specialist, Tools and Administration - Tangerine",
+      "companySlug": "tangerine",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2287,
+          "outputTokens": 294,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2581,
+          "estimatedUsd": 0.0003463,
+          "latencyMs": 1526,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Sr DevOps Specialist, Tools and Administration - Tangerine",
+            "jobId": "6a5cba55-4879-4046-b5e8-4bc97d73e198"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Tangerine is seeking a Senior DevOps Specialist to lead cloud migration and CI/CD pipeline optimization for Java-based enterprise applications. The role focuses on managing DevOps tooling, Kubernetes infrastructure, and automating deployment processes within a Google Cloud environment.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Google Cloud",
+          "Kubernetes",
+          "Jenkins",
+          "Terraform",
+          "GitHub",
+          "GitHub Actions",
+          "SonarQube",
+          "Artifactory",
+          "Groovy",
+          "JavaScript",
+          "Bash"
+        ],
+        "keywords": [
+          "DevOps",
+          "CI/CD",
+          "Cloud Migration",
+          "Application Modernization",
+          "Infrastructure as Code",
+          "High Availability",
+          "Disaster Recovery",
+          "Java",
+          "Automation",
+          "Platform Engineering"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-platform-sre-devops",
+        "location_structured": {
+          "city": "Toronto",
+          "state": "Ontario",
+          "country": "Canada",
+          "formatted": "Toronto, Ontario, Canada"
+        }
+      }
+    },
+    {
+      "jobId": "a9ad7dc0-9fe1-483e-bb62-712bc980ca5c",
+      "title": "Specialist, Derivatives Risk Remediation",
+      "companySlug": "wealthsimple",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2427,
+          "outputTokens": 221,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2648,
+          "estimatedUsd": 0.00033109999999999997,
+          "latencyMs": 1254,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Specialist, Derivatives Risk Remediation",
+            "jobId": "a9ad7dc0-9fe1-483e-bb62-712bc980ca5c"
+          }
+        }
+      ],
+      "output": {
+        "summary": "The Derivative Risk Remediation Specialist will monitor and remediate retail derivative exposures, manage option liquidations, and maintain risk-tracking tools. This role requires deep knowledge of CIRO margin rules and the ability to build automated monitoring solutions using SQL and Python.",
+        "seniority_level": "mid",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "SQL",
+          "Python",
+          "Oracle DB",
+          "Apache Superset",
+          "FactSet",
+          "ICE"
+        ],
+        "keywords": [
+          "derivatives",
+          "risk management",
+          "margin operations",
+          "CIRO",
+          "option strategies",
+          "regulatory compliance",
+          "reconciliation",
+          "trading support",
+          "collateral management",
+          "data visualization"
+        ],
+        "standardized_department": "Operations",
+        "function_category": "risk-management",
+        "location_structured": null
+      }
+    },
+    {
+      "jobId": "c1f15941-82a8-426c-933a-d2c7c42f2d9b",
+      "title": "Senior Analyst, Quantitative Research",
+      "companySlug": "wealthsimple",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2336,
+          "outputTokens": 250,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2586,
+          "estimatedUsd": 0.00033360000000000003,
+          "latencyMs": 1406,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Analyst, Quantitative Research",
+            "jobId": "c1f15941-82a8-426c-933a-d2c7c42f2d9b"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Wealthsimple is seeking a Senior Quantitative Research Analyst to design and validate portfolio optimization models and risk analytics. You will bridge the gap between academic research and production, collaborating with engineering to manage retail client portfolios at scale.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Python",
+          "pandas",
+          "NumPy",
+          "statsmodels"
+        ],
+        "keywords": [
+          "portfolio optimization",
+          "factor investing",
+          "risk analytics",
+          "financial time series",
+          "asset allocation",
+          "quantitative finance",
+          "backtesting",
+          "stress testing",
+          "linear algebra",
+          "statistics",
+          "wealth management",
+          "retail investment"
+        ],
+        "standardized_department": "Product",
+        "function_category": "data-science",
+        "location_structured": {
+          "city": null,
+          "state": null,
+          "country": "Canada",
+          "formatted": "North America (Remote/Hybrid)"
+        }
+      }
+    },
+    {
+      "jobId": "286a62b4-5991-4eb8-897d-819faae319e2",
+      "title": "Senior Software Developer, Ledger",
+      "companySlug": "wealthsimple",
+      "calls": [
+        {
+          "callSite": "extractJobStructure",
+          "modelRequested": "gemini-flash-lite-latest",
+          "modelServed": "gemini-flash-lite-latest",
+          "groundingEnabled": false,
+          "inputTokens": 2425,
+          "outputTokens": 233,
+          "cachedTokens": 0,
+          "thoughtsTokens": 0,
+          "totalTokens": 2658,
+          "estimatedUsd": 0.00033570000000000003,
+          "latencyMs": 1435,
+          "status": "ok",
+          "extra": {
+            "retryCount": 0,
+            "jobTitle": "Senior Software Developer, Ledger",
+            "jobId": "286a62b4-5991-4eb8-897d-819faae319e2"
+          }
+        }
+      ],
+      "output": {
+        "summary": "Wealthsimple is seeking a Senior Software Developer to own and evolve core ledger infrastructure. The role focuses on building high-correctness, auditable financial systems using Java/Kotlin and microservices to ensure strong consistency in transaction processing.",
+        "seniority_level": "senior",
+        "salary_min": null,
+        "salary_max": null,
+        "salary_currency": "USD",
+        "tech_stack": [
+          "Java",
+          "Kotlin",
+          "SQL",
+          "React",
+          "Kafka",
+          "Oracle EBS"
+        ],
+        "keywords": [
+          "ledger",
+          "double-entry accounting",
+          "financial infrastructure",
+          "transaction processing",
+          "distributed systems",
+          "compliance",
+          "audit trails",
+          "reconciliation",
+          "event-driven architecture",
+          "stream processing",
+          "agentic workflows",
+          "intelligent automation",
+          "regulatory reporting"
+        ],
+        "standardized_department": "Engineering",
+        "function_category": "engineering-backend",
+        "location_structured": null
+      }
+    }
+  ]
+}

--- a/web/scripts/artifacts/diff-extract-cd6c3fc.json
+++ b/web/scripts/artifacts/diff-extract-cd6c3fc.json
@@ -1,0 +1,600 @@
+{
+  "baseline": {
+    "path": "scripts/artifacts/baseline-extract-structure-cd6c3fc.json",
+    "model": "gemini-flash-latest",
+    "totals": {
+      "calls": 24,
+      "inputTokens": 55700,
+      "outputTokens": 6083,
+      "cachedTokens": 0,
+      "totalTokens": 61783,
+      "estimatedUsd": 0.031918,
+      "avgLatencyMs": 1839
+    },
+    "processedCount": 24
+  },
+  "candidate": {
+    "path": "scripts/artifacts/baseline-extract-structure-gemini-flash-lite-latest-cd6c3fc.json",
+    "model": "gemini-flash-lite-latest",
+    "totals": {
+      "calls": 24,
+      "inputTokens": 55700,
+      "outputTokens": 5880,
+      "cachedTokens": 0,
+      "totalTokens": 61580,
+      "estimatedUsd": 0.007922,
+      "avgLatencyMs": 1415
+    },
+    "processedCount": 24
+  },
+  "commonJobs": 24,
+  "stats": {
+    "function_category": {
+      "match": 20,
+      "total": 24
+    },
+    "seniority_level": {
+      "match": 23,
+      "total": 24
+    },
+    "standardized_department": {
+      "match": 23,
+      "total": 24
+    },
+    "tech_stack_jaccard_sum": 21.19029793735676,
+    "tech_stack_pairs": 24,
+    "keywords_jaccard_sum": 10.17556731624069,
+    "keywords_pairs": 24
+  },
+  "partial": {
+    "baselineNullOutputs": 0,
+    "candidateNullOutputs": 0,
+    "baselineRetries": 0,
+    "candidateRetries": 0,
+    "baselineMissingCategory": 0,
+    "candidateMissingCategory": 0
+  },
+  "cost": {
+    "deltaUsd": -0.023996,
+    "percentChange": -75.18
+  },
+  "latency": {
+    "deltaMs": -424,
+    "percentChange": -23.1
+  },
+  "acceptance": {
+    "l1AgreementGte95": false,
+    "partialExtractionNotWorse": true,
+    "overall": false
+  },
+  "perJobDiffs": [
+    {
+      "jobId": "645839c0-151d-4404-8d8f-940ea48f368a",
+      "title": "ServiceNow Engineer",
+      "companySlug": "eq-bank",
+      "function_category": {
+        "baseline": "it-internal-systems",
+        "candidate": "engineering-platform-sre-devops",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Engineering",
+        "candidate": "Engineering",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.19
+    },
+    {
+      "jobId": "4aef361c-d770-4eef-8a5a-be0515eaf62d",
+      "title": "Senior Estates and Trust Coordinator",
+      "companySlug": "eq-bank",
+      "function_category": {
+        "baseline": "business-operations",
+        "candidate": "customer-operations",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.6
+    },
+    {
+      "jobId": "9af5a8d4-c15e-490c-b2a6-6f34d804e1b9",
+      "title": "Senior Backend Engineer (CARE Pod)",
+      "companySlug": "eq-bank",
+      "function_category": {
+        "baseline": "engineering-backend",
+        "candidate": "engineering-backend",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Engineering",
+        "candidate": "Engineering",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.28
+    },
+    {
+      "jobId": "5add9237-0247-4579-ba5f-38199b5dad8c",
+      "title": "Senior People Partner",
+      "companySlug": "koho",
+      "function_category": {
+        "baseline": "people-ops-hr",
+        "candidate": "people-ops-hr",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "HR",
+        "candidate": "HR",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.29
+    },
+    {
+      "jobId": "a67a3e67-354b-40dc-abfc-c10b6318bfe5",
+      "title": "Senior Manager, Financial Risk",
+      "companySlug": "koho",
+      "function_category": {
+        "baseline": "risk-management",
+        "candidate": "risk-management",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Finance",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.44
+    },
+    {
+      "jobId": "e64cce30-4b02-42c6-83a3-a22cc989f667",
+      "title": "Director, Financial Risk",
+      "companySlug": "koho",
+      "function_category": {
+        "baseline": "risk-management",
+        "candidate": "risk-management",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "executive",
+        "candidate": "executive",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Finance",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.5
+    },
+    {
+      "jobId": "025a033e-94e6-4dd5-97c2-d800ce743bb8",
+      "title": "Banking Advisor",
+      "companySlug": "bnc",
+      "function_category": {
+        "baseline": "sales-account-executives",
+        "candidate": "account-management-customer-success",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.47
+    },
+    {
+      "jobId": "763200a2-89d6-4a37-83e8-eaa028abf273",
+      "title": "Banking Advisor Jobs for Indigenous People",
+      "companySlug": "bnc",
+      "function_category": {
+        "baseline": "customer-support-cx",
+        "candidate": "customer-support-cx",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "junior",
+        "candidate": "junior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Support",
+        "candidate": "Customer Success",
+        "match": false
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.57
+    },
+    {
+      "jobId": "0dd79afa-9afa-47cd-90fb-fc0fc2c6a665",
+      "title": "Banking Advisor",
+      "companySlug": "bnc",
+      "function_category": {
+        "baseline": "customer-support-cx",
+        "candidate": "customer-support",
+        "match": false
+      },
+      "seniority_level": {
+        "baseline": "junior",
+        "candidate": "junior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Support",
+        "candidate": "Support",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.5
+    },
+    {
+      "jobId": "9a297c56-b3ba-47fa-9393-01a4f3b1d951",
+      "title": "Sales Representative - Southgate Mall",
+      "companySlug": "neo-financial",
+      "function_category": {
+        "baseline": "sales-account-executives",
+        "candidate": "sales-account-executives",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "junior",
+        "candidate": "junior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 0,
+      "keywords_jaccard": 0.27
+    },
+    {
+      "jobId": "96a9b880-5540-42a4-b7ec-388280623af6",
+      "title": "Director, Marketing Analytics",
+      "companySlug": "neo-financial",
+      "function_category": {
+        "baseline": "marketing-growth-performance",
+        "candidate": "marketing-growth-performance",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "executive",
+        "candidate": "senior",
+        "match": false
+      },
+      "standardized_department": {
+        "baseline": "Marketing",
+        "candidate": "Marketing",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.55
+    },
+    {
+      "jobId": "eb3e9b33-7ca4-4ed7-9b6d-3e46494280d0",
+      "title": " Représentant des ventes - Laval ",
+      "companySlug": "neo-financial",
+      "function_category": {
+        "baseline": "sales-account-executives",
+        "candidate": "sales-account-executives",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "junior",
+        "candidate": "junior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.56
+    },
+    {
+      "jobId": "492f71bc-ab2d-447e-a076-5affe0038756",
+      "title": "Third Party Risk and Vendor Management Officer",
+      "companySlug": "questrade",
+      "function_category": {
+        "baseline": "risk-management",
+        "candidate": "risk-management",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.43
+    },
+    {
+      "jobId": "afb62032-c97d-492f-a9f2-fbbcd65dc103",
+      "title": "Analyst, Mutual Fund, Security Master and Physical Securities (Contract)",
+      "companySlug": "questrade",
+      "function_category": {
+        "baseline": "customer-operations",
+        "candidate": "customer-operations",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.4,
+      "keywords_jaccard": 0.42
+    },
+    {
+      "jobId": "7ddca5ee-2708-4120-a8b9-fa703115d899",
+      "title": "Head of Marketing - Questbank",
+      "companySlug": "questrade",
+      "function_category": {
+        "baseline": "marketing-product-brand",
+        "candidate": "marketing-product-brand",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "executive",
+        "candidate": "executive",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Marketing",
+        "candidate": "Marketing",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.2
+    },
+    {
+      "jobId": "70658554-12d3-4e79-884d-b98cec3fa40a",
+      "title": "Clearing & Custody Wealth Management Banker",
+      "companySlug": "rbc",
+      "function_category": {
+        "baseline": "business-development-partnerships",
+        "candidate": "business-development-partnerships",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Sales",
+        "candidate": "Sales",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.35
+    },
+    {
+      "jobId": "f6357a87-6877-4a5e-8371-4a95d507693c",
+      "title": "Senior Network Analyst",
+      "companySlug": "rbc",
+      "function_category": {
+        "baseline": "engineering-platform-sre-devops",
+        "candidate": "engineering-platform-sre-devops",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Engineering",
+        "candidate": "Engineering",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.71,
+      "keywords_jaccard": 0.39
+    },
+    {
+      "jobId": "2c0ddecd-ae50-4e65-8a43-6e2c585416e3",
+      "title": "2026 CFO, Data Governance Summer Analyst (4 Months)",
+      "companySlug": "rbc",
+      "function_category": {
+        "baseline": "data-analytics-bi",
+        "candidate": "data-analytics-bi",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "intern",
+        "candidate": "intern",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Finance",
+        "candidate": "Finance",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.58
+    },
+    {
+      "jobId": "4a410d00-c43c-49c8-95b1-407cdfad1cee",
+      "title": "Senior Manager, External Communications &amp; Community Investment - 18-month contract - Tangerine",
+      "companySlug": "tangerine",
+      "function_category": {
+        "baseline": "marketing-product-brand",
+        "candidate": "marketing-product-brand",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Marketing",
+        "candidate": "Marketing",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.57
+    },
+    {
+      "jobId": "ecdfc114-788a-45ca-a90e-3b1631c33fb4",
+      "title": "Senior Database Administrator",
+      "companySlug": "tangerine",
+      "function_category": {
+        "baseline": "engineering-platform-sre-devops",
+        "candidate": "engineering-platform-sre-devops",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Engineering",
+        "candidate": "Engineering",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.73,
+      "keywords_jaccard": 0.35
+    },
+    {
+      "jobId": "6a5cba55-4879-4046-b5e8-4bc97d73e198",
+      "title": "Sr DevOps Specialist, Tools and Administration - Tangerine",
+      "companySlug": "tangerine",
+      "function_category": {
+        "baseline": "engineering-platform-sre-devops",
+        "candidate": "engineering-platform-sre-devops",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Engineering",
+        "candidate": "Engineering",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.67,
+      "keywords_jaccard": 0.47
+    },
+    {
+      "jobId": "a9ad7dc0-9fe1-483e-bb62-712bc980ca5c",
+      "title": "Specialist, Derivatives Risk Remediation",
+      "companySlug": "wealthsimple",
+      "function_category": {
+        "baseline": "risk-management",
+        "candidate": "risk-management",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "mid",
+        "candidate": "mid",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Operations",
+        "candidate": "Operations",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.86,
+      "keywords_jaccard": 0.22
+    },
+    {
+      "jobId": "c1f15941-82a8-426c-933a-d2c7c42f2d9b",
+      "title": "Senior Analyst, Quantitative Research",
+      "companySlug": "wealthsimple",
+      "function_category": {
+        "baseline": "data-science",
+        "candidate": "data-science",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Product",
+        "candidate": "Product",
+        "match": true
+      },
+      "tech_stack_jaccard": 1,
+      "keywords_jaccard": 0.57
+    },
+    {
+      "jobId": "286a62b4-5991-4eb8-897d-819faae319e2",
+      "title": "Senior Software Developer, Ledger",
+      "companySlug": "wealthsimple",
+      "function_category": {
+        "baseline": "engineering-backend",
+        "candidate": "engineering-backend",
+        "match": true
+      },
+      "seniority_level": {
+        "baseline": "senior",
+        "candidate": "senior",
+        "match": true
+      },
+      "standardized_department": {
+        "baseline": "Engineering",
+        "candidate": "Engineering",
+        "match": true
+      },
+      "tech_stack_jaccard": 0.83,
+      "keywords_jaccard": 0.41
+    }
+  ]
+}

--- a/web/scripts/measure-hash-thrash.ts
+++ b/web/scripts/measure-hash-thrash.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env npx tsx
+/**
+ * measure-hash-thrash.ts — quantify description_hash thrash (READ-ONLY).
+ *
+ * The 2026-05 cost audit found ~88% of daily Gemini extractions were re-runs of
+ * EXISTING jobs whose scraped `description_text` churned the raw SHA-1 even when
+ * the substance was unchanged (volatile boilerplate: posting dates, applicant
+ * counts, requisition IDs, whitespace). `normalizeDescriptionForHash` (in
+ * `lib/jobs/processor.ts`) fingerprints the stable content instead.
+ *
+ * This script proves the win: it re-scrapes a company live and, per job,
+ * compares the RAW-hash flip rate (today's re-extraction trigger) against the
+ * NORMALIZED-hash flip rate (after the fix). The gap is the redundant Gemini
+ * spend the fix removes. Run it some time AFTER a daily collect so the stored
+ * text and the fresh scrape span a real interval.
+ *
+ * It writes NOTHING — safe to run against prod.
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local web/scripts/measure-hash-thrash.ts --company=<slug> [--limit=N]
+ *
+ * Only API-scraped companies (lever / greenhouse / workable / ashby) can be
+ * re-scraped locally. Browser-scraped incumbents (Workday / Phenom / Avature /
+ * Scotiabank) must be measured from the scrape-heavy GitHub Actions runner.
+ */
+
+import { createHash } from "node:crypto";
+import { createAdminClient } from "../lib/supabase/admin";
+import { fetchJobs, isBrowserScraper } from "../lib/scrapers";
+import { normalizeDescriptionForHash } from "../lib/jobs/processor";
+
+const sha1 = (s: string) => createHash("sha1").update(s).digest("hex");
+
+async function main() {
+  const slug = process.argv.find((a) => a.startsWith("--company="))?.split("=")[1];
+  const limitArg = process.argv.find((a) => a.startsWith("--limit="));
+  const limit = limitArg ? parseInt(limitArg.split("=")[1], 10) : 300;
+
+  if (!slug) {
+    console.error(
+      "Usage: npx tsx --env-file=.env.local web/scripts/measure-hash-thrash.ts --company=<slug> [--limit=N]"
+    );
+    console.error(
+      "API-scraped companies only (lever/greenhouse/workable/ashby); browser-scraped incumbents must run from the scrape-heavy workflow."
+    );
+    process.exit(1);
+  }
+
+  const supabase = createAdminClient();
+
+  const { data: company, error: cErr } = await supabase
+    .from("companies")
+    .select("id, slug, name, ats_type, ats_identifier, careers_url")
+    .eq("slug", slug)
+    .single();
+  if (cErr || !company) {
+    console.error(`Company '${slug}' not found: ${cErr?.message ?? "no row"}`);
+    process.exit(1);
+  }
+
+  if (isBrowserScraper(company.ats_type)) {
+    console.error(
+      `'${slug}' uses a browser scraper (${company.ats_type}) — can't re-scrape locally. ` +
+        "Run from the scrape-heavy GH Actions context or pick an API-scraped company."
+    );
+    process.exit(1);
+  }
+
+  // Current stored text + hash for active jobs (the baseline = last scrape).
+  const { data: stored, error: sErr } = await supabase
+    .from("job_postings")
+    .select("external_id, description_text, description_hash")
+    .eq("company_id", company.id)
+    .eq("is_active", true)
+    .limit(limit);
+  if (sErr) {
+    console.error(`stored fetch failed: ${sErr.message}`);
+    process.exit(1);
+  }
+  const storedByExt = new Map<string, string>();
+  for (const r of stored ?? []) storedByExt.set(r.external_id, r.description_text ?? "");
+
+  console.log(`Re-scraping ${company.name} (${company.ats_type}/${company.ats_identifier})…`);
+  const scraped = await fetchJobs(
+    company.ats_type,
+    company.ats_identifier,
+    company.careers_url ?? undefined
+  );
+
+  let matched = 0;
+  let rawFlips = 0;
+  let normFlips = 0;
+  for (const job of scraped) {
+    const oldText = storedByExt.get(job.external_id);
+    if (oldText === undefined) continue; // newly-seen job — nothing to compare against
+    const newText = job.description_text ?? "";
+    if (!oldText && !newText) continue;
+    matched++;
+    if (sha1(oldText) !== sha1(newText)) rawFlips++;
+    if (
+      sha1(normalizeDescriptionForHash(oldText)) !==
+      sha1(normalizeDescriptionForHash(newText))
+    ) {
+      normFlips++;
+    }
+  }
+
+  const pct = (n: number) => (matched ? `${((100 * n) / matched).toFixed(1)}%` : "n/a");
+  const eliminated = rawFlips - normFlips;
+  console.log("\n" + "=".repeat(64));
+  console.log(`  Company:           ${company.name} (${slug})`);
+  console.log(`  Matched jobs:      ${matched}`);
+  console.log(`  Raw-hash flips:    ${rawFlips} (${pct(rawFlips)})   <- triggers re-extraction today`);
+  console.log(`  Normalized flips:  ${normFlips} (${pct(normFlips)})   <- triggers re-extraction after the fix`);
+  console.log(`  Thrash eliminated: ${eliminated} (${pct(eliminated)} of matched) — Gemini extractions avoided`);
+  console.log("=".repeat(64));
+  console.log("Read-only: no rows were written.");
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Why

May Gemini spend spiked **+410%** ($178.75 GCP vs ~$35 in April). I attributed every dollar against `gemini_usage_events`. The diagnosis was counter-intuitive:

- The **spike was one-time** — onboarding the Big-6 banks (~8,200 jobs, May 22–25) forced a backlog of first-time extractions. It won't recur.
- The **recurring driver is `extractJobStructure` (Flash) — 66% of measured spend** ($43.50 of $66 in May). Not the grounded Pro calls.
- **~75% of each extraction call was wasted "thinking" tokens** on a mechanical JSON task.
- **~88% of daily extractions were re-runs of *unchanged* jobs** — volatile boilerplate (posting dates, applicant counts, req IDs) churned the raw SHA-1 hash.
- **Telemetry under-counts the real bill ~2.7×** ($66 vs $179), concentrated on the grounded Pro path — and the **$50/day cost alarm never paged during the spike** because it summed that under-count.
- Embeddings are effectively free ($0.11/mo) — ruled out.

## What changed

| WS | Change | Result |
|---|---|---|
| **WS1** | `extractJobStructure` sets `thinkingConfig.thinkingBudget=0` (+ one-shot degrade if a future alias rejects it) | **−72%/call**, harness-proven, **identical fields** |
| **WS3** | `description_hash` gate fingerprints `normalizeDescriptionForHash(text)`; legacy raw hashes bridge in-code on next scrape | skips the ~88% boilerplate re-runs — **no migration, no re-extraction spike** |
| **WS2** | `GROUNDING_CALIBRATION` knob (default 1, no-op) + multi-signal cost alarm (calibrated-USD / grounded-call-count / token-volume) | alarm no longer blind to under-counted spikes |
| **WS4** | Flash-Lite for extraction — **evaluated & REJECTED** by the ≥95% L1 gate | kept on `gemini-flash-latest` |
| **WS5** | Docs: AI_HYGIENE (cost reconciliation + cheaper-extraction + open-source decision), OBSERVABILITY/CLAUDE (multi-signal alarm), sub-CLAUDEs | — |

### Why not Flash-Lite, and not open-source (the questions raised in planning)
- **Flash-Lite** is ~4× cheaper but failed the gate: it disagreed with Flash on `function_category` (e.g. `it-internal-systems`→`engineering-platform-sre-devops`) and `seniority`, and degraded `tech_stack` Jaccard (powers the company tech panels). With WS1+WS3 already cutting extraction ~90%, the extra ~$2/mo wasn't worth misclassifying roles.
- **Open-source / non-Gemini** providers: the whole spread is ~$2–4/mo vs ~0.5–1.5 eng-days of integration + a second vendor in the hot path. Break-even is ~20–40× current volume; even then **Gemini batch mode (−50%, zero new vendor)** is the first lever. Documented in AI_HYGIENE.

## Mandatory gemini-compare report (extract-structure)

| Variant | per-call $ | thoughts residual | L1 gate |
|---|---|---|---|
| Flash, thinking ON (telemetry baseline) | ~$0.00440 | ~1,400 tok | — |
| **Flash, thinking OFF (this PR)** | **$0.00133** | **0** (total = in+out exactly) | same model |
| Flash-Lite (candidate) | $0.00033 | 0 | **FAIL** (function_category/seniority drift) |

Artifacts committed under `web/scripts/artifacts/` (`baseline-extract-structure-cd6c3fc.json`, `…-gemini-flash-lite-latest-cd6c3fc.json`, `diff-extract-cd6c3fc.json`).

## Verification
- `npx vitest run` (real source): **303 passing**, incl. new `cost-alarm-eval.test.ts` and the normalizer/gate-bridge tests in `processor.test.ts`.
- `npm run build`: clean (Vercel-strict TS).
- `web/scripts/measure-hash-thrash.ts` — read-only; run after a daily collect to quantify raw-flip% vs normalized-flip% before relying on the savings.

## Docs updated
- `docs/AI_HYGIENE.md`, `docs/OBSERVABILITY.md`, root `CLAUDE.md`, `web/lib/ai/CLAUDE.md`, `web/lib/analysis/CLAUDE.md`, `web/.env.example`, `web/data/releases.json` (v2.9.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)