### PR TITLE
fix(jobs): scope job search to active companies (v2.9.3)

### DIFF
--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.9.3",
+    "date": "2026-06-01",
+    "changes": [
+      { "type": "fix", "description": "The Jobs board no longer surfaces roles from companies we've deactivated. Search was matching on each posting's own open/closed status but ignoring whether we still cover the company, so a deactivated employer like Monzo could appear with dozens of \"active\" listings. Both semantic and keyword search now scope to active companies only, matching the \"companies we cover\" count." }
+    ]
+  },
+  {
     "version": "2.9.2",
     "date": "2026-05-31",
     "changes": [

--- a/web/lib/dashboard-queries.ts
+++ b/web/lib/dashboard-queries.ts
@@ -1244,6 +1244,7 @@ async function runSemanticJobSearch(
     .from("job_postings")
     .select(JOBS_LIST_SELECT)
     .in("companies.tier", tierList)
+    .eq("companies.is_active", true)
     .in("id", orderedIds);
   const statusValue = statusScopePredicate(status);
   if (statusValue !== null) hydrate = hydrate.eq("is_active", statusValue);
@@ -1397,6 +1398,7 @@ export async function getJobsListData(
     .from("job_postings")
     .select(JOBS_LIST_SELECT)
     .in("companies.tier", tierList)
+    .eq("companies.is_active", true)
     .order("first_seen_date", { ascending: false })
     .limit(limit);
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "2.1.0",
+  "version": "2.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "2.1.0",
+      "version": "2.9.3",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/supabase/migrations/20260601120000_jobs_semantic_active_company.sql
+++ b/web/supabase/migrations/20260601120000_jobs_semantic_active_company.sql
@@ -1,0 +1,35 @@
+-- Scope semantic job search to ACTIVE companies only. The original
+-- match_job_ids_semantic (20260529120000) filtered by company tier but not by
+-- companies.is_active, so jobs from a deactivated company (e.g. Monzo, whose
+-- job_postings rows are still job-level is_active=true) leaked into results.
+-- The Jobs board contract is "the companies we cover" = active companies, so an
+-- inactive company must never surface regardless of its jobs' own status.
+--
+-- Filtering here (not just in the hydrate query) also keeps the match_count
+-- candidate budget from being spent on rows we will immediately drop.
+--
+-- search_path is locked to '' (repo convention), so vector type/operator stay
+-- public-qualified. Body is otherwise unchanged from 20260529120000.
+CREATE OR REPLACE FUNCTION match_job_ids_semantic(
+  query_embedding vector(768),
+  tier_filter text[],
+  match_count int DEFAULT 1000
+)
+RETURNS TABLE (id uuid, distance double precision)
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM set_config('hnsw.ef_search', '250', true);
+  RETURN QUERY
+    SELECT jp.id, (jp.embedding OPERATOR(public.<=>) query_embedding) AS distance
+    FROM public.job_postings jp
+    JOIN public.companies c ON c.id = jp.company_id
+    WHERE jp.embedding IS NOT NULL
+      AND c.tier = ANY(tier_filter)
+      AND c.is_active = true
+    ORDER BY jp.embedding OPERATOR(public.<=>) query_embedding
+    LIMIT match_count;
+END;
+$$;


### PR DESCRIPTION
## Problem

The Jobs board surfaced roles from **deactivated** companies. Semantic search returned Monzo (screenshot from a user), and the same gap exists in keyword search.

Root cause: both search paths in `getJobsListData` filtered by company **tier** and by each posting's own `is_active` flag, but **never** by `companies.is_active`. A company can be deactivated while its `job_postings` rows stay `is_active=true`:

| company | company is_active | active jobs |
|---|---|---|
| Monzo | **false** | 51 |
| Revolut Canada | **false** | 0 |

So Monzo's 51 job-level-active postings leaked in. The page copy ("the 13 companies we cover") = the 13 *active* companies, confirming inactive companies should never appear.

## Fix

- **`match_job_ids_semantic` RPC** — add `AND c.is_active = true` so inactive companies don't consume the 1000-row candidate budget. New migration `20260601120000_jobs_semantic_active_company.sql`; **already applied to prod** (migrations aren't auto-applied by Vercel).
- **`getJobsListData`** — add `.eq("companies.is_active", true)` to both the semantic hydrate query and the keyword query.

## Verification

- `npm run build` passes.
- Post-fix candidate-set query for fintech tier returns only active companies (Monzo / Revolut Canada gone).

## Docs / changelog

- `web/data/releases.json` → v2.9.3 (fix); `package.json` bumped.
- No architecture/cron/AI/auth/schema doc impact (RPC behavior tightened, not restructured).

🤖 Generated with [Claude Code](https://claude.com/claude-code)