### PR TITLE
fix(scrape): unblock big-bank ingests + stop canary false alarms (v2.9.6)

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -50,7 +50,7 @@ If you add a new outbound `resend.emails.send(...)` or `resend.batch.send(...)` 
 
 Outright scraper errors and zero-result wipes are already caught by [`web/lib/email/scraper-health.ts`](../web/lib/email/scraper-health.ts) at the end of every `/api/cron/collect` run (issue types `failed` and `empty`). Silent partial drops — the scraper still returns *some* jobs but is missing pagination or a careers-site section — used to slip through.
 
-The Phase-3 fragility canary closes that gap for `tier='incumbent'` companies. For each active incumbent at the end of `collect`, it computes:
+The Phase-3 fragility canary closes that gap for `tier='incumbent'` companies. For each active incumbent it computes:
 
 - `todayNewJobs` — new postings whose `first_seen_date` falls in the current UTC day.
 - `rollingAvg7d` — average new-postings per day over the 7 calendar days *before* today.
@@ -59,6 +59,8 @@ The canary fires for a bank when BOTH thresholds hold:
 
 - `todayNewJobs < 0.5 * rollingAvg7d` (a >50% day-over-day drop), AND
 - `rollingAvg7d > 5` (suppress the alert on banks with low baseline volume so a legitimately quiet day doesn't page).
+
+**Only incumbents whose scrape for the run has actually LANDED are evaluated** (`opts.evaluableCompanyIds` — the task is terminal `completed`/`failed`/`cancelled` and not already reported as a `failed`/`empty` issue). This matters because *every* incumbent is a heavy browser scraper offloaded to GitHub Actions, so its rows ingest minutes-to-an-hour *after* `collect` returns and the run is marked complete (`runner.ts` treats offloaded `running` tasks as non-blocking). Without the gate the canary races the offloaded scrapes and reads `0 new today` for every bank — exactly the false "6 incumbent scrapers" alert of June 2026, which was simultaneously *masking* three genuinely-dead scrapers (RBC empty, Scotia/TD `57014`/`520`). A genuinely-broken scraper still fires correctly: its task terminalizes (`completed` with 0 jobs, or `failed`) and `todayNewJobs` is 0. A scraper still `running` at the canary's last invocation that day is caught the next day (or via the `failed` issue path after the stale-task sweep).
 
 The pure threshold rule is `evaluateCanary({today, rolling}) → { fire, reason }` in [`web/lib/email/scraper-health.ts`](../web/lib/email/scraper-health.ts); it has unit tests in `scraper-health.test.ts`. Firing canaries are appended to the existing scraper-alert email under a "Scraper-break canary" section so admins don't get a second message. Failed canary detection logs a structured `log.error` but never blocks the rest of the scraper-health flow.
 

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "2.9.6",
+    "date": "2026-06-04",
+    "changes": [
+      { "type": "fix", "description": "The big-bank scrapers (RBC, Scotiabank, TD) no longer fail silently on the database write after a clean scrape. Each was fetching its full ~1,400–1,900-role corpus, then dying while saving a large debug snapshot — an error that showed up only as \"[object Object]\", hiding the real cause (a write timeout for Scotiabank, a brief Supabase outage for TD) for days. The snapshot write is now best-effort and never aborts the actual job ingest, write errors are recorded legibly, and short Supabase gateway blips are ridden out." },
+      { "type": "fix", "description": "The daily \"scraper-break\" health alert no longer cries wolf. Because the bank scrapers run asynchronously and land their jobs minutes after the morning collection finishes, the alert was checking them too early and reporting every bank as \"0 new today\" — a noisy false alarm that also buried the genuinely-broken ones. It now only judges a scraper once that morning's run has actually landed, so the alert reflects real outages." }
+    ]
+  },
+  {
     "version": "2.9.5",
     "date": "2026-06-03",
     "changes": [

--- a/web/lib/email/scraper-health.ts
+++ b/web/lib/email/scraper-health.ts
@@ -122,6 +122,7 @@ export async function checkAndAlertScraperHealth(
 
     // Detect issues
     const issues: ScraperIssue[] = [];
+    const issueCompanyIds = new Set<string>();
 
     for (const task of tasks) {
       const company = companyMap.get(task.company_id);
@@ -139,6 +140,7 @@ export async function checkAndAlertScraperHealth(
           activeJobCount,
           closedThisRun,
         });
+        issueCompanyIds.add(task.company_id);
       } else if (activeJobCount === 0 && closedThisRun > 0) {
         // Scraper returned nothing, wiped all existing jobs
         issues.push({
@@ -148,14 +150,41 @@ export async function checkAndAlertScraperHealth(
           activeJobCount: 0,
           closedThisRun,
         });
+        issueCompanyIds.add(task.company_id);
       }
     }
+
+    // The canary's "0 new postings today" signal is only meaningful once a
+    // company's scrape for THIS run has actually LANDED. Every incumbent is a
+    // heavy browser scraper offloaded to GitHub Actions (processor.ts), so its
+    // task sits in 'running' — and today's rows are absent — until the async
+    // scrape finishes, which is minutes-to-an-hour AFTER the collect run is
+    // marked complete (runner.ts treats offloaded 'running' tasks as
+    // non-blocking). Evaluating the canary against a still-'running' incumbent
+    // is a guaranteed false "0 new today" — that race is exactly what fired a
+    // "6 incumbent scrapers" alert while three of them had simply not ingested
+    // yet (June 2026). Restrict the canary to incumbents whose task in this run
+    // is terminal, and drop any already surfaced above as a failed/empty issue
+    // so a broken bank isn't double-reported in both sections.
+    const evaluableCompanyIds = new Set(
+      tasks
+        .filter(
+          (t) =>
+            (t.status === "completed" ||
+              t.status === "failed" ||
+              t.status === "cancelled") &&
+            !issueCompanyIds.has(t.company_id)
+        )
+        .map((t) => t.company_id)
+    );
 
     // Independent fragility check: partial-corpus drop for incumbent
     // (big-bank) scrapers. A scraper that returns SOME but not all jobs
     // can silently rot the dataset for days; the canary fires when today's
     // new-postings count is well below the 7-day baseline.
-    const canaries = await detectIncumbentCanaries(supabase);
+    const canaries = await detectIncumbentCanaries(supabase, {
+      evaluableCompanyIds,
+    });
 
     if (issues.length === 0 && canaries.length === 0) {
       log.info("Scraper health check passed — no issues detected.");
@@ -241,11 +270,20 @@ export async function checkAndAlertScraperHealth(
  * Fires the canary when `evaluateCanary` returns true. Read-only; safe to
  * call on every collect run. Errors are swallowed and logged — a failed
  * canary check must never block the existing scraper-health email.
+ *
+ * `opts.evaluableCompanyIds` (when provided) restricts evaluation to companies
+ * whose scrape for the current run has LANDED — i.e. the task is terminal and
+ * not already flagged as a failed/empty issue. Incumbents are heavy scrapers
+ * offloaded to GitHub Actions, so a still-'running' task means today's rows
+ * haven't ingested yet and a "0 new today" reading would be a false positive.
+ * Omitting the set (e.g. a manual/standalone invocation) evaluates every
+ * active incumbent, preserving the original behaviour.
  */
 type SupabaseAdminClient = ReturnType<typeof createAdminClient>;
 
 export async function detectIncumbentCanaries(
-  supabase: SupabaseAdminClient
+  supabase: SupabaseAdminClient,
+  opts?: { evaluableCompanyIds?: Set<string> }
 ): Promise<ScraperCanary[]> {
   try {
     const { data: companies, error: companiesError } = await supabase
@@ -263,6 +301,15 @@ export async function detectIncumbentCanaries(
     }
 
     if (!companies || companies.length === 0) return [];
+
+    // Only judge incumbents whose scrape for this run has actually landed.
+    // Without this gate the canary races the offloaded GitHub Actions scrapes
+    // and reports every incumbent as "0 new today" before its rows ingest.
+    const evaluable = opts?.evaluableCompanyIds
+      ? companies.filter((c) => opts.evaluableCompanyIds!.has(c.id))
+      : companies;
+
+    if (evaluable.length === 0) return [];
 
     // UTC day boundaries. "Today" = postings with first_seen_date in the
     // 24h window starting at 00:00 UTC of the current calendar day.
@@ -291,7 +338,7 @@ export async function detectIncumbentCanaries(
     // for ~7 days after every new incumbent comes online and keep this
     // canary firing daily.
     const counts = await Promise.all(
-      companies.map(async (company) => {
+      evaluable.map(async (company) => {
         const backfillCutoffIso = company.created_at
           ? new Date(
               new Date(company.created_at as string).getTime() + 48 * 60 * 60 * 1000

--- a/web/lib/scrapers/CLAUDE.md
+++ b/web/lib/scrapers/CLAUDE.md
@@ -45,6 +45,14 @@ Workday returns `externalPath` already prefixed with `/job/...`. The detail URL 
 
 Resist the urge to refactor `browser.ts` before launch. It works. The complexity is load-bearing — selector heuristics, retry logic, and per-site quirks are baked in. Post-launch, split it by site and add tests; before launch, do not.
 
+### Heavy-scrape write resilience (`web/scripts/scrape-heavy.ts`)
+
+The offloaded runner fetches the whole corpus in memory, then writes. Two write hazards have repeatedly stranded the big banks (1.4–1.9k jobs) *after* a clean fetch+enrich:
+
+- **The `scraped_data` snapshot is a 12–17MB single JSONB write.** It deterministically blows Supabase's 8s `statement_timeout` (`57014`) for RBC/Scotia/TD and sometimes trips a gateway `520/521`. It is **best-effort only** — written outside the transient-retry and wrapped in try/catch — because the only reader is the rare `startFromStage:'ingest'` resume; Step 8 ingests from the in-memory corpus regardless. **Never make this write fatal again** (it aborted Scotia & TD for days, June 2026). The per-row ingest writes, by contrast, are small and *are* retried.
+- **Error serialization:** supabase-js rejects with a plain `{code,message}` object, not an `Error`. Use `describeError()` (never `String(err)`) when writing `error_message` — `String({...})` is `"[object Object]"`, which masked the real `57014`/`520` causes in the task row for days.
+- **`isTransientDbError` is the allow-list of retry-worthy failures**: PGRST002/001 (schema-cache reload), `57014`/`55P03` (statement/lock timeout under contention), raw transport errors, and Cloudflare gateway 5xx (`520`–`524`) in front of the Supabase origin. A deterministic timeout (the oversized snapshot write) is *not* something retry should hide — it's fixed by not doing the oversized write, not by retrying it.
+
 ## Revolut (offloaded to GitHub Actions)
 
 Revolut's careers page is a custom-built Next.js SPA behind Cloudflare anti-bot. Not on any third-party ATS (probed Smartrecruiters / Lever / Greenhouse / Workable — all return 404 or empty for any Revolut slug variant). The generic `scrapeGenericJobBoard` drops every job because Revolut URLs are slug+UUID (`/careers/position/head-of-risk-257ab149-12e7-4a84-bda0-1ab1a1d36760/`), not `/jobs/<digits>` as the generic ID-extraction regex requires.

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.9.5",
+  "version": "2.9.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/web/scripts/scrape-heavy.ts
+++ b/web/scripts/scrape-heavy.ts
@@ -24,6 +24,38 @@ import { triggerAnalysisForJobs } from "@/lib/jobs/runner";
 import type { Company } from "@/lib/jobs/types";
 
 /**
+ * Render an unknown thrown value as a human-readable string for logs and the
+ * `job_run_tasks.error_message` column. supabase-js / PostgREST reject with a
+ * PLAIN object (`{ code, message, details, hint }`) that is NOT an Error
+ * instance, so the old `error instanceof Error ? error.message : String(error)`
+ * collapsed every DB rejection to the literal "[object Object]". That is
+ * exactly what masked the real failures for days — Scotiabank's `57014`
+ * (statement timeout on the oversized snapshot write) and TD's Supabase-origin
+ * Cloudflare 520/521 both surfaced only as "[object Object]" in the task row.
+ * Prefer a structured `[code] message`; fall back to JSON so we never store
+ * "[object Object]" again.
+ */
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err && typeof err === "object") {
+    const e = err as { message?: unknown; code?: unknown; details?: unknown };
+    const parts: string[] = [];
+    if (typeof e.code === "string" && e.code) parts.push(`[${e.code}]`);
+    if (typeof e.message === "string" && e.message) parts.push(e.message);
+    if (parts.length === 0 && typeof e.details === "string" && e.details) {
+      parts.push(e.details);
+    }
+    if (parts.length > 0) return parts.join(" ");
+    try {
+      return JSON.stringify(err);
+    } catch {
+      return String(err);
+    }
+  }
+  return String(err);
+}
+
+/**
  * Classify an error as a transient Supabase outage worth waiting out, rather
  * than a permanent failure. A Supabase Postgres restart takes the DB offline
  * for a few seconds, then PostgREST rebuilds its schema cache — during that
@@ -46,6 +78,12 @@ import type { Company } from "@/lib/jobs/types";
  * window with backoff exactly like a restart, rather than throwing away the
  * finished scrape. If a company times out every run, that's a systematic
  * signal to batch the per-row writes — not something a retry should hide.
+ *
+ * Finally, a Supabase origin hiccup can surface as a Cloudflare gateway 5xx
+ * (520 "web server is returning an unknown error" / 521 / 522 / 523 / 524)
+ * whose body is an HTML error page rather than a structured PGRST error — the
+ * June 4 2026 TD ingest died on a bare 520. Those are transient platform
+ * blips, so match the Cloudflare error-code/banner text too.
  */
 function isTransientDbError(err: unknown): boolean {
   if (!err || typeof err !== "object") return false;
@@ -64,7 +102,19 @@ function isTransientDbError(err: unknown): boolean {
     msg.includes("connection reset") ||
     msg.includes("statement timeout") ||
     msg.includes("canceling statement due to") ||
-    msg.includes("lock timeout")
+    msg.includes("lock timeout") ||
+    // Cloudflare gateway 5xx in front of the Supabase origin (HTML body).
+    msg.includes("web server is returning an unknown error") || // 520
+    msg.includes("web server is down") || // 521
+    msg.includes("error code 520") ||
+    msg.includes("error code 521") ||
+    msg.includes("error code 522") ||
+    msg.includes("error code 523") ||
+    msg.includes("error code 524") ||
+    msg.includes("bad gateway") ||
+    msg.includes("gateway time-out") ||
+    msg.includes("gateway timeout") ||
+    msg.includes("service unavailable")
   );
 }
 
@@ -370,16 +420,27 @@ async function main() {
     );
     console.log(`✅ Fetched ${jobs.length} jobs`);
 
-    // Step 7: Store scraped data in task. This is the durable snapshot of the
-    // fetched corpus; if it silently fails a later ingest failure has nothing to
-    // fall back on. The May 31 2026 TD run lost all 1370 fetched jobs because
-    // this write swallowed a PGRST002 during a Supabase restart — so retry
-    // transient outages and surface a hard failure instead of dropping it.
-    await withTransientRetry("save scraped_data", async () => {
+    // Step 7: Record scrape completion. Split into two writes that used to be
+    // one, because they have very different failure profiles:
+    //
+    //   (a) progress fields (jobs_fetched + stage_progress.scrape) — a handful
+    //       of bytes; must succeed, so retry transient outages.
+    //   (b) scraped_data — the FULL enriched corpus as a single JSONB value.
+    //       For the big incumbent banks (RBC/Scotia/TD, 1.4-1.9k jobs) that is
+    //       a 12-17MB write that deterministically blows Supabase's 8s
+    //       statement_timeout (57014) and sometimes trips a gateway 520/521.
+    //       The old combined write THREW on that failure, aborting the whole
+    //       run AFTER a clean fetch+enrich and stranding the bank with a stale
+    //       corpus for days (Scotia & TD, June 2026). The snapshot is only ever
+    //       read back by the rare `startFromStage:'ingest'` resume; the ingest
+    //       below (Step 8) uses the in-memory `jobs`, so a missing snapshot
+    //       must NOT abort the run. Write it best-effort, OUTSIDE the transient
+    //       retry (a 57014 here is deterministic for these payloads — retrying
+    //       just burns ~63s before the same failure), and continue on error.
+    await withTransientRetry("save scrape progress", async () => {
       const { error } = await supabase
         .from("job_run_tasks")
         .update({
-          scraped_data: jobs,
           jobs_fetched: jobs.length,
           stage_progress: {
             scrape: {
@@ -392,6 +453,20 @@ async function main() {
         .eq("id", task.id);
       if (error) throw error;
     });
+
+    try {
+      const { error } = await supabase
+        .from("job_run_tasks")
+        .update({ scraped_data: jobs })
+        .eq("id", task.id);
+      if (error) throw error;
+    } catch (snapshotErr) {
+      console.warn(
+        `⚠️  Skipping scraped_data snapshot for task ${task.id} (${jobs.length} jobs): ${describeError(
+          snapshotErr
+        )}. Ingest continues from the in-memory corpus.`
+      );
+    }
 
     // Step 8: Call runIngestStage to save results. Wrapped so a Supabase restart
     // mid-ingest (PostgREST schema-cache reload → PGRST002) is ridden out rather
@@ -464,7 +539,7 @@ async function main() {
       console.log("ℹ️  No new jobs — skipping analysis stage.");
     }
   } catch (error) {
-    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorMessage = describeError(error);
     console.error(`❌ Error during scraping: ${errorMessage}`);
 
     // Mark task + job_run as failed with retry. If the underlying cause


### PR DESCRIPTION
## What & why

Investigating the *"6 incumbent scrapers"* canary email that fired while the DB clearly had new jobs overnight. The investigation found **two coupled problems — one was masking the other.**

### Diagnosis

| Bank | Reality | Root cause |
|---|---|---|
| BMO / CIBC / National Bank | ✅ healthy, scraping daily | — |
| **RBC** | dead since May 28, **0 active jobs** | phenom returns 0 (anti-bot vs GHA IPs) — *separate follow-up* |
| **Scotiabank** | failing since Jun 1 | `57014` statement_timeout on the 12MB `scraped_data` write |
| **TD** | failing since Jun 1 | Supabase-origin Cloudflare `520/521` on the write |

Both Scotia & TD fetched + enriched their **full corpus**, then died on the **write** — and the real error was stored as the useless literal `"[object Object]"`, which is why it went undiagnosed for days. Meanwhile the canary runs the instant `collect` returns, but every incumbent is a heavy scraper **offloaded to GitHub Actions** whose rows land minutes-to-an-hour later — so it read `0 new today` for *every* bank and fired a noisy 6, burying the 3 real outages.

### Fixes

**1. Heavy-scrape write resilience (`scrape-heavy.ts`)**
- `describeError()` — serialize PostgREST `{code,message}` objects instead of `String(err)` → `"[object Object]"`. The masked errors are now legible in the task row.
- The `scraped_data` snapshot (a 12–17MB single JSONB write that deterministically times out for the big banks) is now **best-effort**: split from the cheap progress write, taken outside the transient-retry, try/catch'd, and **never aborts the ingest**. It's only ever read by the rare `startFromStage:'ingest'` resume; Step 8 ingests from the in-memory corpus regardless.
- `isTransientDbError` now also rides out Cloudflare gateway 5xx (`520`–`524`) for genuine Supabase-origin blips like TD's.

**2. Canary landing gate (`scraper-health.ts`)**
- `detectIncumbentCanaries` now only judges incumbents whose task **for this run is terminal** (`completed`/`failed`/`cancelled`) and not already reported as a `failed`/`empty` issue (`evaluableCompanyIds`). A still-`running` (offloaded, not-yet-ingested) incumbent is skipped, killing the race. Genuinely-broken scrapers still fire correctly (task terminalizes with 0 jobs / failed).

After this, today's run would alert on exactly **RBC + Scotia + TD** — the real outages — with no false positives.

## Not in this PR
**RBC's phenom scraper returns 0 jobs** — the live page has the data via `curl` but Puppeteer on GitHub Actions gets an empty page (anti-bot challenge against datacenter IPs). That needs separate live debugging (stealth/proxy/fetch strategy) and can't be reliably fixed/verified from here.

## Testing
- `npm run build` ✅
- `npx tsc --noEmit` ✅
- `vitest run lib/email/scraper-health.test.ts` ✅ (12/12; pure `evaluateCanary` unchanged, new `opts` is optional/backward-compatible)
- `eslint` on changed files ✅

## Docs
- `docs/OBSERVABILITY.md` — canary now documents the landing gate.
- `web/lib/scrapers/CLAUDE.md` — new "Heavy-scrape write resilience" section (snapshot best-effort, `describeError`, transient allow-list).
- Changelog + version bump → **2.9.6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)