### PR TITLE
fix(scrape): retry heavy ingest on statement/lock timeout (v2.9.5)

### DIFF
--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "2.9.5",
+    "date": "2026-06-03",
+    "changes": [
+      { "type": "fix", "description": "Large daily scrapes no longer get thrown away when the database is briefly busy. If a write during a big employer's ingest (e.g. Scotiabank's ~1,900 roles) is cancelled because another job is momentarily holding the same rows, the scraper now waits a moment and retries instead of discarding the whole run — the same resilience we already had for database restarts. A Scotiabank scrape was lost to exactly this on June 3." }
+    ]
+  },
+  {
     "version": "2.9.4",
     "date": "2026-06-01",
     "changes": [

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "web",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "web",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "dependencies": {
         "@google/generative-ai": "^0.24.1",
         "@radix-ui/react-dialog": "^1.1.15",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/scripts/scrape-heavy.ts
+++ b/web/scripts/scrape-heavy.ts
@@ -34,6 +34,18 @@ import type { Company } from "@/lib/jobs/types";
  * later. updateTaskProgress rethrows these wrapped in an Error whose message
  * still carries the "schema cache" / "PGRST002" text, so we match on both the
  * structured `.code` and the message string.
+ *
+ * We also treat Postgres statement/lock timeouts as transient. Supabase pins
+ * statement_timeout=8s (and lock_timeout=8s) on the API roles. During a heavy
+ * ingest the per-row writes run while a sibling writer — the 06:00 collect /
+ * analysis pass still touching the same company's rows — can hold a lock; a
+ * single write then blocks past 8s and is cancelled mid-flight (57014, or
+ * 55P03 if lock_timeout fires first). That killed the June 3 2026 Scotiabank
+ * ingest (1,859 jobs scraped + enriched, then discarded). The ingest is
+ * idempotent (upserts/updates by external id), so we ride out the contention
+ * window with backoff exactly like a restart, rather than throwing away the
+ * finished scrape. If a company times out every run, that's a systematic
+ * signal to batch the per-row writes — not something a retry should hide.
  */
 function isTransientDbError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
@@ -41,6 +53,7 @@ function isTransientDbError(err: unknown): boolean {
   const code = typeof e.code === "string" ? e.code : "";
   const msg = (typeof e.message === "string" ? e.message : "").toLowerCase();
   if (code === "PGRST002" || code === "PGRST001") return true;
+  if (code === "57014" || code === "55P03") return true; // statement_timeout / lock_not_available
   return (
     msg.includes("schema cache") ||
     msg.includes("pgrst002") ||
@@ -48,7 +61,10 @@ function isTransientDbError(err: unknown): boolean {
     msg.includes("not accepting connections") ||
     msg.includes("the database system is starting up") ||
     msg.includes("fetch failed") ||
-    msg.includes("connection reset")
+    msg.includes("connection reset") ||
+    msg.includes("statement timeout") ||
+    msg.includes("canceling statement due to") ||
+    msg.includes("lock timeout")
   );
 }
 


### PR DESCRIPTION
## Symptom
The June 3 06:30 UTC Scotiabank heavy scrape **succeeded** — fetched and enriched all 1,859 jobs — then died on the database write:
```
❌ Error during scraping: [object Object]
❌ Fatal error: { code: '57014', message: 'canceling statement due to statement timeout' }
```
The entire finished scrape was discarded; Scotiabank got no refresh that day.

## Root cause
`57014` = Postgres `statement_timeout`. Supabase pins **`statement_timeout=8s`** and **`lock_timeout=8s`** on the API roles (confirmed via `pg_roles`; `service_role` inherits the session value). The ingest writes ~1,859 jobs as **sequential per-row `UPDATE ... WHERE id = ?`** statements. A single-row PK update is sub-ms, so the 8s is a **lock wait**: a sibling writer — the 06:00 `collect`/analysis pass still touching the same Scotiabank rows — held a lock, and one ingest write blocked past 8s and was cancelled.

This is transient contention, not corruption, and `runIngestStage` is idempotent (upserts/updates by external id). But `isTransientDbError` only classified the Supabase-restart window (`PGRST002`/`PGRST001`, "fetch failed", …) as retryable — **not** Postgres timeouts — so the cancellation went straight to the fatal path that throws away the scrape.

## Fix
Add `57014` (statement_timeout) and `55P03` (lock_not_available), plus their message variants (`"statement timeout"`, `"canceling statement due to"`, `"lock timeout"`), to `isTransientDbError`. `withTransientRetry` then rides out the contention window with 1→32s backoff — the exact treatment the heavy scraper already gives a DB restart (v2.9.1).

Scoped deliberately: a genuine error (e.g. a `23505` duplicate-key) is **not** retried. A company that times out *every* run would still fail after the ~63s budget — so this rides out transient contention without hiding a systematic problem (the deeper fix there would be to batch the per-row writes into chunked upserts; noted as a follow-up, not done here to avoid touching the hot ingest path).

## Not related to the active-company work (#109) or the cron fix (#110)
Verified on prod: `job_postings` has **no custom triggers**, and `active_companies`/`active_job_postings` are plain `security_invoker` views with **no extra rules** — completely inert on the write path. The 8s timeout is a Supabase default that predates all of it. PR #110 is the unrelated cron checkout-ordering fix.

## Verification
- `tsc --noEmit` clean.
- Classifier validated against the exact logged error object (matches by `code` and by wrapped `message`); `55P03` matches; a non-transient `23505` correctly does not.
- (No unit test added: `scrape-heavy.ts` self-executes `main()` at import, so the helper isn't importable without refactoring the entry point — consistent with the repo's existing lack of tests for these script helpers.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)