### PR TITLE
fix(jobs): company filter lists full tier, not just searched results (v2.9.14)

### DIFF
--- a/web/app/(dashboard)/jobs/page.tsx
+++ b/web/app/(dashboard)/jobs/page.tsx
@@ -179,7 +179,7 @@ export default async function JobsPage({
   // The jobs list honors the `?tier=` toggle. The right rail (function heat /
   // cross-company themes) deliberately stays fintech-only regardless of the
   // toggle — those are fintech-pivot surfaces, not tier-scoped.
-  const [jobsResult, heat, themes] = await Promise.all([
+  const [jobsResult, heat, themes, companyOptions] = await Promise.all([
     getJobsListData({
       jobIds: digestJobIds,
       tiers,
@@ -189,6 +189,13 @@ export default async function JobsPage({
     }),
     getFunctionHeatData(30),
     getCrossCompanyThemes(),
+    // Company filter options — every active company in the selected tier(s),
+    // independent of the current search. Through `active_companies` so a
+    // deactivated company can't leak in (CLAUDE.md §7).
+    supabase
+      .from("active_companies")
+      .select("slug, name")
+      .in("tier", [...tiers]),
   ]);
   const { rows, truncated } = jobsResult;
 
@@ -214,19 +221,20 @@ export default async function JobsPage({
     (r) => r.ageDays !== null && r.ageDays <= 7
   ).length;
 
-  // Available companies for dropdown — distinct slugs from active visible rows.
-  const companyMap = new Map<string, { slug: string; name: string }>();
-  for (const r of baseRows) {
-    if (r.companySlug && r.companyName) {
-      companyMap.set(r.companySlug, {
-        slug: r.companySlug,
-        name: r.companyName,
-      });
-    }
-  }
-  const companies = Array.from(companyMap.values()).sort((a, b) =>
-    a.name.localeCompare(b.name)
-  );
+  // Available companies for the dropdown — the full set of active companies in
+  // the selected tier(s), NOT just those present in the current result set. A
+  // filter control's options must represent the filterable universe; deriving
+  // them from the (search-/relevance-capped) rows silently drops any company
+  // whose postings fall outside the window — e.g. an incumbent whose roles miss
+  // the semantic top-200. Mirrors the function dropdown below, which uses the
+  // full taxonomy for the same reason.
+  const companies = (
+    (companyOptions.data ?? []) as Array<{ slug: string; name: string }>
+  )
+    .filter((c) => c.slug && c.name)
+    .map((c) => ({ slug: c.slug, name: c.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  const companyMap = new Map(companies.map((c) => [c.slug, c]));
 
   // Function groups for dropdown — full taxonomy keeps the option set
   // stable across filter swings.

--- a/web/data/releases.json
+++ b/web/data/releases.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "2.9.14",
+    "date": "2026-06-08",
+    "changes": [
+      {
+        "type": "fix",
+        "description": "The Jobs page company filter now always lists every company in the selected tier. Previously the \"All companies\" dropdown was built only from the companies that appeared in the current results — so when you ran a semantic search (say \"AI\") in the Incumbent view, a bank like CIBC could disappear from the dropdown entirely, not because it has no roles but because none of its postings happened to land among the search's top matches. The dropdown is now driven by the full set of companies you cover in the chosen tier (Fintech / Incumbent / All), independent of the search, so you can always filter to any of them."
+      }
+    ]
+  },
+  {
     "version": "2.9.13",
     "date": "2026-06-07",
     "changes": [

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "2.9.13",
+  "version": "2.9.14",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Problem

On the Jobs page, running a **semantic search** under the **Incumbent** tier dropped **CIBC** (and potentially any company) from the "All companies" filter dropdown — even though CIBC is an active incumbent with **480 active, fully-embedded jobs**.

This is **not** CIBC-specific and **not** a data problem. The dropdown was being built from the **current result rows** (`baseRows`), and the company filter is applied client-side over those already-fetched rows. So any company whose postings fall outside the result window silently disappears from the option list.

Semantic search makes it trivial to trigger: `match_job_ids_semantic` returns only the **top-200** nearest vectors across the whole tier. Reproducing the exact production query for `"AI"` + incumbent:

```
rbc: 121   bmo: 30   td: 22   scotiabank: 18   bnc: 7   cibc: 2
                                          ↳ both CIBC hits inactive → 0 after the active filter
```

RBC alone takes 121/200; CIBC's two nearest "AI" roles are both closed, so after the `is_active` filter CIBC contributes zero rows → absent from the result-derived dropdown.

## Fix

A filter control's options should represent the **filterable universe**, not the results. The dropdown is now sourced from the `active_companies` view scoped to the selected tier(s), independent of the search — mirroring the neighboring **function** dropdown, which already uses the full taxonomy "to keep the option set stable across filter swings." Routing through `active_companies` also guarantees a deactivated company can't leak in (CLAUDE.md §7).

CIBC (and every company in the chosen tier) now always appears, in any search mode.

## Known limitation (separate follow-up)

Because company filtering is still client-side over the fetched window, selecting a company that fell outside the semantic top-200 will show an empty table for that query. Making a selected company's *own* most-relevant roles surface requires pushing the company filter into the server query / semantic RPC — tracked as a follow-up (semantic company-scoping), which I'm starting next.

## Testing
- Reproduced the bug via the real embedding + RPC (shown above).
- `npm run build` passes; `tsc --noEmit` and `eslint` clean.
- Verified `active_companies` returns CIBC as an active incumbent.

## Docs / changelog
- `web/data/releases.json` entry added (v2.9.14, fix).
- `web/package.json` bumped 2.9.13 → 2.9.14.
- No architecture/cron/AI/schema/auth changes → no other docs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)