### PR TITLE
fix(ci): checkout before secret-validation in embeddings + editorial crons

### DIFF
--- a/.github/workflows/editorial-cron.yml
+++ b/.github/workflows/editorial-cron.yml
@@ -46,6 +46,12 @@ jobs:
       run:
         working-directory: ./web
     steps:
+      # Checkout MUST come first: the job-level `working-directory: ./web`
+      # default applies to every `run:` step, and ./web doesn't exist until the
+      # repo is checked out. A `run:` step before this fails with "No such file
+      # or directory" trying to start bash in ./web.
+      - uses: actions/checkout@v5
+
       - name: Validate required secrets
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -59,8 +65,6 @@ jobs:
               exit 1
             fi
           done
-
-      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v5
         with:

--- a/.github/workflows/embeddings-backfill-cron.yml
+++ b/.github/workflows/embeddings-backfill-cron.yml
@@ -29,6 +29,12 @@ jobs:
       run:
         working-directory: ./web
     steps:
+      # Checkout MUST come first: the job-level `working-directory: ./web`
+      # default applies to every `run:` step, and ./web doesn't exist until the
+      # repo is checked out. A `run:` step before this fails with "No such file
+      # or directory" trying to start bash in ./web.
+      - uses: actions/checkout@v5
+
       - name: Validate required secrets
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -42,8 +48,6 @@ jobs:
               exit 1
             fi
           done
-
-      - uses: actions/checkout@v5
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
## Symptom
The **Job Embeddings Backfill Cron** failed at its first step, *Validate required secrets*:
> An error occurred trying to start process '/usr/bin/bash' with working directory '.../​./web'. No such file or directory

The job died at step 1 — checkout and everything after showed `0s`/skipped.

## Cause (pre-existing workflow bug, not code)
Both `embeddings-backfill-cron.yml` and `editorial-cron.yml` set a **job-level** default:
```yaml
defaults:
  run:
    working-directory: ./web
```
That default applies to **every** `run:` step — including *Validate required secrets*, which was placed **before** `actions/checkout@v5`. Before checkout, `./web` doesn't exist on the runner, so bash can't even start there. The secret check doesn't touch the filesystem; it just couldn't launch in a missing cwd.

`editorial-cron.yml` (Mondays 11:00 UTC) has the identical structure and fails the same way. A scan confirmed these are the only two workflows with a `./web` default plus a pre-checkout `run:` step (`auto-implement.yml` already checks out first).

## Fix
Move `actions/checkout@v5` to be the **first** step in both workflows, so `./web` exists for every subsequent `run:` step. Added a comment to prevent regression. Verified both still parse and that checkout is now the first step.

## Not related to the active-company read-view work (#109)
This is independent CI plumbing — no app code, schema, or the embeddings script touched. Surfaced by the cron failure while reviewing #109. No changelog/version bump (not user-facing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)